### PR TITLE
Add subscribe to AsyncSequence

### DIFF
--- a/Sources/Afluent/Subscription/AnyCancellable.swift
+++ b/Sources/Afluent/Subscription/AnyCancellable.swift
@@ -58,8 +58,8 @@ extension AsyncSequence {
     ///   - receiveCompletion: A function that is executed when the stream has completed normally with `nil` or an error.
     ///   - receiveOutput: A function that is executed when output is received from the sequence.
     ///   If this function throws an error, then the stream is completed.
-    public func subscribe(receiveCompletion: ((AsyncSequences.Completion<Error>) async -> Void)? = nil,
-                          receiveOutput: ((Element) async throws -> Void)? = nil) -> AnyCancellable {
+    public func sink(receiveCompletion: ((AsyncSequences.Completion<Error>) async -> Void)? = nil,
+                     receiveOutput: ((Element) async throws -> Void)? = nil) -> AnyCancellable {
         DeferredTask {
             do {
                 for try await output in self {

--- a/Sources/Afluent/Subscription/AnyCancellable.swift
+++ b/Sources/Afluent/Subscription/AnyCancellable.swift
@@ -50,3 +50,13 @@ extension AsynchronousUnitOfWork {
         return AnyCancellable(self)
     }
 }
+
+extension AsyncSequence {
+    /// Executes the current async sequence and returns an AnyCancellable token to cancel the subscription.
+    public func subscribe() -> AnyCancellable {
+        DeferredTask {
+            for try await _ in self { }
+        }
+        .subscribe()
+    }
+}

--- a/Tests/AfluentTests/SubscriptionTests.swift
+++ b/Tests/AfluentTests/SubscriptionTests.swift
@@ -346,7 +346,7 @@ final class SubscriptionTests: XCTestCase {
             exp.fulfill()
         }
 
-        let completedSubject = SingleValueSubject<Void>()
+        let completedChannel = SingleValueChannel<Void>()
         let outputExp = expectation(description: "output received")
         outputExp.isInverted = true
 
@@ -355,7 +355,7 @@ final class SubscriptionTests: XCTestCase {
             case .finished: break
             case .failure(let error): XCTFail("Unexpected error \(error)")
             }
-            try? completedSubject.send()
+            try? await completedChannel.send()
         } receiveOutput: {
             outputExp.fulfill()
         }
@@ -364,7 +364,7 @@ final class SubscriptionTests: XCTestCase {
 
         subscription.cancel()
 
-        try await completedSubject.execute()
+        try await completedChannel.execute()
 
         await fulfillment(of: [exp, outputExp], timeout: 0.011)
 
@@ -398,7 +398,7 @@ final class SubscriptionTests: XCTestCase {
             exp.fulfill()
         }
 
-        let completedSubject = SingleValueSubject<Void>()
+        let completedChannel = SingleValueChannel<Void>()
         let outputExp = expectation(description: "output received")
         outputExp.isInverted = true
 
@@ -407,13 +407,13 @@ final class SubscriptionTests: XCTestCase {
             case .finished: break
             case .failure(let error): XCTFail("Unexpected error \(error)")
             }
-            try? completedSubject.send()
+            try? await completedChannel.send()
         } receiveOutput: {
             outputExp.fulfill()
         }
         noop(subscription)
 
-        try await completedSubject.execute()
+        try await completedChannel.execute()
 
         await fulfillment(of: [exp, outputExp], timeout: 0.011)
 
@@ -446,7 +446,7 @@ final class SubscriptionTests: XCTestCase {
             exp.fulfill()
         }
 
-        let completedSubject = SingleValueSubject<Void>()
+        let completedChannel = SingleValueChannel<Void>()
         let outputExp = expectation(description: "output received")
 
         let subscription = sequence.sink { completion in
@@ -454,7 +454,7 @@ final class SubscriptionTests: XCTestCase {
             case .finished: break
             case .failure(let error): XCTFail("Unexpected error \(error)")
             }
-            try? completedSubject.send()
+            try? await completedChannel.send()
         } receiveOutput: {
             outputExp.fulfill()
         }
@@ -463,7 +463,7 @@ final class SubscriptionTests: XCTestCase {
 
         subscription.cancel()
 
-        try await completedSubject.execute()
+        try await completedChannel.execute()
 
         await fulfillment(of: [exp, outputExp], timeout: 0.011)
 
@@ -499,7 +499,7 @@ final class SubscriptionTests: XCTestCase {
             exp.fulfill()
         }
 
-        let completedSubject = SingleValueSubject<Void>()
+        let completedChannel = SingleValueChannel<Void>()
         let outputExp = expectation(description: "output received")
         outputExp.isInverted = true
 
@@ -508,7 +508,7 @@ final class SubscriptionTests: XCTestCase {
             case .finished: XCTFail("Unexpected normal finish")
             case .failure(let error): XCTAssertEqual(error as? Err, .e1)
             }
-            try? completedSubject.send()
+            try? await completedChannel.send()
         } receiveOutput: {
             outputExp.fulfill()
         }
@@ -517,7 +517,7 @@ final class SubscriptionTests: XCTestCase {
 
         subscription.cancel()
 
-        try await completedSubject.execute()
+        try await completedChannel.execute()
 
         await fulfillment(of: [exp, outputExp], timeout: 0.011)
 

--- a/Tests/AfluentTests/SubscriptionTests.swift
+++ b/Tests/AfluentTests/SubscriptionTests.swift
@@ -321,6 +321,212 @@ final class SubscriptionTests: XCTestCase {
         XCTAssert(started)
         XCTAssertFalse(ended)
     }
+
+    func testAsyncSequenceReceivesCompletionWhenCancelled() async throws {
+        try XCTSkipIf(ProcessInfo.processInfo.environment["CI"] == "true")
+        actor Test {
+            var started = false
+            var ended = false
+
+            func start() { started = true }
+            func end() { ended = true }
+        }
+        let test = Test()
+
+        let exp = expectation(description: "thing happened")
+        exp.isInverted = true
+        let sequence = AsyncThrowingStream<Void, Error> { continuation in
+            Task {
+                await test.start()
+                try await Task.sleep(for: .milliseconds(10))
+                continuation.yield()
+            }
+        }.map {
+            await test.end()
+            exp.fulfill()
+        }
+
+        let completedSubject = SingleValueSubject<Void>()
+        let outputExp = expectation(description: "output received")
+        outputExp.isInverted = true
+
+        let subscription = sequence.subscribe { completion in
+            switch completion {
+            case .finished: break
+            case .failure(let error): XCTFail("Unexpected error \(error)")
+            }
+            try? completedSubject.send()
+        } receiveOutput: {
+            outputExp.fulfill()
+        }
+
+        try await Task.sleep(for: .milliseconds(2))
+
+        subscription.cancel()
+
+        try await completedSubject.execute()
+
+        await fulfillment(of: [exp, outputExp], timeout: 0.011)
+
+        let started = await test.started
+        let ended = await test.ended
+
+        XCTAssert(started)
+        XCTAssertFalse(ended)
+    }
+
+    func testAsyncSequenceReceivesCompletionWhenStreamCompletes() async throws {
+        try XCTSkipIf(ProcessInfo.processInfo.environment["CI"] == "true")
+        actor Test {
+            var started = false
+            var ended = false
+
+            func start() { started = true }
+            func end() { ended = true }
+        }
+        let test = Test()
+
+        let exp = expectation(description: "thing happened")
+        exp.isInverted = true
+        let sequence = AsyncThrowingStream<Void, Error> { continuation in
+            Task {
+                await test.start()
+                continuation.finish()
+            }
+        }.map {
+            await test.end()
+            exp.fulfill()
+        }
+
+        let completedSubject = SingleValueSubject<Void>()
+        let outputExp = expectation(description: "output received")
+        outputExp.isInverted = true
+
+        let subscription = sequence.subscribe { completion in
+            switch completion {
+            case .finished: break
+            case .failure(let error): XCTFail("Unexpected error \(error)")
+            }
+            try? completedSubject.send()
+        } receiveOutput: {
+            outputExp.fulfill()
+        }
+        noop(subscription)
+
+        try await completedSubject.execute()
+
+        await fulfillment(of: [exp, outputExp], timeout: 0.011)
+
+        let started = await test.started
+        let ended = await test.ended
+
+        XCTAssert(started)
+        XCTAssertFalse(ended)
+    }
+
+    func testAsyncSequenceReceivesOutputThenCompletionWhenCancelled() async throws {
+        try XCTSkipIf(ProcessInfo.processInfo.environment["CI"] == "true")
+        actor Test {
+            var started = false
+            var ended = false
+
+            func start() { started = true }
+            func end() { ended = true }
+        }
+        let test = Test()
+
+        let exp = expectation(description: "thing happened")
+        let sequence = AsyncStream<Void> { continuation in
+            Task {
+                await test.start()
+                continuation.yield()
+            }
+        }.map {
+            await test.end()
+            exp.fulfill()
+        }
+
+        let completedSubject = SingleValueSubject<Void>()
+        let outputExp = expectation(description: "output received")
+
+        let subscription = sequence.subscribe { completion in
+            switch completion {
+            case .finished: break
+            case .failure(let error): XCTFail("Unexpected error \(error)")
+            }
+            try? completedSubject.send()
+        } receiveOutput: {
+            outputExp.fulfill()
+        }
+
+        try await Task.sleep(for: .milliseconds(2))
+
+        subscription.cancel()
+
+        try await completedSubject.execute()
+
+        await fulfillment(of: [exp, outputExp], timeout: 0.011)
+
+        let started = await test.started
+        let ended = await test.ended
+
+        XCTAssert(started)
+        XCTAssert(ended)
+    }
+
+    func testAsyncSequenceReceivesErrorInCompletion() async throws {
+        try XCTSkipIf(ProcessInfo.processInfo.environment["CI"] == "true")
+        actor Test {
+            var started = false
+            var ended = false
+
+            func start() { started = true }
+            func end() { ended = true }
+        }
+        let test = Test()
+
+        enum Err: Error, Equatable { case e1 }
+
+        let exp = expectation(description: "thing happened")
+        exp.isInverted = true
+        let sequence = AsyncThrowingStream<Void, Error> { continuation in
+            Task {
+                await test.start()
+                continuation.yield(with: .failure(Err.e1))
+            }
+        }.map {
+            await test.end()
+            exp.fulfill()
+        }
+
+        let completedSubject = SingleValueSubject<Void>()
+        let outputExp = expectation(description: "output received")
+        outputExp.isInverted = true
+
+        let subscription = sequence.subscribe { completion in
+            switch completion {
+            case .finished: XCTFail("Unexpected normal finish")
+            case .failure(let error): XCTAssertEqual(error as? Err, .e1)
+            }
+            try? completedSubject.send()
+        } receiveOutput: {
+            outputExp.fulfill()
+        }
+
+        try await Task.sleep(for: .milliseconds(2))
+
+        subscription.cancel()
+
+        try await completedSubject.execute()
+
+        await fulfillment(of: [exp, outputExp], timeout: 0.011)
+
+        let started = await test.started
+        let ended = await test.ended
+
+        XCTAssert(started)
+        XCTAssertFalse(ended)
+    }
 }
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)

--- a/Tests/AfluentTests/SubscriptionTests.swift
+++ b/Tests/AfluentTests/SubscriptionTests.swift
@@ -72,6 +72,7 @@ final class SubscriptionTests: XCTestCase {
         }
 
         var subscription: AnyCancellable? = task.subscribe()
+        noop(subscription)
 
         try await Task.sleep(for: .milliseconds(2))
 
@@ -159,4 +160,170 @@ final class SubscriptionTests: XCTestCase {
         XCTAssert(started)
         XCTAssertFalse(ended)
     }
+
+    // MARK: AsyncSequence
+
+    func testAsyncSequenceCancelledBeforeItEnds() async throws {
+        try XCTSkipIf(ProcessInfo.processInfo.environment["CI"] == "true")
+        actor Test {
+            var started = false
+            var ended = false
+
+            func start() { started = true }
+            func end() { ended = true }
+        }
+        let test = Test()
+
+        let exp = expectation(description: "thing happened")
+        exp.isInverted = true
+        let sequence = AsyncStream<Void> { continuation in
+            Task {
+                await test.start()
+                try await Task.sleep(for: .milliseconds(10))
+                continuation.yield()
+            }
+        }.map {
+            await test.end()
+            exp.fulfill()
+        }
+
+        let subscription = sequence.subscribe()
+
+        try await Task.sleep(for: .milliseconds(2))
+
+        subscription.cancel()
+
+        await fulfillment(of: [exp], timeout: 0.011)
+
+        let started = await test.started
+        let ended = await test.ended
+
+        XCTAssert(started)
+        XCTAssertFalse(ended)
+    }
+
+    func testAsyncSequenceCancelledViaDeinitialization() async throws {
+        try XCTSkipIf(ProcessInfo.processInfo.environment["CI"] == "true")
+        actor Test {
+            var started = false
+            var ended = false
+
+            func start() { started = true }
+            func end() { ended = true }
+        }
+        let test = Test()
+
+        let exp = expectation(description: "thing happened")
+        exp.isInverted = true
+        let sequence = AsyncStream<Void> { continuation in
+            Task {
+                await test.start()
+                try await Task.sleep(for: .milliseconds(10))
+                continuation.yield()
+            }
+        }.map {
+            await test.end()
+            exp.fulfill()
+        }
+
+        var subscription: AnyCancellable? = sequence.subscribe()
+        noop(subscription)
+
+        try await Task.sleep(for: .milliseconds(2))
+
+        subscription = nil
+
+        await fulfillment(of: [exp], timeout: 0.011)
+
+        let started = await test.started
+        let ended = await test.ended
+
+        XCTAssert(started)
+        XCTAssertFalse(ended)
+    }
+
+    func testAsyncSequenceCancelledViaDeinitialization_WhenStoredInSet() async throws {
+        try XCTSkipIf(ProcessInfo.processInfo.environment["CI"] == "true")
+        actor Test {
+            var started = false
+            var ended = false
+
+            func start() { started = true }
+            func end() { ended = true }
+        }
+        let test = Test()
+
+        let exp = expectation(description: "thing happened")
+        exp.isInverted = true
+        let sequence = AsyncStream<Void> { continuation in
+            Task {
+                await test.start()
+                try await Task.sleep(for: .milliseconds(10))
+                continuation.yield()
+            }
+        }.map {
+            await test.end()
+            exp.fulfill()
+        }
+
+        sequence.subscribe()
+            .store(in: &set)
+
+        try await Task.sleep(for: .milliseconds(2))
+
+        set.removeAll()
+
+        await fulfillment(of: [exp], timeout: 0.011)
+
+        let started = await test.started
+        let ended = await test.ended
+
+        XCTAssert(started)
+        XCTAssertFalse(ended)
+    }
+
+    func testAsyncSequenceCancelledViaDeinitialization_WhenStoredInCollection() async throws {
+        try XCTSkipIf(ProcessInfo.processInfo.environment["CI"] == "true")
+        actor Test {
+            var started = false
+            var ended = false
+
+            func start() { started = true }
+            func end() { ended = true }
+        }
+        let test = Test()
+
+        let exp = expectation(description: "thing happened")
+        exp.isInverted = true
+        let sequence = AsyncStream<Void> { continuation in
+            Task {
+                await test.start()
+                try await Task.sleep(for: .milliseconds(10))
+                continuation.yield()
+            }
+        }.map {
+            await test.end()
+            exp.fulfill()
+        }
+
+        sequence.subscribe()
+            .store(in: &collection)
+
+        try await Task.sleep(for: .milliseconds(2))
+
+        collection.removeAll()
+
+        await fulfillment(of: [exp], timeout: 0.011)
+
+        let started = await test.started
+        let ended = await test.ended
+
+        XCTAssert(started)
+        XCTAssertFalse(ended)
+    }
+}
+
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+extension SubscriptionTests {
+    func noop(_ any: Any?) { }
 }

--- a/Tests/AfluentTests/SubscriptionTests.swift
+++ b/Tests/AfluentTests/SubscriptionTests.swift
@@ -187,7 +187,7 @@ final class SubscriptionTests: XCTestCase {
             exp.fulfill()
         }
 
-        let subscription = sequence.subscribe()
+        let subscription = sequence.sink()
 
         try await Task.sleep(for: .milliseconds(2))
 
@@ -226,7 +226,7 @@ final class SubscriptionTests: XCTestCase {
             exp.fulfill()
         }
 
-        var subscription: AnyCancellable? = sequence.subscribe()
+        var subscription: AnyCancellable? = sequence.sink()
         noop(subscription)
 
         try await Task.sleep(for: .milliseconds(2))
@@ -266,7 +266,7 @@ final class SubscriptionTests: XCTestCase {
             exp.fulfill()
         }
 
-        sequence.subscribe()
+        sequence.sink()
             .store(in: &set)
 
         try await Task.sleep(for: .milliseconds(2))
@@ -306,7 +306,7 @@ final class SubscriptionTests: XCTestCase {
             exp.fulfill()
         }
 
-        sequence.subscribe()
+        sequence.sink()
             .store(in: &collection)
 
         try await Task.sleep(for: .milliseconds(2))
@@ -350,7 +350,7 @@ final class SubscriptionTests: XCTestCase {
         let outputExp = expectation(description: "output received")
         outputExp.isInverted = true
 
-        let subscription = sequence.subscribe { completion in
+        let subscription = sequence.sink { completion in
             switch completion {
             case .finished: break
             case .failure(let error): XCTFail("Unexpected error \(error)")
@@ -402,7 +402,7 @@ final class SubscriptionTests: XCTestCase {
         let outputExp = expectation(description: "output received")
         outputExp.isInverted = true
 
-        let subscription = sequence.subscribe { completion in
+        let subscription = sequence.sink { completion in
             switch completion {
             case .finished: break
             case .failure(let error): XCTFail("Unexpected error \(error)")
@@ -449,7 +449,7 @@ final class SubscriptionTests: XCTestCase {
         let completedSubject = SingleValueSubject<Void>()
         let outputExp = expectation(description: "output received")
 
-        let subscription = sequence.subscribe { completion in
+        let subscription = sequence.sink { completion in
             switch completion {
             case .finished: break
             case .failure(let error): XCTFail("Unexpected error \(error)")
@@ -503,7 +503,7 @@ final class SubscriptionTests: XCTestCase {
         let outputExp = expectation(description: "output received")
         outputExp.isInverted = true
 
-        let subscription = sequence.subscribe { completion in
+        let subscription = sequence.sink { completion in
             switch completion {
             case .finished: XCTFail("Unexpected normal finish")
             case .failure(let error): XCTAssertEqual(error as? Err, .e1)


### PR DESCRIPTION
## Description

Adds a `subscribe` operator to `AsyncSequence` that returns an `AnyCancellable`. I've tried to make the function as similar to Combine's `Publisher.sink(receiveCompletion:receiveValue:)` as possible.

I've nested the `Completion` type in `AsyncSequences` to mirror how `Subscribers.Completion` is nested.

Please nitpick the signatures / types!

Bonus: if / when this operator is merged, an `AsyncSequence` can be created and subscribed to in a synchronous context!