### PR TITLE
[collect-sequence] - Added Collect operator - TT

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -4,11 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types:
-      - closed
-    branches:
-      - main
 
 jobs:
   test:
@@ -30,7 +25,6 @@ jobs:
     - name: Bump version and push tag
       id: bump_version
       uses: anothrNick/github-tag-action@1.67.0
-      if: github.ref == 'refs/heads/main'
       env:
         GITHUB_TOKEN: ${{ secrets.TOKEN }}
         WITH_V: false

--- a/Sources/Afluent/SequenceOperators/CollectSequence.swift
+++ b/Sources/Afluent/SequenceOperators/CollectSequence.swift
@@ -1,0 +1,43 @@
+//
+//  CollectSequence.swift
+//
+//
+//  Created by Tyler Thompson on 12/23/23.
+//
+
+import Foundation
+
+extension AsyncSequences {
+    public struct Collect<Upstream: AsyncSequence>: AsyncSequence {
+        public typealias Element = [Upstream.Element]
+        let upstream: Upstream
+
+        public struct AsyncIterator: AsyncIteratorProtocol {
+            var upstreamIterator: Upstream.AsyncIterator
+            var collected = Element()
+
+            public mutating func next() async throws -> Element? {
+                try Task.checkCancellation()
+                while let next = try await upstreamIterator.next() {
+                    collected.append(next)
+                }
+                return collected
+            }
+        }
+
+        public func makeAsyncIterator() -> AsyncIterator {
+            AsyncIterator(upstreamIterator: upstream.makeAsyncIterator())
+        }
+    }
+}
+
+extension AsyncSequence {
+    /// Collects all received elements, and emits a single array of the collection when the upstream sequence finishes.
+    /// ### Discussion:
+    /// Use `collect()` to gather elements into an array that the operator emits after the upstream sequence finishes.
+    /// If the upstream sequence fails with an error, this sequence forwards the error to the downstream receiver instead of sending its output.
+    /// - Important: Be cautious when using `collect` on sequences that can emit a large number of elements or do not complete, as it can lead to high memory usage or even memory exhaustion.
+    public func collect() -> AsyncSequences.Collect<Self> {
+        AsyncSequences.Collect(upstream: self)
+    }
+}

--- a/Tests/AfluentTests/SequenceTests/CollectSequenceTests.swift
+++ b/Tests/AfluentTests/SequenceTests/CollectSequenceTests.swift
@@ -1,0 +1,57 @@
+//
+//  CollectSequenceTests.swift
+//
+//
+//  Created by Tyler Thompson on 12/23/23.
+//
+
+import Afluent
+import Foundation
+import XCTest
+
+final class CollectSequenceTests: XCTestCase {
+    func testCollectWithEmptySequence() async throws {
+        let emptySequence = [Int]().async
+        let collected = try await emptySequence.collect().first()
+        XCTAssertTrue(try XCTUnwrap(collected).isEmpty, "Collect should return an empty array for an empty sequence")
+    }
+
+    func testCollectWithNonEmptySequence() async throws {
+        let numbers = [1, 2, 3].async
+        let collected = try await numbers.collect().first()
+        XCTAssertEqual(collected, [1, 2, 3], "Collect should return all elements in the sequence")
+    }
+
+    func testCollectWithSequenceContainingSingleElement() async throws {
+        let singleElementSequence = [42].async
+        let collected = try await singleElementSequence.collect().first()
+        XCTAssertEqual(collected, [42], "Collect should return an array with the single element")
+    }
+
+    func testCollectWithSequenceThrowingError() async throws {
+        enum TestError: Error, Equatable {
+            case someError
+        }
+
+        let errorSequence = AsyncThrowingStream<Int, Error> { continuation in
+            continuation.finish(throwing: TestError.someError)
+        }
+        do {
+            _ = try await errorSequence.collect().first()
+            XCTFail("Collect should throw the error encountered in the sequence")
+        } catch {
+            XCTAssertEqual(error as? TestError, .someError, "Collect should throw the correct error")
+        }
+    }
+}
+
+extension Array {
+    fileprivate var async: AsyncStream<Element> {
+        AsyncStream { continuation in
+            for element in self {
+                continuation.yield(element)
+            }
+            continuation.finish()
+        }
+    }
+}

--- a/Tests/AfluentTests/SequenceTests/HandleEventsSequenceTests.swift
+++ b/Tests/AfluentTests/SequenceTests/HandleEventsSequenceTests.swift
@@ -50,7 +50,7 @@ final class HandleEventsSequenceTests: XCTestCase {
         }
         let test = Test()
 
-        let values = Array(0...9)
+        let values = Array(0 ... 9)
 
         let task = Task {
             let sequence = values.async.handleEvents(receiveNext: {
@@ -101,7 +101,7 @@ final class HandleEventsSequenceTests: XCTestCase {
 
     func testHandleComplete() async throws {
         let exp = expectation(description: "thing happened")
-        let task = Task {
+        Task {
             let sequence = DeferredTask { 1 }
                 .toAsyncSequence()
                 .handleEvents(receiveComplete: {


### PR DESCRIPTION
Added a `collect` operator that works like Combine's. It's worth noting that some folks seem to expect `collect` to gather all elements and return, but that's not generally how operator style APIs function. Instead, just like Combine, this collects all elements into an array and then emits that array as a sequence of 1. 

This means that if you want to use `collect` like some other async libraries have it, you'd call `collect().first()` or `collect().sink()`.