### PR TITLE
[handleevents-sequence] - HandleEvents added to AsyncSequence - TT

### DIFF
--- a/Sources/Afluent/SequenceOperators/HandleEventsSequence.swift
+++ b/Sources/Afluent/SequenceOperators/HandleEventsSequence.swift
@@ -1,0 +1,71 @@
+//
+//  HandleEventsSequence.swift
+//
+//
+//  Created by Tyler Thompson on 12/1/23.
+//
+
+import Foundation
+
+extension AsyncSequences {
+    public struct HandleEvents<Upstream: AsyncSequence>: AsyncSequence {
+        public typealias Element = Upstream.Element
+        let upstream: Upstream
+        let receiveOutput: ((Element) async throws -> Void)?
+        let receiveError: ((Error) async throws -> Void)?
+        let receiveComplete: (() async throws -> Void)?
+        let receiveCancel: (() async throws -> Void)?
+
+        public struct AsyncIterator: AsyncIteratorProtocol {
+            let upstream: Upstream
+            let receiveOutput: ((Element) async throws -> Void)?
+            let receiveError: ((Error) async throws -> Void)?
+            let receiveComplete: (() async throws -> Void)?
+            let receiveCancel: (() async throws -> Void)?
+            lazy var iterator = upstream.makeAsyncIterator()
+            
+            public mutating func next() async throws -> Element? {
+                do {
+                    try Task.checkCancellation()
+                    if let val = try await iterator.next() {
+                        try await self.receiveOutput?(val)
+                        return val
+                    } else {
+                        return nil
+                    }
+                } catch {
+                    if !(error is CancellationError) {
+                        try await self.receiveError?(error)
+                    } else {
+                        try await self.receiveCancel?()
+                    }
+                    throw error
+                }
+            }
+        }
+        
+        public func makeAsyncIterator() -> AsyncIterator {
+            AsyncIterator(upstream: upstream,
+                          receiveOutput: receiveOutput,
+                          receiveError: receiveError,
+                          receiveComplete: receiveComplete,
+                          receiveCancel: receiveCancel)
+        }
+    }
+}
+
+extension AsyncSequence {
+    /// Adds side-effects to the receiving events of the upstream `AsyncSequence`.
+    ///
+    /// - Parameters:
+    ///   - receiveOutput: A closure that is invoked when the upstream emits a successful output. The closure can throw errors.
+    ///   - receiveError: A closure that is invoked when the upstream emits an error. The closure can throw errors.
+    ///   - receiveCancel: A closure that is invoked when the unit of work is cancelled. The closure can throw errors.
+    ///
+    /// - Returns: An `AsynchronousUnitOfWork` that performs the side-effects for the specified receiving events.
+    ///
+    /// - Note: The returned `AsynchronousUnitOfWork` forwards all receiving events from the upstream unit of work.
+    public func handleEvents(@_inheritActorContext @_implicitSelfCapture receiveOutput: ((Element) async throws -> Void)? = nil, @_inheritActorContext @_implicitSelfCapture receiveError: ((Error) async throws -> Void)? = nil, @_inheritActorContext @_implicitSelfCapture receiveComplete: (() async throws -> Void)? = nil, @_inheritActorContext @_implicitSelfCapture receiveCancel: (() async throws -> Void)? = nil) -> AsyncSequences.HandleEvents<Self> {
+        AsyncSequences.HandleEvents(upstream: self, receiveOutput: receiveOutput, receiveError: receiveError, receiveComplete: receiveComplete, receiveCancel: receiveCancel)
+    }
+}

--- a/Sources/Afluent/Workers/HandleEvents.swift
+++ b/Sources/Afluent/Workers/HandleEvents.swift
@@ -55,7 +55,7 @@ extension AsynchronousUnitOfWork {
     /// - Returns: An `AsynchronousUnitOfWork` that performs the side-effects for the specified receiving events.
     ///
     /// - Note: The returned `AsynchronousUnitOfWork` forwards all receiving events from the upstream unit of work.
-    public func handleEvents(receiveOutput: ((Success) async throws -> Void)? = nil, receiveError: ((Error) async throws -> Void)? = nil, receiveCancel: (() async throws -> Void)? = nil) -> some AsynchronousUnitOfWork<Success> {
+    public func handleEvents(@_inheritActorContext @_implicitSelfCapture receiveOutput: ((Success) async throws -> Void)? = nil, @_inheritActorContext @_implicitSelfCapture receiveError: ((Error) async throws -> Void)? = nil, @_inheritActorContext @_implicitSelfCapture receiveCancel: (() async throws -> Void)? = nil) -> some AsynchronousUnitOfWork<Success> {
         Workers.HandleEvents(upstream: self, receiveOutput: receiveOutput, receiveError: receiveError, receiveCancel: receiveCancel)
     }
 }

--- a/Tests/AfluentTests/SequenceTests/HandleEventsSequenceTests.swift
+++ b/Tests/AfluentTests/SequenceTests/HandleEventsSequenceTests.swift
@@ -1,0 +1,109 @@
+//
+//  HandleEventsSequenceTests.swift
+//
+//
+//  Created by Tyler Thompson on 12/1/23.
+//
+
+import Foundation
+import Afluent
+import XCTest
+
+final class HandleEventsSequenceTests: XCTestCase {
+    func testHandleOutput() async throws {
+        actor Test {
+            var output: Any?
+            
+            func output(_ any: Any?) { output = any }
+        }
+        let test = Test()
+        
+        let exp = self.expectation(description: "thing happened")
+        let task = Task {
+            try await DeferredTask {
+                1
+            }
+            .toAsyncSequence()
+            .handleEvents(receiveOutput: {
+                await test.output($0)
+                exp.fulfill()
+            })
+            .first { _ in true }
+        }
+        
+        try await Task.sleep(for: .milliseconds(2))
+        
+        task.cancel()
+        
+        await fulfillment(of: [exp], timeout: 1)
+        
+        let output = await test.output
+        
+        XCTAssertEqual(output as? Int, 1)
+    }
+    
+    func testHandleError() async throws {
+        actor Test {
+            var error: Error?
+            
+            func error(_ error: Error) { self.error = error }
+        }
+        let test = Test()
+        
+        let exp = self.expectation(description: "thing happened")
+        let task = Task {
+            try await DeferredTask {
+                throw URLError(.badURL)
+            }
+            .toAsyncSequence()
+            .handleEvents(receiveError: {
+                await test.error($0)
+                exp.fulfill()
+            })
+            .first { _ in true }
+        }
+        
+        try await Task.sleep(for: .milliseconds(2))
+        
+        task.cancel()
+        
+        await fulfillment(of: [exp], timeout: 1)
+        
+        let error = await test.error
+        
+        XCTAssertEqual(error as? URLError, URLError(.badURL))
+    }
+    
+    func testHandleCancel() async throws {
+        try XCTSkipIf(ProcessInfo.processInfo.environment["CI"] == "true")
+        actor Test {
+            var canceled = false
+            
+            func cancel() { canceled = true }
+        }
+        let test = Test()
+        
+        let exp = self.expectation(description: "thing happened")
+        let task = Task {
+            try await DeferredTask {
+                try await Task.sleep(for: .milliseconds(10))
+            }
+            .toAsyncSequence()
+            .handleEvents(receiveCancel: {
+                await test.cancel()
+                exp.fulfill()
+            })
+            .first { _ in true }
+        }
+        
+        try await Task.sleep(for: .milliseconds(2))
+        
+        task.cancel()
+        
+        await fulfillment(of: [exp], timeout: 1)
+        
+        let canceled = await test.canceled
+        
+        XCTAssert(canceled)
+    }
+}


### PR DESCRIPTION
This creates a `handleEvents` operator *very* similar to Combine's. The difference is there are 2 closures, one for handling an error, one for handling completion. This is because, unlike Combine, Afluent doesn't have a dedicated "completion" type. In fact, such a type might never be reasonable but certainly isn't until `AsyncSequence` has primary associated types. 