### PR TITLE
Extension of AsynchronousUnitOfWork - WithUnretained.

### DIFF
--- a/Sources/Afluent/Workers/WithUnretained.swift
+++ b/Sources/Afluent/Workers/WithUnretained.swift
@@ -1,0 +1,33 @@
+//
+//  AsynchronousUnitOfWork+withUnretained.swift
+//  
+//
+//  Created by Daniel Bachar on 11/8/23.
+//
+
+import Foundation
+
+public enum UnretainedError: Error, Equatable {
+    case failedRetaining
+}
+
+// Heavily based on the RxSwift operator - `withUnretained`.
+// https://github.com/ReactiveX/RxSwift/blob/main/RxSwift/Observables/WithUnretained.swift
+
+extension AsynchronousUnitOfWork {
+    /// Provides an unretained, safe to use (i.e. not implicitly unwrapped), reference to an object along with the events emitted by the operator.
+    /// In the case the provided object cannot be retained successfully, the sequence will throw.
+    /// - Parameters:
+    ///   - obj: The object to provide an unretained reference on.
+    ///   - resultSelector: A function to combine the unretained referenced on `obj` and the value of the observable sequence.
+    /// - Returns: An AsynchronousUnitOfWork that contains the result of `resultSelector` being called with an unretained reference on `obj` and the values of the original sequence.
+    public func withUnretained<Object: AnyObject, Out>(
+        _ obj: Object,
+        resultSelector: @escaping (Object, Success) -> Out
+    ) -> some AsynchronousUnitOfWork<Out> {
+        tryMap { [weak obj] element -> Out in
+            guard let obj = obj else { throw UnretainedError.failedRetaining }
+            return resultSelector(obj, element)
+        }
+    }
+}

--- a/Tests/AfluentTests/WorkerTests/WithUnretainedTests.swift
+++ b/Tests/AfluentTests/WorkerTests/WithUnretainedTests.swift
@@ -1,0 +1,38 @@
+//
+//  WithUnretainedTests.swift
+//
+//
+//  Created by Daniel Bachar on 11/8/23.
+//
+import Afluent
+
+import Foundation
+import XCTest
+
+
+final class WithUnretainedTests: XCTestCase {
+    class MyType {}
+    
+    func testWithUnretainedHolds() async throws {
+        
+        let myTypeInstance = MyType()
+
+        try await DeferredTask { 1 }
+            .withUnretained(myTypeInstance, resultSelector: { myType, _ in
+                XCTAssertNotNil(myType)
+            })
+            .execute()
+    }
+    
+    func testWithUnretainedThrows() async throws {
+        do {
+            try await DeferredTask { 1 }
+                .withUnretained(MyType(), resultSelector: { _, _ in })
+                .execute()
+            XCTFail("Should throw if failed to retain")
+        } catch {
+            XCTAssertEqual(error as? UnretainedError, UnretainedError.failedRetaining)
+        }
+        
+    }
+}


### PR DESCRIPTION
Extension of AsynchronousUnitOfWork with a new Operator `WithUnretained`

Provides an unretained, safe to use (i.e. not implicitly unwrapped), reference to an object along with the events emitted by the operator. In the case the provided object cannot be retained successfully, the sequence will throw.

Heavily based on the RxSwift operator - `withUnretained` - https://github.com/ReactiveX/RxSwift/blob/main/RxSwift/Observables/WithUnretained.swift - The difference is that here it will throw if didn't manage to unwrap. As we don't care for the stream

