### PR TITLE
Fix concurrency bug in SingleValueSubject

### DIFF
--- a/Sources/Afluent/Workers/SingleValueSubject.swift
+++ b/Sources/Afluent/Workers/SingleValueSubject.swift
@@ -31,7 +31,7 @@ public final class SingleValueSubject<Success: Sendable>: AsynchronousUnitOfWork
             guard let self else { throw CancellationError() }
 
             func getSentValue() throws -> Success? {
-                try _lock.protect {
+                try self._lock.protect {
                     if case .sentValue(let success) = self.subjectState {
                         return success
                     } else if case .sentError(let error) = self.subjectState {


### PR DESCRIPTION
## Description

On main, `SingleValueSubject` has a bug when `send` and `execute` are run concurrently:

1. `execute` begins, sees no value or error sent so creates a `withUnsafeThrowingContinuation` closure
2. `send` begins and sets the value or error
3. `execute` overrides the value set by `send` with a continuation, thus never sending

The behavior seems to contradict the documentation for `withUnsafeThrowingContinuation`:
> The body of the closure executes synchronously on the calling task

Nonetheless, this bug is easily reproducible by running either of the new tests repeatedly with the existing `SingleValueSubject` behavior.