### PR TITLE
To stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ struct Post: Codable {
 let posts = try await DeferredTask {
     try await URLSession.shared.data(from: URL(string: "https://jsonplaceholder.typicode.com/posts")!)
 }
-.map(\.data) // Extract the data from the URLSession response
+.map(\.0) // Extract the data from the URLSession response
 .decode(type: [Post].self, decoder: JSONDecoder()) // Decode the JSON into an array of `Post` objects
 .retry() // Automatically retry the request if it fails
 .execute() // Execute the deferred task
@@ -99,7 +99,7 @@ Fetching, decoding JSON data, and implementing retries using Afluent:
 let posts = try await DeferredTask {
     try await URLSession.shared.data(from: URL(string: "https://jsonplaceholder.typicode.com/posts")!)
 }
-.map(\.data) // Extract the data from the URLSession response
+.map(\.0) // Extract the data from the URLSession response
 .decode(type: [Post].self, decoder: JSONDecoder()) // Decode the JSON into an array of `Post` objects
 .retry(3) // Automatically retry the request up to 3 times if it fails
 .execute() // Execute the deferred task
@@ -111,7 +111,7 @@ let posts = try await DeferredTask {
   
 - **Built-in Error Handling**: Afluent's `retry` method elegantly handles retries, eliminating the need for manual loops and error checks.
   
-- **Rich Set of Operations**: Beyond retries, Afluent offers operations like `map`, `flatMap`, `filter`, and more, enriching the `async/await` experience.
+- **Rich Set of Operations**: Beyond retries, Afluent offers operations like `map`, `flatMap`, and over 20 more, enriching the `async/await` experience.
 
 - **Readability**: Afluent's fluent design makes the code's intent clearer, enhancing maintainability.
 

--- a/Sources/Afluent/Workers/HandleEvents.swift
+++ b/Sources/Afluent/Workers/HandleEvents.swift
@@ -15,7 +15,7 @@ extension Workers {
         let receiveError: ((Error) async throws -> Void)?
         let receiveCancel: (() async throws -> Void)?
 
-        init(upstream: Upstream, receiveOutput: ((Success) async throws -> Void)?, receiveError: ((Error) async throws -> Void)?, receiveCancel: (() async throws -> Void)?) {
+        init(upstream: Upstream, @_inheritActorContext @_implicitSelfCapture receiveOutput: ((Success) async throws -> Void)?, @_inheritActorContext @_implicitSelfCapture receiveError: ((Error) async throws -> Void)?, @_inheritActorContext @_implicitSelfCapture receiveCancel: (() async throws -> Void)?) {
             self.upstream = upstream
             self.receiveOutput = receiveOutput
             self.receiveError = receiveError
@@ -26,19 +26,17 @@ extension Workers {
             AsynchronousOperation { [weak self] in
                 guard let self else { throw CancellationError() }
 
-                return try await withTaskCancellationHandler {
-                    do {
-                        let val = try await self.upstream.operation()
-                        try await self.receiveOutput?(val)
-                        return val
-                    } catch {
-                        if !(error is CancellationError) {
-                            try await self.receiveError?(error)
-                        }
-                        throw error
+                do {
+                    let val = try await self.upstream.operation()
+                    try await self.receiveOutput?(val)
+                    return val
+                } catch {
+                    if !(error is CancellationError) {
+                        try await self.receiveError?(error)
+                    } else {
+                        try await self.receiveCancel?()
                     }
-                } onCancel: {
-                    Task { try await self.receiveCancel?() }
+                    throw error
                 }
             }
         }

--- a/Sources/Afluent/Workers/HandleEvents.swift
+++ b/Sources/Afluent/Workers/HandleEvents.swift
@@ -25,8 +25,9 @@ extension Workers {
         func _operation() async throws -> AsynchronousOperation<Success> {
             AsynchronousOperation { [weak self] in
                 guard let self else { throw CancellationError() }
-
+                
                 do {
+                    try Task.checkCancellation()
                     let val = try await self.upstream.operation()
                     try await self.receiveOutput?(val)
                     return val

--- a/Sources/Afluent/Workers/ToStream.swift
+++ b/Sources/Afluent/Workers/ToStream.swift
@@ -8,6 +8,13 @@
 import Foundation
 
 extension AsynchronousUnitOfWork {
+    /// Converts the asynchronous unit of work into an `AsyncThrowingStream`.
+    ///
+    /// This method allows you to transform the result of an `AsynchronousUnitOfWork` into a stream, encapsulated in an `AsyncThrowingStream`. This can be useful when you want to bridge the single-value asynchronous operation into a stream-based API, or when you need to integrate with APIs expecting a stream of values.
+    ///
+    /// The resulting stream will emit a single value if the operation succeeds, or it will finish with an error if the operation fails.
+    ///
+    /// - Returns: An `AsyncThrowingStream` that represents the operation of the `AsynchronousUnitOfWork`. The stream emits a single value and then finishes, or finishes with an error if the operation fails.
     public func toStream() -> AsyncThrowingStream<Success, Error> {
         .init { continuation in
             Task {

--- a/Sources/Afluent/Workers/ToStream.swift
+++ b/Sources/Afluent/Workers/ToStream.swift
@@ -1,0 +1,24 @@
+//
+//  ToStream.swift
+//
+//
+//  Created by Tyler Thompson on 11/11/23.
+//
+
+import Foundation
+
+extension AsynchronousUnitOfWork {
+    public func toStream() -> AsyncThrowingStream<Success, Error> {
+        .init { continuation in
+            Task {
+                do {
+                    let val = try await operation()
+                    continuation.yield(val)
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+        }
+    }
+}

--- a/Tests/AfluentTests/WorkerTests/ToStreamTests.swift
+++ b/Tests/AfluentTests/WorkerTests/ToStreamTests.swift
@@ -1,0 +1,25 @@
+//
+//  ToStreamTests.swift
+//
+//
+//  Created by Tyler Thompson on 11/23/23.
+//
+
+import Foundation
+import Afluent
+import XCTest
+
+import Atomics
+
+final class ToStreamTests: XCTestCase {
+    func convertingUnitOfWorkToAsyncSequence() async throws {
+        var counter = ManagedAtomic(0)
+        
+        for try await val in DeferredTask(operation: { 1 }).toStream() {
+            counter.wrappingIncrement(ordering: .relaxed)
+            XCTAssertEqual(val, 1)
+        }
+        
+        XCTAssertEqual(counter.load(ordering: .relaxed), 1)
+    }
+}


### PR DESCRIPTION
This adds a new `toStream` operator that converts an `AsynchronousUnitOfWork` into an `AsyncSequence`. 

It also made some tweaks to `handleEvents` so that it inherits actor context and manages cancellation better (by managing it within the same task, rather than creating a new one)