### PR TITLE
Single value subject

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+https://github.com/Tyler-Keith-Thompson/Afluent/issues.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/Sources/Afluent/Extensions/RecursiveLockExtensions.swift
+++ b/Sources/Afluent/Extensions/RecursiveLockExtensions.swift
@@ -1,0 +1,16 @@
+//
+//  RecursiveLockExtensions.swift
+//
+//
+//  Created by Tyler Thompson on 11/10/23.
+//
+
+import Foundation
+
+extension NSRecursiveLock {
+    func protect<T>(_ instructions: () throws -> T) rethrows -> T {
+        lock()
+        defer { unlock() }
+        return try instructions()
+    }
+}

--- a/Sources/Afluent/Workers/SingleValueSubject.swift
+++ b/Sources/Afluent/Workers/SingleValueSubject.swift
@@ -1,0 +1,97 @@
+//
+//  SingleValueSubject.swift
+//
+//
+//  Created by Tyler Thompson on 11/10/23.
+//
+
+import Foundation
+
+/// A subject that emits a single value or an error.
+///
+/// `SingleValueSubject` is an `AsynchronousUnitOfWork` that can be manually completed with either a success value or an error. It's useful for scenarios where you need to bridge callback-based APIs into the world of `async/await`.
+///
+/// - Note: Once completed, any further attempts to send a value or an error will result in a `SubjectError.alreadyCompleted`.
+public final class SingleValueSubject<Success: Sendable>: AsynchronousUnitOfWork, @unchecked Sendable {
+    /// Errors specific to `SingleValueSubject`.
+    public enum SubjectError: Error {
+        /// Indicates that the subject has already been completed and cannot accept further values or errors.
+        case alreadyCompleted
+    }
+    
+    private let _lock = NSRecursiveLock()
+    public private(set) var state: TaskState<Success>
+    private var subjectState = State.noValue
+    
+    /// Creates a new `SingleValueSubject`.
+    public init() {
+        state = TaskState.unsafeCreation()
+        state = TaskState { [weak self] in
+            guard let self else { throw CancellationError() }
+            self.lock()
+            if case .sentValue(let success) = self.subjectState {
+                self.unlock()
+                return success
+            } else if case .sentError(let error) = self.subjectState {
+                self.unlock()
+                throw error
+            }
+            self.unlock()
+            return try await withUnsafeThrowingContinuation { continuation in
+                self.lock()
+                self.subjectState = .hasContinuation(continuation)
+                self.unlock()
+            }
+        }
+    }
+    
+    private func lock() { self._lock.lock() }
+    private func unlock() { self._lock.unlock() }
+    
+    /// Sends a value to the subject.
+    ///
+    /// Completes the subject with the provided value. If the subject is already completed, this method throws a `SubjectError.alreadyCompleted`.
+    ///
+    /// - Parameter value: The success value to send.
+    /// - Throws: `SubjectError.alreadyCompleted` if the subject is already completed.
+    public func send(_ value: Success) throws {
+        try _lock.protect {
+            switch self.subjectState {
+            case .noValue: self.subjectState = .sentValue(value)
+            case .hasContinuation(let continuation):
+                self.subjectState = .sentValue(value)
+                continuation.resume(returning: value)
+            default:
+                throw SubjectError.alreadyCompleted
+            }
+        }
+    }
+    
+    /// Sends an error to the subject.
+    ///
+    /// Completes the subject with the provided error. If the subject is already completed, this method throws a `SubjectError.alreadyCompleted`.
+    ///
+    /// - Parameter error: The error to send.
+    /// - Throws: `SubjectError.alreadyCompleted` if the subject is already completed.
+    public func send(error: Error) throws {
+        try _lock.protect {
+            switch self.subjectState {
+            case .noValue: self.subjectState = .sentError(error)
+            case .hasContinuation(let continuation):
+                self.subjectState = .sentError(error)
+                continuation.resume(throwing: error)
+            default:
+                throw SubjectError.alreadyCompleted
+            }
+        }
+    }
+}
+
+extension SingleValueSubject {
+    private enum State {
+        case noValue
+        case sentValue(Success)
+        case sentError(Error)
+        case hasContinuation(UnsafeContinuation<Success, Error>)
+    }
+}

--- a/Tests/AfluentTests/WorkerTests/SingleValueSubjectTests.swift
+++ b/Tests/AfluentTests/WorkerTests/SingleValueSubjectTests.swift
@@ -1,0 +1,126 @@
+//
+//  SingleValueSubjectTests.swift
+//
+//
+//  Created by Tyler Thompson on 11/10/23.
+//
+
+import Foundation
+import Afluent
+import XCTest
+
+final class SingleValueSubjectTests: XCTestCase {
+    func testSingleValueSubjectEmittingValueBeforeTaskRuns() async throws {
+        let expected = Int.random(in: 1...1000)
+        let exp = expectation(description: "task executed")
+        let subject = SingleValueSubject<Int>()
+        let unitOfWork = subject.map {
+            exp.fulfill()
+            return $0
+        }
+        
+        try subject.send(expected)
+        
+        let actual = try await unitOfWork.execute()
+        await fulfillment(of: [exp], timeout: 0)
+        XCTAssertEqual(actual, expected)
+    }
+    
+    func testSingleValueSubjectEmittingValueAfterTaskRuns() async throws {
+        let expected = Int.random(in: 1...1000)
+        let exp = expectation(description: "task executed")
+        let subject = SingleValueSubject<Int>()
+        subject.map {
+            exp.fulfill()
+            XCTAssertEqual($0, expected)
+            return $0
+        }.run() // task started
+        
+        try subject.send(expected)
+        
+        await fulfillment(of: [exp], timeout: 0.01)
+    }
+    
+    func testSingleValueSubjectEmittingErrorBeforeTaskRuns() async throws {
+        enum Err: Error { case e1 }
+        let subject = SingleValueSubject<Int>()
+        
+        try subject.send(error: Err.e1)
+        
+        let actualResult = try await subject.result
+        XCTAssertThrowsError(try actualResult.get()) { error in
+            XCTAssertEqual(error as? Err, .e1)
+        }
+    }
+    
+    func testSingleValueSubjectEmittingErrorAfterTaskRuns() async throws {
+        try XCTSkipIf(ProcessInfo.processInfo.environment["CI"] == "true")
+
+        enum Err: Error { case e1 }
+        let exp = expectation(description: "task executed")
+        let subject = SingleValueSubject<Int>()
+        let unitOfWork = subject
+            .materialize()
+            .map {
+                exp.fulfill()
+                return $0
+            }
+
+        Task {
+            try await Task.sleep(nanoseconds: UInt64(Measurement<UnitDuration>.milliseconds(10).converted(to: .nanoseconds).value))
+            try subject.send(error: Err.e1)
+        }
+
+        let actualResult = try await unitOfWork.execute()
+        XCTAssertThrowsError(try actualResult.get()) { error in
+            XCTAssertEqual(error as? Err, .e1)
+        }
+
+        await fulfillment(of: [exp], timeout: 0.01)
+    }
+    
+    func testSingleValueSubjectOnlyEmitsValueOnce() async throws {
+        let expected = Int.random(in: 1...1000)
+        let exp = expectation(description: "task executed")
+        let subject = SingleValueSubject<Int>()
+        subject.map {
+            exp.fulfill()
+            XCTAssertEqual($0, expected)
+            return $0
+        }.run() // task started
+        
+        try subject.send(expected)
+        XCTAssertThrowsError(try subject.send(expected))
+        
+        await fulfillment(of: [exp], timeout: 0.01)
+    }
+    
+    func testSingleValueSubjectOnlyEmitsErrorOnce() async throws {
+        try XCTSkipIf(ProcessInfo.processInfo.environment["CI"] == "true")
+
+        enum Err: Error { case e1 }
+        let exp = expectation(description: "task executed")
+        let exp1 = expectation(description: "Subject error sent")
+        let subject = SingleValueSubject<Int>()
+        let unitOfWork = subject
+            .materialize()
+            .map {
+                exp.fulfill()
+                return $0
+            }
+
+        Task {
+            try await Task.sleep(nanoseconds: UInt64(Measurement<UnitDuration>.milliseconds(10).converted(to: .nanoseconds).value))
+            try subject.send(error: Err.e1)
+            XCTAssertThrowsError(try subject.send(error: Err.e1))
+            exp1.fulfill()
+        }
+
+        let actualResult = try await unitOfWork.execute()
+        XCTAssertThrowsError(try actualResult.get()) { error in
+            XCTAssertEqual(error as? Err, .e1)
+        }
+
+        await fulfillment(of: [exp, exp1], timeout: 0.01)
+    }
+}


### PR DESCRIPTION
Added a single value subject. This is roughly equivalent to the following combine chain:

let subject = PassthroughSubject<MyType, Error>().first().share()

In other words, it will emit a single value eventually, and won't ever send more, but subscriptions after it has emitted a value will just get that value (or error). 

This can be really helpful when bridging to synchronous APIs. The whole thing is thread-safe, so there's no need to synchronize calls to `send`