### PR TITLE
Fixed a deadlock bug with SingleValueChannel

### DIFF
--- a/Sources/Afluent/SequenceOperators/DecodeSequence.swift
+++ b/Sources/Afluent/SequenceOperators/DecodeSequence.swift
@@ -26,7 +26,8 @@ extension AsyncSequences {
         }
 
         public func makeAsyncIterator() -> AsyncIterator {
-            AsyncIterator(upstreamIterator: upstream.makeAsyncIterator(), decoder: decoder)
+            AsyncIterator(upstreamIterator: upstream.makeAsyncIterator(),
+                          decoder: decoder)
         }
     }
 }

--- a/Sources/Afluent/SequenceOperators/DematerializeSequence.swift
+++ b/Sources/Afluent/SequenceOperators/DematerializeSequence.swift
@@ -12,12 +12,11 @@ extension AsyncSequences {
         let upstream: Upstream
 
         public struct AsyncIterator: AsyncIteratorProtocol {
-            let upstream: Upstream
-            lazy var iterator = upstream.makeAsyncIterator()
+            var upstream: Upstream.AsyncIterator
 
             public mutating func next() async throws -> Element? {
                 try Task.checkCancellation()
-                if let val = try await iterator.next() {
+                if let val = try await upstream.next() {
                     switch val {
                         case .element(let element): return element
                         case .failure(let error): throw error
@@ -30,7 +29,7 @@ extension AsyncSequences {
         }
 
         public func makeAsyncIterator() -> AsyncIterator {
-            AsyncIterator(upstream: upstream)
+            AsyncIterator(upstream: upstream.makeAsyncIterator())
         }
     }
 }

--- a/Sources/Afluent/SequenceOperators/EncodeSequence.swift
+++ b/Sources/Afluent/SequenceOperators/EncodeSequence.swift
@@ -26,7 +26,8 @@ extension AsyncSequences {
         }
 
         public func makeAsyncIterator() -> AsyncIterator {
-            AsyncIterator(upstreamIterator: upstream.makeAsyncIterator(), encoder: encoder)
+            AsyncIterator(upstreamIterator: upstream.makeAsyncIterator(),
+                          encoder: encoder)
         }
     }
 }

--- a/Sources/Afluent/SequenceOperators/MaterializeSequence.swift
+++ b/Sources/Afluent/SequenceOperators/MaterializeSequence.swift
@@ -24,15 +24,14 @@ extension AsyncSequences {
         let upstream: Upstream
 
         public struct AsyncIterator: AsyncIteratorProtocol {
-            let upstream: Upstream
+            var upstream: Upstream.AsyncIterator
             var completed = false
-            lazy var iterator = upstream.makeAsyncIterator()
 
             public mutating func next() async throws -> Element? {
                 guard !completed else { return nil }
                 do {
                     try Task.checkCancellation()
-                    if let val = try await iterator.next() {
+                    if let val = try await upstream.next() {
                         return .element(val)
                     } else {
                         completed = true
@@ -46,7 +45,7 @@ extension AsyncSequences {
         }
 
         public func makeAsyncIterator() -> AsyncIterator {
-            AsyncIterator(upstream: upstream)
+            AsyncIterator(upstream: upstream.makeAsyncIterator())
         }
     }
 }


### PR DESCRIPTION
Actor reentrancy is hard to reason about. As a consequence there's a bug I still don't 100% understand with SingleValueChannel that running repeated tests caught where it'd deadlock. That has now been fixed! 

I also made some minor refactors on creating upstream iterators a little earlier in the lifecycle.