### PR TITLE
[single-value-channel] - Single Value Channel added - TT

### DIFF
--- a/Sources/Afluent/DeferredTask.swift
+++ b/Sources/Afluent/DeferredTask.swift
@@ -26,7 +26,10 @@ public actor DeferredTask<Success: Sendable>: AsynchronousUnitOfWork {
         self.operation = operation
     }
     
-    public func _operation() async throws -> Success {
-        try await operation()
+    public func _operation() async throws -> AsynchronousOperation<Success> {
+        AsynchronousOperation { [weak self] in
+            guard let self else { throw CancellationError() }
+            return try await self.operation()
+        }
     }
 }

--- a/Sources/Afluent/DeferredTask.swift
+++ b/Sources/Afluent/DeferredTask.swift
@@ -14,14 +14,19 @@ import Foundation
 /// until explicitly awaited.
 ///
 /// - Note: The `Success` type must conform to the `Sendable` protocol.
-public struct DeferredTask<Success: Sendable>: AsynchronousUnitOfWork {
-    public let state: TaskState<Success>
+public actor DeferredTask<Success: Sendable>: AsynchronousUnitOfWork {
+    public let state = TaskState<Success>()
+    let operation: @Sendable () async throws -> Success
 
     /// Initializes a new instance of `DeferredTask`.
     ///
     /// - Parameters:
     ///   - operation: The asynchronous operation that this task will execute. The operation should be a throwing, async closure that returns a value of type `Success`.
     public init(@_inheritActorContext @_implicitSelfCapture operation: @escaping @Sendable () async throws -> Success) {
-        state = TaskState(operation: operation)
+        self.operation = operation
+    }
+    
+    public func _operation() async throws -> Success {
+        try await operation()
     }
 }

--- a/Sources/Afluent/Workers/AssertNoFailure.swift
+++ b/Sources/Afluent/Workers/AssertNoFailure.swift
@@ -12,14 +12,16 @@ extension Workers {
         let state = TaskState<Success>()
         let upstream: Upstream
         
-        func _operation() async throws -> Success {
-            do {
-                return try await upstream.operation()
-            } catch {
-                if !(error is CancellationError) {
-                    assertionFailure("Expected no error in asynchronous unit of work, but got: \(error)")
+        func _operation() async throws -> AsynchronousOperation<Success> {
+            AsynchronousOperation {
+                do {
+                    return try await upstream.operation()
+                } catch {
+                    if !(error is CancellationError) {
+                        assertionFailure("Expected no error in asynchronous unit of work, but got: \(error)")
+                    }
+                    throw error
                 }
-                throw error
             }
         }
     }

--- a/Sources/Afluent/Workers/Catch.swift
+++ b/Sources/Afluent/Workers/Catch.swift
@@ -18,13 +18,15 @@ extension Workers {
             self.handler = handler
         }
         
-        func _operation() async throws -> Success {
-            do {
-                return try await upstream.operation()
-            } catch {
-                guard !(error is CancellationError) else { throw error }
-                
-                return try await handler(error).operation()
+        func _operation() async throws -> AsynchronousOperation<Success> {
+            AsynchronousOperation {
+                do {
+                    return try await upstream.operation()
+                } catch {
+                    guard !(error is CancellationError) else { throw error }
+                    
+                    return try await handler(error).operation()
+                }
             }
         }
     }

--- a/Sources/Afluent/Workers/Decode.swift
+++ b/Sources/Afluent/Workers/Decode.swift
@@ -20,8 +20,10 @@ extension Workers {
         let upstream: Upstream
         let decoder: Decoder
 
-        func _operation() async throws -> Success {
-            try decoder.decode(Success.self, from: try await upstream.operation())
+        func _operation() async throws -> AsynchronousOperation<Success> {
+            AsynchronousOperation {
+                try decoder.decode(Success.self, from: try await upstream.operation())
+            }
         }
     }
 }

--- a/Sources/Afluent/Workers/Decode.swift
+++ b/Sources/Afluent/Workers/Decode.swift
@@ -15,13 +15,13 @@ public protocol TopLevelDecoder<Input> {
 extension JSONDecoder: TopLevelDecoder { }
 
 extension Workers {
-    struct Decode<Success: Sendable & Decodable>: AsynchronousUnitOfWork {
-        let state: TaskState<Success>
+    struct Decode<Upstream: AsynchronousUnitOfWork, Decoder: TopLevelDecoder & Sendable, Success: Sendable & Decodable>: AsynchronousUnitOfWork where Upstream.Success == Decoder.Input {
+        let state = TaskState<Success>()
+        let upstream: Upstream
+        let decoder: Decoder
 
-        init<U: AsynchronousUnitOfWork, D: TopLevelDecoder>(upstream: U, decoder: D) where U.Success == D.Input {
-            state = TaskState {
-                try decoder.decode(Success.self, from: try await upstream.operation())
-            }
+        func _operation() async throws -> Success {
+            try decoder.decode(Success.self, from: try await upstream.operation())
         }
     }
 }

--- a/Sources/Afluent/Workers/Delay.swift
+++ b/Sources/Afluent/Workers/Delay.swift
@@ -14,10 +14,12 @@ extension Workers {
         let upstream: Upstream
         let duration: Measurement<UnitDuration>
         
-        func _operation() async throws -> Success {
-            let val = try await upstream.operation()
-            try await Task.sleep(nanoseconds: UInt64(duration.converted(to: .nanoseconds).value))
-            return val
+        func _operation() async throws -> AsynchronousOperation<Success> {
+            AsynchronousOperation {
+                let val = try await upstream.operation()
+                try await Task.sleep(nanoseconds: UInt64(duration.converted(to: .nanoseconds).value))
+                return val
+            }
         }
     }
 }

--- a/Sources/Afluent/Workers/Delay.swift
+++ b/Sources/Afluent/Workers/Delay.swift
@@ -9,16 +9,15 @@ import Foundation
 
 extension Workers {
     @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-    struct Delay<Success: Sendable>: AsynchronousUnitOfWork {
-        let state: TaskState<Success>
-
-        init<U: AsynchronousUnitOfWork>(upstream: U, duration: Measurement<UnitDuration>) where U.Success == Success {
-            let delayInNanoseconds = duration.converted(to: .nanoseconds).value
-            state = TaskState {
-                let val = try await upstream.operation()
-                try await Task.sleep(nanoseconds: UInt64(delayInNanoseconds))
-                return val
-            }
+    struct Delay<Upstream: AsynchronousUnitOfWork, Success: Sendable>: AsynchronousUnitOfWork where Upstream.Success == Success {
+        let state = TaskState<Success>()
+        let upstream: Upstream
+        let duration: Measurement<UnitDuration>
+        
+        func _operation() async throws -> Success {
+            let val = try await upstream.operation()
+            try await Task.sleep(nanoseconds: UInt64(duration.converted(to: .nanoseconds).value))
+            return val
         }
     }
 }

--- a/Sources/Afluent/Workers/Encode.swift
+++ b/Sources/Afluent/Workers/Encode.swift
@@ -15,13 +15,13 @@ public protocol TopLevelEncoder<Output> {
 extension JSONEncoder: TopLevelEncoder { }
 
 extension Workers {
-    struct Encode<Success: Sendable>: AsynchronousUnitOfWork {
-        let state: TaskState<Success>
-
-        init<U: AsynchronousUnitOfWork, E: TopLevelEncoder>(upstream: U, encoder: E) where Success == E.Output, U.Success: Encodable {
-            state = TaskState {
-                try encoder.encode(try await upstream.operation())
-            }
+    struct Encode<Upstream: AsynchronousUnitOfWork, Encoder: TopLevelEncoder & Sendable, Success: Sendable>: AsynchronousUnitOfWork where Success == Encoder.Output, Upstream.Success: Encodable {
+        let state = TaskState<Success>()
+        let upstream: Upstream
+        let encoder: Encoder
+        
+        func _operation() async throws -> Success {
+            try encoder.encode(try await upstream.operation())
         }
     }
 }

--- a/Sources/Afluent/Workers/Encode.swift
+++ b/Sources/Afluent/Workers/Encode.swift
@@ -20,8 +20,10 @@ extension Workers {
         let upstream: Upstream
         let encoder: Encoder
         
-        func _operation() async throws -> Success {
-            try encoder.encode(try await upstream.operation())
+        func _operation() async throws -> AsynchronousOperation<Success> {
+            AsynchronousOperation {
+                try encoder.encode(try await upstream.operation())
+            }
         }
     }
 }

--- a/Sources/Afluent/Workers/EraseToAnyAsynchronousUnitOfWork.swift
+++ b/Sources/Afluent/Workers/EraseToAnyAsynchronousUnitOfWork.swift
@@ -9,9 +9,15 @@ import Foundation
 
 /// A unit of work that performs type erasure by wrapping another unit of work.
 public struct AnyAsynchronousUnitOfWork<Success: Sendable>: AsynchronousUnitOfWork {
-    public let state: TaskState<Success>
+    public let state = TaskState<Success>()
+    let upstream: any AsynchronousUnitOfWork<Success>
+
     public init<U: AsynchronousUnitOfWork>(_ upstream: U) where Success == U.Success {
-        state = upstream.state
+        self.upstream = upstream
+    }
+    
+    public func _operation() async throws -> Success {
+        try await upstream._operation()
     }
 }
 

--- a/Sources/Afluent/Workers/EraseToAnyAsynchronousUnitOfWork.swift
+++ b/Sources/Afluent/Workers/EraseToAnyAsynchronousUnitOfWork.swift
@@ -12,11 +12,11 @@ public struct AnyAsynchronousUnitOfWork<Success: Sendable>: AsynchronousUnitOfWo
     public let state = TaskState<Success>()
     let upstream: any AsynchronousUnitOfWork<Success>
 
-    public init<U: AsynchronousUnitOfWork>(_ upstream: U) where Success == U.Success {
+    public init(_ upstream: any AsynchronousUnitOfWork<Success>) {
         self.upstream = upstream
     }
     
-    public func _operation() async throws -> Success {
+    public func _operation() async throws -> AsynchronousOperation<Success> {
         try await upstream._operation()
     }
 }

--- a/Sources/Afluent/Workers/FlatMap.swift
+++ b/Sources/Afluent/Workers/FlatMap.swift
@@ -18,8 +18,10 @@ extension Workers {
             self.transform = transform
         }
         
-        func _operation() async throws -> Success {
-            try await transform(try await upstream.operation()).operation()
+        func _operation() async throws -> AsynchronousOperation<Success> {
+            AsynchronousOperation {
+                try await transform(try await upstream.operation()).operation()
+            }
         }
     }
 }

--- a/Sources/Afluent/Workers/Map.swift
+++ b/Sources/Afluent/Workers/Map.swift
@@ -18,8 +18,10 @@ extension Workers {
             self.transform = transform
         }
         
-        func _operation() async throws -> Success {
-            await transform(try await upstream.operation())
+        func _operation() async throws -> AsynchronousOperation<Success> {
+            AsynchronousOperation {
+                await transform(try await upstream.operation())
+            }
         }
     }
     
@@ -33,8 +35,10 @@ extension Workers {
             self.transform = transform
         }
         
-        func _operation() async throws -> Success {
-            try await transform(try await upstream.operation())
+        func _operation() async throws -> AsynchronousOperation<Success> {
+            AsynchronousOperation {
+                try await transform(try await upstream.operation())
+            }
         }
     }
 }

--- a/Sources/Afluent/Workers/Materialize.swift
+++ b/Sources/Afluent/Workers/Materialize.swift
@@ -18,12 +18,14 @@ extension Workers {
             self.upstream = upstream
         }
         
-        func _operation() async throws -> Success {
-            do {
-                return .success(try await upstream.operation())
-            } catch {
-                guard !(error is CancellationError) else { throw error }
-                return .failure(error)
+        func _operation() async throws -> AsynchronousOperation<Success> {
+            AsynchronousOperation {
+                do {
+                    return .success(try await upstream.operation())
+                } catch {
+                    guard !(error is CancellationError) else { throw error }
+                    return .failure(error)
+                }
             }
         }
     }

--- a/Sources/Afluent/Workers/ReplaceError.swift
+++ b/Sources/Afluent/Workers/ReplaceError.swift
@@ -17,12 +17,14 @@ extension Workers {
             self.newValue = newValue
         }
         
-        func _operation() async throws -> Success {
-            do {
-                return try await upstream.operation()
-            } catch {
-                guard !(error is CancellationError) else { throw error }
-                return newValue
+        func _operation() async throws -> AsynchronousOperation<Success> {
+            AsynchronousOperation {
+                do {
+                    return try await upstream.operation()
+                } catch {
+                    guard !(error is CancellationError) else { throw error }
+                    return newValue
+                }
             }
         }
     }

--- a/Sources/Afluent/Workers/ReplaceNil.swift
+++ b/Sources/Afluent/Workers/ReplaceNil.swift
@@ -7,16 +7,21 @@
 
 import Foundation
 extension Workers {
-    struct ReplaceNil<Success: Sendable>: AsynchronousUnitOfWork {
-        let state: TaskState<Success>
+    struct ReplaceNil<Upstream: AsynchronousUnitOfWork, Success: Sendable>: AsynchronousUnitOfWork where Upstream.Success == Success? {
+        let state = TaskState<Success>()
+        let upstream: Upstream
+        let newValue: Success
 
-        init<U: AsynchronousUnitOfWork>(upstream: U, newValue: Success) where U.Success == Success? {
-            state = TaskState {
-                if let val = try await upstream.operation() {
-                    return val
-                } else {
-                    return newValue
-                }
+        init(upstream: Upstream, newValue: Success) {
+            self.upstream = upstream
+            self.newValue = newValue
+        }
+        
+        func _operation() async throws -> Success {
+            if let val = try await upstream.operation() {
+                return val
+            } else {
+                return newValue
             }
         }
     }
@@ -29,6 +34,6 @@ extension AsynchronousUnitOfWork {
     ///
     /// - Returns: An `AsynchronousUnitOfWork` that emits the specified value instead of `nil` when the upstream emits `nil`.
     public func replaceNil<S: Sendable>(with value: S) -> some AsynchronousUnitOfWork<S> where Success == S? {
-        Workers.ReplaceNil<S>(upstream: self, newValue: value)
+        Workers.ReplaceNil<Self, S>(upstream: self, newValue: value)
     }
 }

--- a/Sources/Afluent/Workers/ReplaceNil.swift
+++ b/Sources/Afluent/Workers/ReplaceNil.swift
@@ -17,11 +17,13 @@ extension Workers {
             self.newValue = newValue
         }
         
-        func _operation() async throws -> Success {
-            if let val = try await upstream.operation() {
-                return val
-            } else {
-                return newValue
+        func _operation() async throws -> AsynchronousOperation<Success> {
+            AsynchronousOperation {
+                if let val = try await upstream.operation() {
+                    return val
+                } else {
+                    return newValue
+                }
             }
         }
     }

--- a/Sources/Afluent/Workers/Retain.swift
+++ b/Sources/Afluent/Workers/Retain.swift
@@ -8,19 +8,21 @@
 import Foundation
 
 extension Workers {
-    actor Retain<Success>: AsynchronousUnitOfWork {
-        let state: TaskState<Success>
+    actor Retain<Upstream: AsynchronousUnitOfWork, Success>: AsynchronousUnitOfWork where Success == Upstream.Success {
+        let state = TaskState<Success>()
+        let upstream: Upstream
         var cachedSuccess: Success?
-        init<U: AsynchronousUnitOfWork>(upstream: U) where Success == U.Success {
-            state = TaskState.unsafeCreation()
-            state.setOperation { [weak self] in
-                guard let self else { throw CancellationError() }
-                if let success = await cachedSuccess {
-                    return success
-                } else {
-                    let result = try await upstream.operation()
-                    return await cache(result)
-                }
+        
+        init(upstream: Upstream) {
+            self.upstream = upstream
+        }
+        
+        func _operation() async throws -> Success {
+            if let success = cachedSuccess {
+                return success
+            } else {
+                let result = try await upstream.operation()
+                return cache(result)
             }
         }
         

--- a/Sources/Afluent/Workers/Retain.swift
+++ b/Sources/Afluent/Workers/Retain.swift
@@ -17,12 +17,16 @@ extension Workers {
             self.upstream = upstream
         }
         
-        func _operation() async throws -> Success {
-            if let success = cachedSuccess {
-                return success
-            } else {
-                let result = try await upstream.operation()
-                return cache(result)
+        func _operation() async throws -> AsynchronousOperation<Success> {
+            AsynchronousOperation { [weak self] in
+                guard let self else { throw CancellationError() }
+
+                if let success = await self.cachedSuccess {
+                    return success
+                } else {
+                    let result = try await self.upstream.operation()
+                    return await self.cache(result)
+                }
             }
         }
         

--- a/Sources/Afluent/Workers/Retry.swift
+++ b/Sources/Afluent/Workers/Retry.swift
@@ -9,10 +9,9 @@ import Foundation
 
 extension Workers {
     actor Retry<Upstream: AsynchronousUnitOfWork, Success>: AsynchronousUnitOfWork where Upstream.Success == Success {
-        var retryCount: UInt
-
         let state = TaskState<Success>()
         let upstream: Upstream
+        var retryCount: UInt
 
         init(upstream: Upstream, retries: UInt) {
             self.upstream = upstream
@@ -48,10 +47,9 @@ extension Workers {
     }
     
     actor RetryOn<Upstream: AsynchronousUnitOfWork, Failure: Error & Equatable, Success>: AsynchronousUnitOfWork where Upstream.Success == Success {
-        var retryCount: UInt
-
         let state = TaskState<Success>()
         let upstream: Upstream
+        var retryCount: UInt
         let error: Failure
 
         init(upstream: Upstream, retries: UInt, error: Failure) {

--- a/Sources/Afluent/Workers/RetryAfterFlatMapping.swift
+++ b/Sources/Afluent/Workers/RetryAfterFlatMapping.swift
@@ -8,10 +8,9 @@
 import Foundation
 extension Workers {
     actor RetryAfterFlatMapping<Upstream: AsynchronousUnitOfWork, Downstream: AsynchronousUnitOfWork, Success>: AsynchronousUnitOfWork where Upstream.Success == Success {
-        var retryCount: UInt
-
         let state = TaskState<Success>()
         let upstream: Upstream
+        var retryCount: UInt
         let transform: @Sendable (Error) async throws -> Downstream
 
         init(upstream: Upstream, retries: UInt, @_inheritActorContext @_implicitSelfCapture transform: @escaping @Sendable (Error) async throws -> Downstream) {
@@ -51,16 +50,15 @@ extension Workers {
     }
     
     actor RetryOnAfterFlatMapping<Upstream: AsynchronousUnitOfWork, Downstream: AsynchronousUnitOfWork, Failure: Error & Equatable, Success>: AsynchronousUnitOfWork where Upstream.Success == Success {
-        var retryCount: UInt
-
         let state = TaskState<Success>()
         let upstream: Upstream
-        let transform: @Sendable (Failure) async throws -> Downstream
+        var retryCount: UInt
         let error: Failure
+        let transform: @Sendable (Failure) async throws -> Downstream
 
         init(upstream: Upstream, retries: UInt, error: Failure, @_inheritActorContext @_implicitSelfCapture transform: @escaping @Sendable (Failure) async throws -> Downstream) {
-            retryCount = retries
             self.upstream = upstream
+            retryCount = retries
             self.error = error
             self.transform = transform
         }

--- a/Sources/Afluent/Workers/Share.swift
+++ b/Sources/Afluent/Workers/Share.swift
@@ -8,18 +8,23 @@
 import Foundation
 
 extension Workers {
-    actor Share<Success: Sendable>: AsynchronousUnitOfWork {
-        let state: TaskState<Success>
-        private lazy var task = state.setLazyTask()
+    actor Share<Upstream: AsynchronousUnitOfWork, Success: Sendable>: AsynchronousUnitOfWork where Upstream.Success == Success {
+        let state = TaskState<Success>()
+        let upstream: Upstream
+        private lazy var task = Task { try await upstream.operation() }
         
-        init<U: AsynchronousUnitOfWork>(upstream: U) where U.Success == Success {
-            state = upstream.state
+        init(upstream: Upstream) {
+            self.upstream = upstream
         }
         
         public var result: Result<Success, Error> {
             get async {
                 await task.result
             }
+        }
+        
+        public func _operation() async throws -> Success {
+            try await task.value
         }
         
         @discardableResult public func execute() async throws -> Success {

--- a/Sources/Afluent/Workers/Share.swift
+++ b/Sources/Afluent/Workers/Share.swift
@@ -23,8 +23,11 @@ extension Workers {
             }
         }
         
-        public func _operation() async throws -> Success {
-            try await task.value
+        public func _operation() async throws -> AsynchronousOperation<Success> {
+            AsynchronousOperation { [weak self] in
+                guard let self else { throw CancellationError() }
+                return try await self.task.value
+            }
         }
         
         @discardableResult public func execute() async throws -> Success {

--- a/Sources/Afluent/Workers/SingleValueChannel.swift
+++ b/Sources/Afluent/Workers/SingleValueChannel.swift
@@ -1,0 +1,107 @@
+//
+//  SingleValueChannel.swift
+//
+//
+//  Created by Tyler Thompson on 11/11/23.
+//
+
+import Foundation
+
+/// A channel that emits a single value or an error.
+///
+/// ` SingleValueChannel` is an `AsynchronousUnitOfWork` that can be manually completed with either a success value or an error. It's useful for scenarios where you need to bridge callback-based APIs into the world of `async/await`.
+///
+/// - Note: Once completed, any further attempts to send a value or an error will result in a `ChannelError.alreadyCompleted`.
+/// - Important: This is very similar to a `SingleValueSubject`, but shares more similarities with `AsyncChannel` in swift-async-algorithms. Sending is an `async` operation, and therefore the ergonomics of this type are a little different. However, it should generally be preferred where possible over `SingleValueSubject`
+public actor SingleValueChannel<Success: Sendable>: AsynchronousUnitOfWork {
+    /// Errors specific to `SingleValueChannel`.
+    public enum ChannelError: Error {
+        /// Indicates that the channel has already been completed and cannot accept further values or errors.
+        case alreadyCompleted
+    }
+    
+    public let state: TaskState<Success>
+    private var channelState = State.noValue
+    
+    /// Creates a new `SingleValueChannel`.
+    public init() {
+        state = TaskState.unsafeCreation()
+        state.setOperation { [weak self] in
+            guard let self else { throw CancellationError() }
+            if case .sentValue(let success) = await self.channelState {
+                return success
+            } else if case .sentError(let error) = await self.channelState {
+                throw error
+            }
+
+            return try await withUnsafeThrowingContinuation { continuation in
+                Task {
+                    await self.setchannelState(.hasContinuation(continuation))
+                }
+            }
+        }
+    }
+    
+    private func setchannelState(_ state: State) {
+        channelState = state
+    }
+    
+    /// Sends a value to the channel.
+    ///
+    /// Completes the channel with the provided value. If the channel is already completed, this method throws a `ChannelError.alreadyCompleted`.
+    ///
+    /// - Parameter value: The success value to send.
+    /// - Throws: `ChannelError.alreadyCompleted` if the channel is already completed.
+    public func send(_ value: Success) throws {
+        switch self.channelState {
+        case .noValue: self.channelState = .sentValue(value)
+        case .hasContinuation(let continuation):
+            self.channelState = .sentValue(value)
+            continuation.resume(returning: value)
+        default:
+            throw ChannelError.alreadyCompleted
+        }
+    }
+    
+    /// Sends a value to the channel.
+    ///
+    /// Completes the channel with the provided value. If the channel is already completed, this method throws a `ChannelError.alreadyCompleted`.
+    ///
+    /// - Throws: `ChannelError.alreadyCompleted` if the channel is already completed.
+    public func send() throws where Success == Void {
+        switch self.channelState {
+        case .noValue: self.channelState = .sentValue(())
+        case .hasContinuation(let continuation):
+            self.channelState = .sentValue(())
+            continuation.resume(returning: ())
+        default:
+            throw ChannelError.alreadyCompleted
+        }
+    }
+    
+    /// Sends an error to the channel.
+    ///
+    /// Completes the channel with the provided error. If the channel is already completed, this method throws a `ChannelError.alreadyCompleted`.
+    ///
+    /// - Parameter error: The error to send.
+    /// - Throws: `ChannelError.alreadyCompleted` if the channel is already completed.
+    public func send(error: Error) throws {
+        switch self.channelState {
+        case .noValue: self.channelState = .sentError(error)
+        case .hasContinuation(let continuation):
+            self.channelState = .sentError(error)
+            continuation.resume(throwing: error)
+        default:
+            throw ChannelError.alreadyCompleted
+        }
+    }
+}
+
+extension SingleValueChannel {
+    private enum State {
+        case noValue
+        case sentValue(Success)
+        case sentError(Error)
+        case hasContinuation(UnsafeContinuation<Success, Error>)
+    }
+}

--- a/Sources/Afluent/Workers/SingleValueSubject.swift
+++ b/Sources/Afluent/Workers/SingleValueSubject.swift
@@ -67,6 +67,24 @@ public final class SingleValueSubject<Success: Sendable>: AsynchronousUnitOfWork
         }
     }
     
+    /// Sends a value to the subject.
+    ///
+    /// Completes the subject with the provided value. If the subject is already completed, this method throws a `SubjectError.alreadyCompleted`.
+    ///
+    /// - Throws: `SubjectError.alreadyCompleted` if the subject is already completed.
+    public func send() throws where Success == Void {
+        try _lock.protect {
+            switch self.subjectState {
+            case .noValue: self.subjectState = .sentValue(())
+            case .hasContinuation(let continuation):
+                self.subjectState = .sentValue(())
+                continuation.resume(returning: ())
+            default:
+                throw SubjectError.alreadyCompleted
+            }
+        }
+    }
+    
     /// Sends an error to the subject.
     ///
     /// Completes the subject with the provided error. If the subject is already completed, this method throws a `SubjectError.alreadyCompleted`.

--- a/Sources/Afluent/Workers/Timeout.swift
+++ b/Sources/Afluent/Workers/Timeout.swift
@@ -7,39 +7,43 @@
 
 import Foundation
 extension Workers {
-    actor Timeout<Success: Sendable>: AsynchronousUnitOfWork {
-        let state: TaskState<Success>
+    actor Timeout<Upstream: AsynchronousUnitOfWork, Success: Sendable>: AsynchronousUnitOfWork where Upstream.Success == Success {
+        let state = TaskState<Success>()
+        let upstream: Upstream
         var customError: Error?
         var timedOut = false
+        let duration: Measurement<UnitDuration>
 
-        init<U: AsynchronousUnitOfWork>(upstream: U, duration: Measurement<UnitDuration>, error: Error?) where U.Success == Success {
-            let nanosecondDelay = duration.converted(to: .nanoseconds).value
+        init(upstream: Upstream, duration: Measurement<UnitDuration>, error: Error?) {
+            self.upstream = upstream
+            self.duration = duration
             customError = error
-            state = TaskState.unsafeCreation()
-            state.setOperation { [weak self] in
+        }
+        
+        func _operation() async throws -> Success {
+            reset()
+            let timeoutTask = Task { [weak self] in
                 guard let self else { throw CancellationError() }
-                await self.reset()
-                let timeoutTask = Task {
-                    try await Task.sleep(nanoseconds: UInt64(nanosecondDelay))
-                    await self.timeout()
-                    upstream.cancel()
-                }
-                
-                return try await Task {
-                    do {
-                        let result = try await upstream.execute()
-                        timeoutTask.cancel()
-                        return result
-                    } catch {
-                        timeoutTask.cancel()
-                        if await self.timedOut {
-                            throw await self.customError ?? CancellationError()
-                        } else {
-                            throw error
-                        }
-                    }
-                }.value
+                try await Task.sleep(nanoseconds: UInt64(self.duration.converted(to: .nanoseconds).value))
+                await self.timeout()
+                upstream.cancel()
             }
+            
+            return try await Task { [weak self] in
+                guard let self else { throw CancellationError() }
+                do {
+                    let result = try await upstream.execute()
+                    timeoutTask.cancel()
+                    return result
+                } catch {
+                    timeoutTask.cancel()
+                    if await self.timedOut {
+                        throw await self.customError ?? CancellationError()
+                    } else {
+                        throw error
+                    }
+                }
+            }.value
         }
         
         func reset() {

--- a/Sources/Afluent/Workers/Zip.swift
+++ b/Sources/Afluent/Workers/Zip.swift
@@ -20,10 +20,12 @@ extension Workers {
             self.downstream = downstream
         }
         
-        func _operation() async throws -> Success {
-            async let u = try await upstream.operation()
-            async let d = try await downstream.operation()
-            return (try await u, try await d)
+        func _operation() async throws -> AsynchronousOperation<Success> {
+            AsynchronousOperation {
+                async let u = try await upstream.operation()
+                async let d = try await downstream.operation()
+                return (try await u, try await d)
+            }
         }
     }
     
@@ -41,12 +43,14 @@ extension Workers {
             self.d1 = d1
         }
         
-        func _operation() async throws -> Success {
-            async let u = try await upstream.operation()
-            async let d_0 = try await d0.operation()
-            async let d_1 = try await d1.operation()
-            
-            return (try await u, try await d_0, try await d_1)
+        func _operation() async throws -> AsynchronousOperation<Success> {
+            AsynchronousOperation {
+                async let u = try await upstream.operation()
+                async let d_0 = try await d0.operation()
+                async let d_1 = try await d1.operation()
+                
+                return (try await u, try await d_0, try await d_1)
+            }
         }
     }
     
@@ -66,13 +70,15 @@ extension Workers {
             self.d2 = d2
         }
         
-        func _operation() async throws -> Success {
-            async let u = try await upstream.operation()
-            async let d_0 = try await d0.operation()
-            async let d_1 = try await d1.operation()
-            async let d_2 = try await d2.operation()
-            
-            return (try await u, try await d_0, try await d_1, try await d_2)
+        func _operation() async throws -> AsynchronousOperation<Success> {
+            AsynchronousOperation {
+                async let u = try await upstream.operation()
+                async let d_0 = try await d0.operation()
+                async let d_1 = try await d1.operation()
+                async let d_2 = try await d2.operation()
+                
+                return (try await u, try await d_0, try await d_1, try await d_2)
+            }
         }
     }
 }

--- a/Sources/Afluent/Workers/Zip.swift
+++ b/Sources/Afluent/Workers/Zip.swift
@@ -8,44 +8,71 @@
 import Foundation
 
 extension Workers {
-    struct Zip<Success: Sendable>: AsynchronousUnitOfWork {
-        let state: TaskState<Success>
+    struct Zip<Upstream: AsynchronousUnitOfWork, Downstream: AsynchronousUnitOfWork>: AsynchronousUnitOfWork {
+        typealias Success = (Upstream.Success, Downstream.Success)
         
-        init<U: AsynchronousUnitOfWork, D: AsynchronousUnitOfWork>(upstream: U, downstream: D) where Success == (U.Success, D.Success) {
-            state = TaskState {
-                async let u = try await upstream.operation()
-                async let d = try await downstream.operation()
-                return (try await u, try await d)
-            }
+        let state = TaskState<Success>()
+        let upstream: Upstream
+        let downstream: Downstream
+
+        init(upstream: Upstream, downstream: Downstream) {
+            self.upstream = upstream
+            self.downstream = downstream
+        }
+        
+        func _operation() async throws -> Success {
+            async let u = try await upstream.operation()
+            async let d = try await downstream.operation()
+            return (try await u, try await d)
         }
     }
     
-    struct Zip3<Success: Sendable>: AsynchronousUnitOfWork {
-        let state: TaskState<Success>
+    struct Zip3<Upstream: AsynchronousUnitOfWork, Downstream0: AsynchronousUnitOfWork, Downstream1: AsynchronousUnitOfWork>: AsynchronousUnitOfWork {
+        typealias Success = (Upstream.Success, Downstream0.Success, Downstream1.Success)
+
+        let state = TaskState<Success>()
+        let upstream: Upstream
+        let d0: Downstream0
+        let d1: Downstream1
+
+        init(upstream: Upstream, d0: Downstream0, d1: Downstream1) {
+            self.upstream = upstream
+            self.d0 = d0
+            self.d1 = d1
+        }
         
-        init<U: AsynchronousUnitOfWork, D0: AsynchronousUnitOfWork, D1: AsynchronousUnitOfWork>(upstream: U, d0: D0, d1: D1) where Success == (U.Success, D0.Success, D1.Success) {
-            state = TaskState {
-                async let u = try await upstream.operation()
-                async let d_0 = try await d0.operation()
-                async let d_1 = try await d1.operation()
-                
-                return (try await u, try await d_0, try await d_1)
-            }
+        func _operation() async throws -> Success {
+            async let u = try await upstream.operation()
+            async let d_0 = try await d0.operation()
+            async let d_1 = try await d1.operation()
+            
+            return (try await u, try await d_0, try await d_1)
         }
     }
     
-    struct Zip4<Success: Sendable>: AsynchronousUnitOfWork {
-        let state: TaskState<Success>
+    struct Zip4<Upstream: AsynchronousUnitOfWork, Downstream0: AsynchronousUnitOfWork, Downstream1: AsynchronousUnitOfWork, Downstream2: AsynchronousUnitOfWork>: AsynchronousUnitOfWork {
+        typealias Success = (Upstream.Success, Downstream0.Success, Downstream1.Success, Downstream2.Success)
+
+        let state = TaskState<Success>()
+        let upstream: Upstream
+        let d0: Downstream0
+        let d1: Downstream1
+        let d2: Downstream2
+
+        init(upstream: Upstream, d0: Downstream0, d1: Downstream1, d2: Downstream2) {
+            self.upstream = upstream
+            self.d0 = d0
+            self.d1 = d1
+            self.d2 = d2
+        }
         
-        init<U: AsynchronousUnitOfWork, D0: AsynchronousUnitOfWork, D1: AsynchronousUnitOfWork, D2: AsynchronousUnitOfWork>(upstream: U, d0: D0, d1: D1, d2: D2) where Success == (U.Success, D0.Success, D1.Success, D2.Success) {
-            state = TaskState {
-                async let u = try await upstream.operation()
-                async let d_0 = try await d0.operation()
-                async let d_1 = try await d1.operation()
-                async let d_2 = try await d2.operation()
-                
-                return (try await u, try await d_0, try await d_1, try await d_2)
-            }
+        func _operation() async throws -> Success {
+            async let u = try await upstream.operation()
+            async let d_0 = try await d0.operation()
+            async let d_1 = try await d1.operation()
+            async let d_2 = try await d2.operation()
+            
+            return (try await u, try await d_0, try await d_1, try await d_2)
         }
     }
 }
@@ -67,7 +94,7 @@ extension AsynchronousUnitOfWork {
     ///   - transform: A function that takes a tuple of results from both units of work and returns a transformed result.
     /// - Returns: A new asynchronous unit of work that produces the transformed result when completed.
     public func zip<D: AsynchronousUnitOfWork, T: Sendable>(_ downstream: D, @_inheritActorContext @_implicitSelfCapture transform: @escaping @Sendable ((Success, D.Success)) async throws -> T) -> some AsynchronousUnitOfWork<T> {
-        Workers.TryMap<T>(upstream: Workers.Zip<(Success, D.Success)>(upstream: self, downstream: downstream), transform: transform)
+        Workers.TryMap<Workers.Zip<Self, D>, T>(upstream: Workers.Zip<Self, D>(upstream: self, downstream: downstream), transform: transform)
     }
     
     // zip3
@@ -89,7 +116,7 @@ extension AsynchronousUnitOfWork {
     ///   - transform: A function that takes a tuple of results from all units of work and returns a transformed result.
     /// - Returns: A new asynchronous unit of work that produces the transformed result when completed.
     public func zip<D0: AsynchronousUnitOfWork, D1: AsynchronousUnitOfWork, T: Sendable>(_ d0: D0, _ d1: D1, @_inheritActorContext @_implicitSelfCapture transform: @escaping @Sendable ((Success, D0.Success, D1.Success)) async throws -> T) -> some AsynchronousUnitOfWork<T> {
-        Workers.TryMap<T>(upstream: Workers.Zip3<(Success, D0.Success, D1.Success)>(upstream: self, d0: d0, d1: d1), transform: transform)
+        Workers.TryMap<Workers.Zip3<Self, D0, D1>, T>(upstream: Workers.Zip3<Self, D0, D1>(upstream: self, d0: d0, d1: d1), transform: transform)
     }
     
     // zip4
@@ -113,6 +140,6 @@ extension AsynchronousUnitOfWork {
     ///   - transform: A function that takes a tuple of results from all units of work and returns a transformed result.
     /// - Returns: A new asynchronous unit of work that produces the transformed result when completed.
     public func zip<D0: AsynchronousUnitOfWork, D1: AsynchronousUnitOfWork, D2: AsynchronousUnitOfWork, T: Sendable>(_ d0: D0, _ d1: D1, _ d2: D2, @_inheritActorContext @_implicitSelfCapture transform: @escaping @Sendable ((Success, D0.Success, D1.Success, D2.Success)) async throws -> T) -> some AsynchronousUnitOfWork<T> {
-        Workers.TryMap<T>(upstream: Workers.Zip4<(Success, D0.Success, D1.Success, D2.Success)>(upstream: self, d0: d0, d1: d1, d2: d2), transform: transform)
+        Workers.TryMap<Workers.Zip4<Self, D0, D1, D2>, T>(upstream: Workers.Zip4<Self, D0, D1, D2>(upstream: self, d0: d0, d1: d1, d2: d2), transform: transform)
     }
 }


### PR DESCRIPTION
This shares a lot of similarities with SingleValueSubject. The key difference is that the `send` methods are `async`. This provides similar ergonomics to the channels in swift-async-algorithms. In general, because this is able to use swift concurrency under the hood, it should be preferred. 

This remains valuable for single-value notifications...but becomes less convenient for bridging to synchronous APIs than `SingleValueSubject` does.