### PR TITLE
HandleEventsSequence + HandleEvents Additions

### DIFF
--- a/Sources/Afluent/SequenceOperators/BreakpointSequence.swift
+++ b/Sources/Afluent/SequenceOperators/BreakpointSequence.swift
@@ -19,15 +19,15 @@ extension AsyncSequence {
     ///
     /// - Returns: An asynchronous unit of work with the breakpoint conditions applied.
     @_transparent @_alwaysEmitIntoClient @inlinable public func breakpoint(receiveOutput: ((Element) async throws -> Bool)? = nil, receiveError: ((Error) async throws -> Bool)? = nil) -> AsyncSequences.HandleEvents<Self> {
-        handleEvents { output in
+        handleEvents(receiveOutput: { output in
             if try await receiveOutput?(output) == true {
                 raise(SIGTRAP)
             }
-        } receiveError: { error in
+        }, receiveError: { error in
             if try await receiveError?(error) == true {
                 raise(SIGTRAP)
             }
-        }
+        })
     }
 
     /// Introduces a breakpoint into the async sequence when an error occurs.

--- a/Sources/Afluent/SequenceOperators/HandleEventsSequence.swift
+++ b/Sources/Afluent/SequenceOperators/HandleEventsSequence.swift
@@ -11,6 +11,8 @@ extension AsyncSequences {
     public struct HandleEvents<Upstream: AsyncSequence>: AsyncSequence {
         public typealias Element = Upstream.Element
         let upstream: Upstream
+        let receiveMakeIterator: (() -> Void)?
+        let receiveNext: (() async throws -> Void)?
         let receiveOutput: ((Element) async throws -> Void)?
         let receiveError: ((Error) async throws -> Void)?
         let receiveComplete: (() async throws -> Void)?
@@ -18,6 +20,7 @@ extension AsyncSequences {
 
         public struct AsyncIterator: AsyncIteratorProtocol {
             let upstream: Upstream
+            let receiveNext: (() async throws -> Void)?
             let receiveOutput: ((Element) async throws -> Void)?
             let receiveError: ((Error) async throws -> Void)?
             let receiveComplete: (() async throws -> Void)?
@@ -27,6 +30,7 @@ extension AsyncSequences {
             public mutating func next() async throws -> Element? {
                 do {
                     try Task.checkCancellation()
+                    try await receiveNext?()
                     if let val = try await iterator.next() {
                         try await receiveOutput?(val)
                         return val
@@ -46,11 +50,13 @@ extension AsyncSequences {
         }
 
         public func makeAsyncIterator() -> AsyncIterator {
-            AsyncIterator(upstream: upstream,
-                          receiveOutput: receiveOutput,
-                          receiveError: receiveError,
-                          receiveComplete: receiveComplete,
-                          receiveCancel: receiveCancel)
+            receiveMakeIterator?()
+            return AsyncIterator(upstream: upstream,
+                                 receiveNext: receiveNext,
+                                 receiveOutput: receiveOutput,
+                                 receiveError: receiveError,
+                                 receiveComplete: receiveComplete,
+                                 receiveCancel: receiveCancel)
         }
     }
 }
@@ -66,7 +72,7 @@ extension AsyncSequence {
     /// - Returns: An `AsynchronousUnitOfWork` that performs the side-effects for the specified receiving events.
     ///
     /// - Note: The returned `AsynchronousUnitOfWork` forwards all receiving events from the upstream unit of work.
-    public func handleEvents(@_inheritActorContext @_implicitSelfCapture receiveOutput: ((Element) async throws -> Void)? = nil, @_inheritActorContext @_implicitSelfCapture receiveError: ((Error) async throws -> Void)? = nil, @_inheritActorContext @_implicitSelfCapture receiveComplete: (() async throws -> Void)? = nil, @_inheritActorContext @_implicitSelfCapture receiveCancel: (() async throws -> Void)? = nil) -> AsyncSequences.HandleEvents<Self> {
-        AsyncSequences.HandleEvents(upstream: self, receiveOutput: receiveOutput, receiveError: receiveError, receiveComplete: receiveComplete, receiveCancel: receiveCancel)
+    public func handleEvents(@_inheritActorContext @_implicitSelfCapture receiveMakeIterator: (() -> Void)? = nil, @_inheritActorContext @_implicitSelfCapture receiveNext: (() async throws -> Void)? = nil, @_inheritActorContext @_implicitSelfCapture receiveOutput: ((Element) async throws -> Void)? = nil, @_inheritActorContext @_implicitSelfCapture receiveError: ((Error) async throws -> Void)? = nil, @_inheritActorContext @_implicitSelfCapture receiveComplete: (() async throws -> Void)? = nil, @_inheritActorContext @_implicitSelfCapture receiveCancel: (() async throws -> Void)? = nil) -> AsyncSequences.HandleEvents<Self> {
+        AsyncSequences.HandleEvents(upstream: self, receiveMakeIterator: receiveMakeIterator, receiveNext: receiveNext, receiveOutput: receiveOutput, receiveError: receiveError, receiveComplete: receiveComplete, receiveCancel: receiveCancel)
     }
 }

--- a/Sources/Afluent/SequenceOperators/HandleEventsSequence.swift
+++ b/Sources/Afluent/SequenceOperators/HandleEventsSequence.swift
@@ -65,6 +65,8 @@ extension AsyncSequence {
     /// Adds side-effects to the receiving events of the upstream `AsyncSequence`.
     ///
     /// - Parameters:
+    ///   - receiveMakeIterator: A closure that is invoked when the an iterator is requested from this sequence.
+    ///   - receiveNext: A closure that is invoked when the next element is requested from this sequence. The closure can throw errors.
     ///   - receiveOutput: A closure that is invoked when the upstream emits a successful output. The closure can throw errors.
     ///   - receiveError: A closure that is invoked when the upstream emits an error. The closure can throw errors.
     ///   - receiveCancel: A closure that is invoked when the unit of work is cancelled. The closure can throw errors.

--- a/Sources/Afluent/SequenceOperators/PrintSequence.swift
+++ b/Sources/Afluent/SequenceOperators/PrintSequence.swift
@@ -16,6 +16,10 @@ extension AsyncSequence {
     /// - Returns: An `AsyncSequence` that behaves identically to the upstream but logs events.
     public func print(_ prefix: String = "") -> AsyncSequences.HandleEvents<Self> {
         handleEvents {
+            Swift.print("\(prefix) received make iterator")
+        } receiveNext: {
+            Swift.print("\(prefix) received next")
+        } receiveOutput: {
             Swift.print("\(prefix) received output: \($0)")
         } receiveError: {
             Swift.print("\(prefix) received error: \($0)")

--- a/Sources/Afluent/Workers/Assign.swift
+++ b/Sources/Afluent/Workers/Assign.swift
@@ -13,8 +13,8 @@ extension AsynchronousUnitOfWork {
     ///  - Parameter object: The object to assign the output to.
     ///  - Note: This method will not retain the object passed in. If the object is deallocated the assignment will stop.
     public func assign<Root: AnyObject>(to keyPath: ReferenceWritableKeyPath<Root, Success>, on object: Root) async throws {
-        _ = try await handleEvents { [weak object] in
+        _ = try await handleEvents(receiveOutput: { [weak object] in
             object?[keyPath: keyPath] = $0
-        }.execute()
+        }).execute()
     }
 }

--- a/Sources/Afluent/Workers/Breakpoint.swift
+++ b/Sources/Afluent/Workers/Breakpoint.swift
@@ -19,15 +19,15 @@ extension AsynchronousUnitOfWork {
     ///
     /// - Returns: An asynchronous unit of work with the breakpoint conditions applied.
     @_transparent @_alwaysEmitIntoClient @inlinable public func breakpoint(receiveOutput: ((Success) async throws -> Bool)? = nil, receiveError: ((Error) async throws -> Bool)? = nil) -> some AsynchronousUnitOfWork<Success> {
-        handleEvents { output in
+        handleEvents(receiveOutput: { output in
             if try await receiveOutput?(output) == true {
                 raise(SIGTRAP)
             }
-        } receiveError: { error in
+        }, receiveError: { error in
             if try await receiveError?(error) == true {
                 raise(SIGTRAP)
             }
-        }
+        })
     }
 
     /// Introduces a breakpoint into the asynchronous unit of work when an error occurs.

--- a/Sources/Afluent/Workers/HandleEvents.swift
+++ b/Sources/Afluent/Workers/HandleEvents.swift
@@ -29,8 +29,8 @@ extension Workers {
                 guard let self else { throw CancellationError() }
 
                 do {
-                    try await receiveExecute?()
                     try Task.checkCancellation()
+                    try await receiveExecute?()
                     let val = try await self.upstream.operation()
                     try await self.receiveOutput?(val)
                     return val
@@ -51,6 +51,7 @@ extension AsynchronousUnitOfWork {
     /// Adds side-effects to the receiving events of the upstream `AsynchronousUnitOfWork`.
     ///
     /// - Parameters:
+    ///   - receiveExecute: A closure that is invoked immediately before the upstream is executed. The closure can throw errors.
     ///   - receiveOutput: A closure that is invoked when the upstream emits a successful output. The closure can throw errors.
     ///   - receiveError: A closure that is invoked when the upstream emits an error. The closure can throw errors.
     ///   - receiveCancel: A closure that is invoked when the unit of work is cancelled. The closure can throw errors.

--- a/Sources/Afluent/Workers/HandleEvents.swift
+++ b/Sources/Afluent/Workers/HandleEvents.swift
@@ -11,14 +11,14 @@ extension Workers {
     actor HandleEvents<Upstream: AsynchronousUnitOfWork, Success: Sendable>: AsynchronousUnitOfWork where Upstream.Success == Success {
         let state = TaskState<Success>()
         let upstream: Upstream
-        let receiveExecute: (() async throws -> Void)?
+        let receiveOperation: (() async throws -> Void)?
         let receiveOutput: ((Success) async throws -> Void)?
         let receiveError: ((Error) async throws -> Void)?
         let receiveCancel: (() async throws -> Void)?
 
-        init(upstream: Upstream, @_inheritActorContext @_implicitSelfCapture receiveExecute: (() async throws -> Void)?, @_inheritActorContext @_implicitSelfCapture receiveOutput: ((Success) async throws -> Void)?, @_inheritActorContext @_implicitSelfCapture receiveError: ((Error) async throws -> Void)?, @_inheritActorContext @_implicitSelfCapture receiveCancel: (() async throws -> Void)?) {
+        init(upstream: Upstream, @_inheritActorContext @_implicitSelfCapture receiveOperation: (() async throws -> Void)?, @_inheritActorContext @_implicitSelfCapture receiveOutput: ((Success) async throws -> Void)?, @_inheritActorContext @_implicitSelfCapture receiveError: ((Error) async throws -> Void)?, @_inheritActorContext @_implicitSelfCapture receiveCancel: (() async throws -> Void)?) {
             self.upstream = upstream
-            self.receiveExecute = receiveExecute
+            self.receiveOperation = receiveOperation
             self.receiveOutput = receiveOutput
             self.receiveError = receiveError
             self.receiveCancel = receiveCancel
@@ -30,7 +30,7 @@ extension Workers {
 
                 do {
                     try Task.checkCancellation()
-                    try await receiveExecute?()
+                    try await receiveOperation?()
                     let val = try await self.upstream.operation()
                     try await self.receiveOutput?(val)
                     return val
@@ -51,7 +51,7 @@ extension AsynchronousUnitOfWork {
     /// Adds side-effects to the receiving events of the upstream `AsynchronousUnitOfWork`.
     ///
     /// - Parameters:
-    ///   - receiveExecute: A closure that is invoked immediately before the upstream is executed. The closure can throw errors.
+    ///   - receiveOperation: A closure that is invoked immediately before the upstream operation is executed. The closure can throw errors.
     ///   - receiveOutput: A closure that is invoked when the upstream emits a successful output. The closure can throw errors.
     ///   - receiveError: A closure that is invoked when the upstream emits an error. The closure can throw errors.
     ///   - receiveCancel: A closure that is invoked when the unit of work is cancelled. The closure can throw errors.
@@ -59,7 +59,7 @@ extension AsynchronousUnitOfWork {
     /// - Returns: An `AsynchronousUnitOfWork` that performs the side-effects for the specified receiving events.
     ///
     /// - Note: The returned `AsynchronousUnitOfWork` forwards all receiving events from the upstream unit of work.
-    public func handleEvents(@_inheritActorContext @_implicitSelfCapture receiveExecute: (() async throws -> Void)? = nil, @_inheritActorContext @_implicitSelfCapture receiveOutput: ((Success) async throws -> Void)? = nil, @_inheritActorContext @_implicitSelfCapture receiveError: ((Error) async throws -> Void)? = nil, @_inheritActorContext @_implicitSelfCapture receiveCancel: (() async throws -> Void)? = nil) -> some AsynchronousUnitOfWork<Success> {
-        Workers.HandleEvents(upstream: self, receiveExecute: receiveExecute, receiveOutput: receiveOutput, receiveError: receiveError, receiveCancel: receiveCancel)
+    public func handleEvents(@_inheritActorContext @_implicitSelfCapture receiveOperation: (() async throws -> Void)? = nil, @_inheritActorContext @_implicitSelfCapture receiveOutput: ((Success) async throws -> Void)? = nil, @_inheritActorContext @_implicitSelfCapture receiveError: ((Error) async throws -> Void)? = nil, @_inheritActorContext @_implicitSelfCapture receiveCancel: (() async throws -> Void)? = nil) -> some AsynchronousUnitOfWork<Success> {
+        Workers.HandleEvents(upstream: self, receiveOperation: receiveOperation, receiveOutput: receiveOutput, receiveError: receiveError, receiveCancel: receiveCancel)
     }
 }

--- a/Sources/Afluent/Workers/Print.swift
+++ b/Sources/Afluent/Workers/Print.swift
@@ -16,7 +16,7 @@ extension AsynchronousUnitOfWork {
     /// - Returns: An `AsynchronousUnitOfWork` that behaves identically to the upstream but logs events.
     public func print(_ prefix: String = "") -> some AsynchronousUnitOfWork<Success> {
         handleEvents {
-            Swift.print("\(prefix) received execute")
+            Swift.print("\(prefix) received operation")
         } receiveOutput: {
             Swift.print("\(prefix) received output: \($0)")
         } receiveError: {

--- a/Sources/Afluent/Workers/Print.swift
+++ b/Sources/Afluent/Workers/Print.swift
@@ -16,6 +16,8 @@ extension AsynchronousUnitOfWork {
     /// - Returns: An `AsynchronousUnitOfWork` that behaves identically to the upstream but logs events.
     public func print(_ prefix: String = "") -> some AsynchronousUnitOfWork<Success> {
         handleEvents {
+            Swift.print("\(prefix) received execute")
+        } receiveOutput: {
             Swift.print("\(prefix) received output: \($0)")
         } receiveError: {
             Swift.print("\(prefix) received error: \($0)")

--- a/Tests/AfluentTests/SequenceTests/HandleEventsSequenceTests.swift
+++ b/Tests/AfluentTests/SequenceTests/HandleEventsSequenceTests.swift
@@ -11,6 +11,66 @@ import XCTest
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 final class HandleEventsSequenceTests: XCTestCase {
+    func testHandleMakeIterator() async throws {
+        actor Test {
+            var iteratorMade = false
+
+            func makeIterator() { iteratorMade = true }
+        }
+        let test = Test()
+
+        let exp = expectation(description: "thing happened")
+
+        Task {
+            _ = DeferredTask {
+                try await Task.sleep(for: .milliseconds(10))
+            }
+            .toAsyncSequence()
+            .handleEvents(receiveMakeIterator: {
+                Task {
+                    await test.makeIterator()
+                    exp.fulfill()
+                }
+            })
+            .makeAsyncIterator()
+        }
+
+        await fulfillment(of: [exp], timeout: 1)
+
+        let iteratorMade = await test.iteratorMade
+
+        XCTAssert(iteratorMade)
+    }
+
+    func testHandleNext() async throws {
+        actor Test {
+            var nextCalled: Int = 0
+
+            func next() { nextCalled += 1 }
+        }
+        let test = Test()
+
+        let values = Array(0...9)
+
+        let task = Task {
+            let sequence = AsyncStream { continuation in
+                values.forEach { continuation.yield($0) }
+                continuation.finish()
+            }
+                .handleEvents(receiveNext: {
+                    await test.next()
+                })
+
+            for try await _ in sequence { }
+        }
+
+        try await task.value
+
+        let nextCalled = await test.nextCalled
+
+        XCTAssertEqual(nextCalled, values.count + 1) // values + finish
+    }
+
     func testHandleOutput() async throws {
         actor Test {
             var output: Any?

--- a/Tests/AfluentTests/SequenceTests/HandleEventsSequenceTests.swift
+++ b/Tests/AfluentTests/SequenceTests/HandleEventsSequenceTests.swift
@@ -53,13 +53,9 @@ final class HandleEventsSequenceTests: XCTestCase {
         let values = Array(0...9)
 
         let task = Task {
-            let sequence = AsyncStream { continuation in
-                values.forEach { continuation.yield($0) }
-                continuation.finish()
-            }
-                .handleEvents(receiveNext: {
-                    await test.next()
-                })
+            let sequence = values.async.handleEvents(receiveNext: {
+                await test.next()
+            })
 
             for try await _ in sequence { }
         }
@@ -180,5 +176,16 @@ final class HandleEventsSequenceTests: XCTestCase {
         let canceled = await test.canceled
 
         XCTAssert(canceled)
+    }
+}
+
+extension Array {
+    fileprivate var async: AsyncStream<Element> {
+        AsyncStream { continuation in
+            for element in self {
+                continuation.yield(element)
+            }
+            continuation.finish()
+        }
     }
 }

--- a/Tests/AfluentTests/WorkerTests/HandleEventsTests.swift
+++ b/Tests/AfluentTests/WorkerTests/HandleEventsTests.swift
@@ -11,6 +11,35 @@ import XCTest
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 final class HandleEventsTests: XCTestCase {
+    func testHandleExecute() async throws {
+        actor Test {
+            var executed = false
+
+            func execute() { executed = true }
+        }
+        let test = Test()
+
+        let exp = expectation(description: "thing happened")
+        let task = DeferredTask {
+            try await Task.sleep(for: .milliseconds(10))
+        }.handleEvents(receiveExecute: {
+            await test.execute()
+            exp.fulfill()
+        })
+
+        task.run()
+
+        try await Task.sleep(for: .milliseconds(2))
+
+        task.cancel()
+
+        await fulfillment(of: [exp], timeout: 1)
+
+        let executed = await test.executed
+
+        XCTAssert(executed)
+    }
+
     func testHandleOutput() async throws {
         actor Test {
             var output: Any?

--- a/Tests/AfluentTests/WorkerTests/HandleEventsTests.swift
+++ b/Tests/AfluentTests/WorkerTests/HandleEventsTests.swift
@@ -11,19 +11,19 @@ import XCTest
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 final class HandleEventsTests: XCTestCase {
-    func testHandleExecute() async throws {
+    func testHandleOperation() async throws {
         actor Test {
-            var executed = false
+            var operationCalled = false
 
-            func execute() { executed = true }
+            func operation() { operationCalled = true }
         }
         let test = Test()
 
         let exp = expectation(description: "thing happened")
         let task = DeferredTask {
             try await Task.sleep(for: .milliseconds(10))
-        }.handleEvents(receiveExecute: {
-            await test.execute()
+        }.handleEvents(receiveOperation: {
+            await test.operation()
             exp.fulfill()
         })
 
@@ -35,9 +35,9 @@ final class HandleEventsTests: XCTestCase {
 
         await fulfillment(of: [exp], timeout: 1)
 
-        let executed = await test.executed
+        let operationCalled = await test.operationCalled
 
-        XCTAssert(executed)
+        XCTAssert(operationCalled)
     }
 
     func testHandleOutput() async throws {


### PR DESCRIPTION
## Description

Adds the following to `HandleEventsSequence`:
* `receiveMakeIterator`: called when `makeAsyncIterator` is called
* `receiveNext`: called when `next` is called

Adds the following to `HandleEvents`:
* `receiveExecute`: called immediately prior to the upstream `operation` execution

The availability of these operators would be especially useful for testing when using Afluent.

Open to feedback / suggestions.