### PR TITLE
CatchSequence - TT

### DIFF
--- a/Sources/Afluent/SequenceOperators/AsyncSequences.swift
+++ b/Sources/Afluent/SequenceOperators/AsyncSequences.swift
@@ -1,0 +1,16 @@
+//
+//  AsyncSequences.swift
+//
+//
+//  Created by Tyler Thompson on 11/28/23.
+//
+
+import Foundation
+
+/// A namespace for grouping related AsyncSequence operations.
+///
+/// The `AsyncSequences` enum itself doesn't contain values, serving solely as a container for nested types and functionalities to keep them organized.
+/// For example, it might contain static methods, nested types, or enums that deal with specific aspects of asynchronous work.
+public enum AsyncSequences {
+    
+}

--- a/Sources/Afluent/SequenceOperators/CatchSequence.swift
+++ b/Sources/Afluent/SequenceOperators/CatchSequence.swift
@@ -1,0 +1,57 @@
+//
+//  CatchSequence.swift
+//  
+//
+//  Created by Tyler Thompson on 11/28/23.
+//
+
+import Foundation
+
+extension AsyncSequences {
+    public struct Catch<Upstream: AsyncSequence, Downstream: AsyncSequence>: AsyncSequence where Upstream.Element == Downstream.Element {
+        public typealias Element = Upstream.Element
+        let upstream: Upstream
+        let handler: @Sendable (Error) async throws -> Downstream
+
+        init(upstream: Upstream, @_inheritActorContext @_implicitSelfCapture _ handler: @escaping @Sendable (Error) async throws -> Downstream) {
+            self.upstream = upstream
+            self.handler = handler
+        }
+        
+        public struct AsyncIterator: AsyncIteratorProtocol {
+            var upstreamIterator: Upstream.AsyncIterator
+            let handler: @Sendable (Error) async throws -> Downstream
+            var caughtIterator: Downstream.AsyncIterator?
+            
+            public mutating func next() async throws -> Element? {
+                if var caughtIterator {
+                    return try await caughtIterator.next()
+                }
+                
+                do {
+                    return try await upstreamIterator.next()
+                } catch {
+                    caughtIterator = try await handler(error).makeAsyncIterator()
+                    return try await next()
+                }
+            }
+        }
+        
+        public func makeAsyncIterator() -> AsyncIterator {
+            AsyncIterator(upstreamIterator: upstream.makeAsyncIterator(),
+                          handler: handler)
+        }
+    }
+}
+
+extension AsyncSequence {
+    /// Catches any errors emitted by the upstream `AsyncSequence` and handles them using the provided closure.
+    ///
+    /// - Parameters:
+    ///   - handler: A closure that takes an `Error` and returns an `AsynchSequence`.
+    ///
+    /// - Returns: An `AsyncSequence` that will catch and handle any errors emitted by the upstream sequence.
+    public func `catch`<D: AsyncSequence>(@_inheritActorContext @_implicitSelfCapture _ handler: @escaping @Sendable (Error) async -> D) -> AsyncSequences.Catch<Self, D> {
+        AsyncSequences.Catch(upstream: self, handler)
+    }
+}

--- a/Tests/AfluentTests/SequenceTests/CatchSequenceTests.swift
+++ b/Tests/AfluentTests/SequenceTests/CatchSequenceTests.swift
@@ -1,0 +1,126 @@
+//
+//  CatchSequenceTests.swift
+//
+//
+//  Created by Tyler Thompson on 11/28/23.
+//
+
+import Foundation
+import Afluent
+import XCTest
+
+final class CatchSequenceTests: XCTestCase {
+    func testCatchDoesNotInterfereWithNoFailure() async throws {
+        let val = try await DeferredTask { 1 }.toAsyncSequence()
+            .catch { _ in DeferredTask { 2 }.toAsyncSequence() }
+            .first { _ in true }
+        
+        XCTAssertEqual(val, 1)
+    }
+    
+    func testCatchDoesNotThrowError() async throws {
+        let val = await Task {
+            try await DeferredTask { 1 }.toAsyncSequence()
+                .map { _ -> Int in throw URLError(.badURL) }
+                .catch { error in
+                    XCTAssertEqual(error as? URLError, URLError(.badURL))
+                    return DeferredTask { 2 }.toAsyncSequence()
+                }
+                .first { _ in true }
+        }.result
+        
+        XCTAssertEqual(try val.get(), 2)
+    }
+    
+//    func testCatchSpecificError() async throws {
+//        enum Err: Error, Equatable {
+//            case e1
+//            case e2
+//        }
+//        
+//        let val = try await DeferredTask { 1 }
+//            .tryMap { _ in throw Err.e1 }
+//            .catch(Err.e1) { error -> DeferredTask<Int> in
+//                XCTAssertEqual(error, .e1)
+//                return DeferredTask { 2 }
+//            }
+//            .result
+//        
+//        XCTAssertEqual(try val.get(), 2)
+//    }
+    
+//    func testCatchSpecificError_DoesNotCatchWrongError() async throws {
+//        enum Err: Error, Equatable {
+//            case e1
+//            case e2
+//        }
+//        
+//        let val = try await DeferredTask { 1 }
+//            .tryMap { _ in throw Err.e2 }
+//            .catch(Err.e1) { error -> DeferredTask<Int> in
+//                XCTAssertEqual(error, .e1)
+//                return DeferredTask { 2 }
+//            }
+//            .result
+//        
+//        XCTAssertThrowsError(try val.get()) { error in
+//            XCTAssertEqual(error as? Err, .e2)
+//        }
+//    }
+
+//    func testTryCatchDoesNotInterfereWithNoFailure() async throws {
+//        let val = try await DeferredTask { 1 }
+//            .tryCatch { _ in DeferredTask { 2 } }
+//            .execute()
+//        
+//        XCTAssertEqual(val, 1)
+//    }
+//    
+//    func testTryCatchDoesNotThrowError() async throws {
+//        let val = try await DeferredTask { 1 }
+//            .tryMap { _ in throw URLError(.badURL) }
+//            .tryCatch { error -> DeferredTask<Int> in
+//                XCTAssertEqual(error as? URLError, URLError(.badURL))
+//                return DeferredTask { 2 }
+//            }
+//            .result
+//        
+//        XCTAssertEqual(try val.get(), 2)
+//    }
+//    
+//    func testTryCatchSpecificError() async throws {
+//        enum Err: Error, Equatable {
+//            case e1
+//            case e2
+//        }
+//        
+//        let val = try await DeferredTask { 1 }
+//            .tryMap { _ in throw Err.e1 }
+//            .tryCatch(Err.e1) { error -> DeferredTask<Int> in
+//                XCTAssertEqual(error, .e1)
+//                return DeferredTask { 2 }
+//            }
+//            .result
+//        
+//        XCTAssertEqual(try val.get(), 2)
+//    }
+//    
+//    func testTryCatchSpecificError_DoesNotCatchWrongError() async throws {
+//        enum Err: Error, Equatable {
+//            case e1
+//            case e2
+//        }
+//        
+//        let val = try await DeferredTask { 1 }
+//            .tryMap { _ in throw Err.e2 }
+//            .tryCatch(Err.e1) { error -> DeferredTask<Int> in
+//                XCTAssertEqual(error, .e1)
+//                return DeferredTask { 2 }
+//            }
+//            .result
+//        
+//        XCTAssertThrowsError(try val.get()) { error in
+//            XCTAssertEqual(error as? Err, .e2)
+//        }
+//    }
+}


### PR DESCRIPTION
This is the first addition in the library to AsyncSequence. Lots of research and POC work lead to an understanding that we probably *can* create all the RX style operators we want. The trick will be not to recreate anything in the standard library or swift async algorithms. 

The README will remain untouched regarding sequences for now, but once we reach a critical mass of operators that can change.