### PR TITLE
Materialize sequence

### DIFF
--- a/Sources/Afluent/Extensions/AsyncSequenceExtensions.swift
+++ b/Sources/Afluent/Extensions/AsyncSequenceExtensions.swift
@@ -1,0 +1,15 @@
+//
+//  AsyncSequenceExtensions.swift
+//
+//
+//  Created by Tyler Thompson on 12/1/23.
+//
+
+import Foundation
+
+extension AsyncSequence {
+    /// Returns the first element of the sequence
+    @_disfavoredOverload public func first() async rethrows -> Self.Element? {
+        try await first { _ in true }
+    }
+}

--- a/Sources/Afluent/SequenceOperators/DematerializeSequence.swift
+++ b/Sources/Afluent/SequenceOperators/DematerializeSequence.swift
@@ -1,0 +1,50 @@
+//
+//  DematerializeSequence.swift
+//
+//
+//  Created by Tyler Thompson on 12/1/23.
+//
+
+import Foundation
+
+extension AsyncSequences {
+    public struct Dematerialize<Upstream: AsyncSequence, Element>: AsyncSequence where Upstream.Element == AsyncSequences.Event<Element> {
+        let upstream: Upstream
+        
+        public struct AsyncIterator: AsyncIteratorProtocol {
+            let upstream: Upstream
+            lazy var iterator = upstream.makeAsyncIterator()
+            
+            public mutating func next() async throws -> Element? {
+                try Task.checkCancellation()
+                if let val = try await iterator.next() {
+                    switch val {
+                    case .element(let element): return element
+                    case .failure(let error): throw error
+                    case .complete: return nil
+                    }
+                } else {
+                    return nil
+                }
+            }
+        }
+        
+        public func makeAsyncIterator() -> AsyncIterator {
+            AsyncIterator(upstream: upstream)
+        }
+    }
+}
+
+extension AsyncSequence {
+    /// Transforms a sequence of `Event` values back into their original form in an `AsyncSequence`.
+    ///
+    /// This method is the inverse of `materialize`. It takes an `AsyncSequence` of `Event` values and transforms it back into an `AsyncSequence` of the original elements, propagating errors as thrown exceptions.
+    ///
+    /// - Note: The sequence must be of type `AsyncSequences.Event<T>`. The `dematerialize` method will extract the original elements and errors from these events.
+    ///
+    /// - Returns: An `AsyncSequences.Dematerialize` instance that represents the original `AsyncSequence` with its elements and errors.
+    /// - Throws: Re-throws any errors that were encapsulated in the `Event.failure` cases.
+    public func dematerialize<T>() -> AsyncSequences.Dematerialize<Self, T> where Element == AsyncSequences.Event<T> {
+        AsyncSequences.Dematerialize(upstream: self)
+    }
+}

--- a/Sources/Afluent/SequenceOperators/MaterializeSequence.swift
+++ b/Sources/Afluent/SequenceOperators/MaterializeSequence.swift
@@ -1,0 +1,63 @@
+//
+//  MaterializeSequence.swift
+//
+//
+//  Created by Tyler Thompson on 12/1/23.
+//
+
+import Foundation
+
+extension AsyncSequences {
+    public struct Materialize<Upstream: AsyncSequence>: AsyncSequence {
+        public typealias Element = Event
+        
+        let upstream: Upstream
+        
+        /// Represents the different kinds of events that can be emitted by `Materialize`.
+        public enum Event {
+            /// An element from the upstream sequence.
+            case element(Upstream.Element)
+            /// An error encountered in the upstream sequence.
+            case failure(Error)
+            /// The completion of the upstream sequence.
+            case complete
+        }
+        
+        public struct AsyncIterator: AsyncIteratorProtocol {
+            let upstream: Upstream
+            var completed = false
+            lazy var iterator = upstream.makeAsyncIterator()
+            
+            public mutating func next() async throws -> Element? {
+                guard !completed else { return nil }
+                do {
+                    try Task.checkCancellation()
+                    if let val = try await iterator.next() {
+                        return .element(val)
+                    } else {
+                        completed = true
+                        return .complete
+                    }
+                } catch {
+                    guard !(error is CancellationError) else { throw error }
+                    return .failure(error)
+                }
+            }
+        }
+        
+        public func makeAsyncIterator() -> AsyncIterator {
+            AsyncIterator(upstream: upstream)
+        }
+    }
+}
+
+extension AsyncSequence {
+    /// Transforms the elements, completion, and errors of the current `AsyncSequence` into `Event` values.
+    ///
+    /// This method wraps the `AsyncSequence` and emits each of its elements, errors, and completion as distinct `Event` cases. It's useful for uniformly handling all aspects of the sequence's lifecycle.
+    ///
+    /// - Returns: An `AsyncSequences.Materialize` instance that represents the transformed sequence.
+    public func materialize() -> AsyncSequences.Materialize<Self> {
+        AsyncSequences.Materialize(upstream: self)
+    }
+}

--- a/Sources/Afluent/SequenceOperators/MaterializeSequence.swift
+++ b/Sources/Afluent/SequenceOperators/MaterializeSequence.swift
@@ -8,20 +8,20 @@
 import Foundation
 
 extension AsyncSequences {
+    /// Represents the different kinds of events that can be emitted by `Materialize`.
+    public enum Event<Element> {
+        /// An element from the upstream sequence.
+        case element(Element)
+        /// An error encountered in the upstream sequence.
+        case failure(Error)
+        /// The completion of the upstream sequence.
+        case complete
+    }
+    
     public struct Materialize<Upstream: AsyncSequence>: AsyncSequence {
-        public typealias Element = Event
+        public typealias Element = Event<Upstream.Element>
         
         let upstream: Upstream
-        
-        /// Represents the different kinds of events that can be emitted by `Materialize`.
-        public enum Event {
-            /// An element from the upstream sequence.
-            case element(Upstream.Element)
-            /// An error encountered in the upstream sequence.
-            case failure(Error)
-            /// The completion of the upstream sequence.
-            case complete
-        }
         
         public struct AsyncIterator: AsyncIteratorProtocol {
             let upstream: Upstream

--- a/Tests/AfluentTests/SequenceTests/AnyAsyncSequenceTests.swift
+++ b/Tests/AfluentTests/SequenceTests/AnyAsyncSequenceTests.swift
@@ -18,7 +18,7 @@ final class AnyAsyncSequenceTests: XCTestCase {
                 } else {
                     return DeferredTask { 0 }.toAsyncSequence().eraseToAnyAsyncSequence()
                 }
-            }.first { _ in true }
+            }.first()
         
         XCTAssertEqual(val, 1)
     }
@@ -31,7 +31,7 @@ final class AnyAsyncSequenceTests: XCTestCase {
                 } else {
                     return DeferredTask { 0 }.toAsyncSequence().eraseToAnyAsyncSequence()
                 }
-            }.first { _ in true }
+            }.first()
         
         XCTAssertEqual(val, 0)
     }

--- a/Tests/AfluentTests/SequenceTests/CatchSequenceTests.swift
+++ b/Tests/AfluentTests/SequenceTests/CatchSequenceTests.swift
@@ -13,7 +13,7 @@ final class CatchSequenceTests: XCTestCase {
     func testCatchDoesNotInterfereWithNoFailure() async throws {
         let val = try await DeferredTask { 1 }.toAsyncSequence()
             .catch { _ in DeferredTask { 2 }.toAsyncSequence() }
-            .first { _ in true }
+            .first()
         
         XCTAssertEqual(val, 1)
     }
@@ -26,7 +26,7 @@ final class CatchSequenceTests: XCTestCase {
                     XCTAssertEqual(error as? URLError, URLError(.badURL))
                     return DeferredTask { 2 }.toAsyncSequence()
                 }
-                .first { _ in true }
+                .first()
         }.result
         
         XCTAssertEqual(try val.get(), 2)
@@ -45,7 +45,7 @@ final class CatchSequenceTests: XCTestCase {
                     XCTAssertEqual(error, .e1)
                     return DeferredTask { 2 }.toAsyncSequence()
                 }
-                .first { _ in true }
+                .first()
         }.result
         
         XCTAssertEqual(try val.get(), 2)
@@ -64,7 +64,7 @@ final class CatchSequenceTests: XCTestCase {
                     XCTAssertEqual(error, .e1)
                     return DeferredTask { 2 }.toAsyncSequence()
                 }
-                .first { _ in true }
+                .first()
         }
         .result
         
@@ -76,7 +76,7 @@ final class CatchSequenceTests: XCTestCase {
     func testTryCatchDoesNotInterfereWithNoFailure() async throws {
         let val = try await DeferredTask { 1 }.toAsyncSequence()
             .tryCatch { _ in DeferredTask { 2 }.toAsyncSequence() }
-            .first { _ in true }
+            .first()
         
         XCTAssertEqual(val, 1)
     }
@@ -89,7 +89,7 @@ final class CatchSequenceTests: XCTestCase {
                     XCTAssertEqual(error as? URLError, URLError(.badURL))
                     return DeferredTask { 2 }.toAsyncSequence()
                 }
-                .first { _ in true }
+                .first()
         }
         .result
         
@@ -109,7 +109,7 @@ final class CatchSequenceTests: XCTestCase {
                     XCTAssertEqual(error, .e1)
                     return DeferredTask { 2 }.toAsyncSequence()
                 }
-                .first { _ in true }
+                .first()
         }
         .result
         
@@ -129,7 +129,7 @@ final class CatchSequenceTests: XCTestCase {
                     XCTAssertEqual(error, .e1)
                     return DeferredTask { 2 }.toAsyncSequence()
                 }
-                .first { _ in true }
+                .first()
         }
         .result
         

--- a/Tests/AfluentTests/SequenceTests/HandleEventsSequenceTests.swift
+++ b/Tests/AfluentTests/SequenceTests/HandleEventsSequenceTests.swift
@@ -28,7 +28,7 @@ final class HandleEventsSequenceTests: XCTestCase {
                 await test.output($0)
                 exp.fulfill()
             })
-            .first { _ in true }
+            .first()
         }
         
         try await Task.sleep(for: .milliseconds(2))
@@ -60,7 +60,7 @@ final class HandleEventsSequenceTests: XCTestCase {
                 await test.error($0)
                 exp.fulfill()
             })
-            .first { _ in true }
+            .first()
         }
         
         try await Task.sleep(for: .milliseconds(2))
@@ -93,7 +93,7 @@ final class HandleEventsSequenceTests: XCTestCase {
                 await test.cancel()
                 exp.fulfill()
             })
-            .first { _ in true }
+            .first()
         }
         
         try await Task.sleep(for: .milliseconds(2))

--- a/Tests/AfluentTests/SequenceTests/MaterializeSequenceTests.swift
+++ b/Tests/AfluentTests/SequenceTests/MaterializeSequenceTests.swift
@@ -49,6 +49,30 @@ final class MaterializeSequenceTests: XCTestCase {
         }
     }
     
+    func testDematerializeWithError() async throws {
+        let result = await Task {
+            try await DeferredTask { throw URLError(.badURL) }
+                .toAsyncSequence()
+                .materialize()
+                .dematerialize()
+                .first()
+        }.result
+
+        XCTAssertThrowsError(try result.get()) { error in
+            XCTAssertEqual(error as? URLError, URLError(.badURL))
+        }
+    }
+    
+    func testDematerializeWithoutError() async throws {
+        let result = try await DeferredTask { 1 }
+                .toAsyncSequence()
+                .materialize()
+                .dematerialize()
+                .first()
+        
+        XCTAssertEqual(result, 1)
+    }
+    
     func testMaterializeDoesNotInterfereWithCancellation() async throws {
         try XCTSkipIf(ProcessInfo.processInfo.environment["CI"] == "true")
         actor Test {

--- a/Tests/AfluentTests/SequenceTests/MaterializeSequenceTests.swift
+++ b/Tests/AfluentTests/SequenceTests/MaterializeSequenceTests.swift
@@ -1,0 +1,90 @@
+//
+//  MaterializeSequenceTests.swift
+//
+//
+//  Created by Tyler Thompson on 12/1/23.
+//
+
+import Foundation
+import Afluent
+import XCTest
+
+final class MaterializeSequenceTests: XCTestCase {
+    func testMaterializeCapturesSuccesses() async throws {
+        let result = try await DeferredTask { 1 }
+            .toAsyncSequence()
+            .materialize()
+            .first()
+        
+        if case .element(let val) = result {
+            XCTAssertEqual(val, 1)
+        } else {
+            XCTFail("Expected element, got: \(String(describing: result))")
+        }
+    }
+    
+    func testMaterializeCapturesCompletion() async throws {
+        let result = try await DeferredTask { 1 }
+            .toAsyncSequence()
+            .materialize()
+            .dropFirst()
+            .first()
+
+        guard case .complete = result else {
+            XCTFail("Expected completion, got: \(String(describing: result))")
+            return
+        }
+    }
+    
+    func testMaterializeCapturesNonCancelErrors() async throws {
+        let result = try await DeferredTask { throw URLError(.badURL) }
+            .toAsyncSequence()
+            .materialize()
+            .first()
+        
+        if case .failure(let error) = result {
+            XCTAssertEqual(error as? URLError, URLError(.badURL))
+        } else {
+            XCTFail("Expected failure, got: \(String(describing: result))")
+        }
+    }
+    
+    func testMaterializeDoesNotInterfereWithCancellation() async throws {
+        try XCTSkipIf(ProcessInfo.processInfo.environment["CI"] == "true")
+        actor Test {
+            var started = false
+            var ended = false
+            
+            func start() { started = true }
+            func end() { ended = true }
+        }
+        let test = Test()
+        
+        let exp = self.expectation(description: "thing happened")
+        exp.isInverted = true
+        let task = Task {
+            try await DeferredTask {
+                await test.start()
+                try await Task.sleep(for: .milliseconds(10))
+            }.map {
+                await test.end()
+                exp.fulfill()
+            }
+            .toAsyncSequence()
+            .materialize()
+            .first()
+        }
+        
+        try await Task.sleep(for: .milliseconds(2))
+        
+        task.cancel()
+        
+        await fulfillment(of: [exp], timeout: 0.011)
+        
+        let started = await test.started
+        let ended = await test.ended
+        
+        XCTAssert(started)
+        XCTAssertFalse(ended)
+    }
+}

--- a/Tests/AfluentTests/SequenceTests/RetryAfterFlatMappingSequenceTests.swift
+++ b/Tests/AfluentTests/SequenceTests/RetryAfterFlatMappingSequenceTests.swift
@@ -33,7 +33,7 @@ final class RetryAfterFlatMappingSequenceTests: XCTestCase {
                 }
                 .toAsyncSequence()
             }
-            .first { _ in true }
+            .first()
         }
         
         _ = await t.result
@@ -64,7 +64,7 @@ final class RetryAfterFlatMappingSequenceTests: XCTestCase {
                 }
                 .toAsyncSequence()
             }
-            .first { _ in true }
+            .first()
         }
         
         _ = await t.result
@@ -95,7 +95,7 @@ final class RetryAfterFlatMappingSequenceTests: XCTestCase {
                 }
                 .toAsyncSequence()
             }
-            .first { _ in true }
+            .first()
         }
         
         _ = await t.result
@@ -125,7 +125,7 @@ final class RetryAfterFlatMappingSequenceTests: XCTestCase {
                 }
                 .toAsyncSequence()
             }
-            .first { _ in true }
+            .first()
         }
         
         _ = await t.result

--- a/Tests/AfluentTests/SequenceTests/RetryOnAfterFlatMappingSequenceTests.swift
+++ b/Tests/AfluentTests/SequenceTests/RetryOnAfterFlatMappingSequenceTests.swift
@@ -36,7 +36,7 @@ final class RetryOnAfterFlatMappingSequenceTests: XCTestCase {
                 }
                 .toAsyncSequence()
             }
-            .first { _ in true }
+            .first()
         }
         
         _ = await t.result
@@ -70,7 +70,7 @@ final class RetryOnAfterFlatMappingSequenceTests: XCTestCase {
                 }
                 .toAsyncSequence()
             }
-            .first { _ in true }
+            .first()
         }
         
         _ = await t.result
@@ -104,7 +104,7 @@ final class RetryOnAfterFlatMappingSequenceTests: XCTestCase {
                 }
                 .toAsyncSequence()
             }
-            .first { _ in true }
+            .first()
         }
         
         _ = await t.result
@@ -137,7 +137,7 @@ final class RetryOnAfterFlatMappingSequenceTests: XCTestCase {
                 }
                 .toAsyncSequence()
             }
-            .first { _ in true }
+            .first()
         }
         
         _ = await t.result

--- a/Tests/AfluentTests/SequenceTests/RetryOnSequenceTests.swift
+++ b/Tests/AfluentTests/SequenceTests/RetryOnSequenceTests.swift
@@ -31,7 +31,7 @@ class RetryOnSequenceTests: XCTestCase {
             .toAsyncSequence()
             .map { _ in throw Err.e1 }
             .retry(retryCount, on: Err.e1)
-            .first { _ in true }
+            .first()
         }
         
         _ = await t.result
@@ -60,7 +60,7 @@ class RetryOnSequenceTests: XCTestCase {
             .toAsyncSequence()
             .map { _ in throw Err.e1 }
             .retry(0, on: Err.e1)
-            .first { _ in true }
+            .first()
         }
         
         _ = await t.result
@@ -89,7 +89,7 @@ class RetryOnSequenceTests: XCTestCase {
             .toAsyncSequence()
             .map { _ in throw Err.e1 }
             .retry(on: Err.e1)
-            .first { _ in true }
+            .first()
         }
         
         _ = await t.result
@@ -117,7 +117,7 @@ class RetryOnSequenceTests: XCTestCase {
             }
             .toAsyncSequence()
             .retry(10, on: Err.e1)
-            .first { _ in true }
+            .first()
         }
         
         _ = await t.result

--- a/Tests/AfluentTests/SequenceTests/RetrySequenceTests.swift
+++ b/Tests/AfluentTests/SequenceTests/RetrySequenceTests.swift
@@ -27,7 +27,7 @@ final class RetrySequenceTests: XCTestCase {
             }.toAsyncSequence()
                 .map { _ in throw URLError(.badURL) }
                 .retry(retryCount)
-                .first { _ in true }
+                .first()
         }
         
         _ = await t.result
@@ -53,7 +53,7 @@ final class RetrySequenceTests: XCTestCase {
             .toAsyncSequence()
             .map { _ in throw URLError(.badURL) }
             .retry(0)
-            .first { _ in true }
+            .first()
         }
         
         _ = await t.result
@@ -79,7 +79,7 @@ final class RetrySequenceTests: XCTestCase {
             .toAsyncSequence()
             .map { _ in throw URLError(.badURL) }
             .retry()
-            .first { _ in true }
+            .first()
         }
         
         _ = await t.result
@@ -106,7 +106,7 @@ final class RetrySequenceTests: XCTestCase {
             .map { _ in throw URLError(.badURL) }
             .retry()
             .retry()
-            .first { _ in true }
+            .first()
         }
 
         _ = await t.result


### PR DESCRIPTION
Added a materialize operator. This emits all events the `AsyncSequence` receives into an `Event` which lets you build custom transforms and manage side-effects.