### PR TITLE
FlatMap max subscriptions

### DIFF
--- a/Sources/Afluent/SequenceOperators/FlatMapSequence.swift
+++ b/Sources/Afluent/SequenceOperators/FlatMapSequence.swift
@@ -30,15 +30,13 @@ extension AsyncSequences {
                                 Task { [transform] in
                                     do {
                                         try Task.checkCancellation()
-                                        for try await el in upstream {
-                                            Task { [transform] in
-                                                do {
+                                        try await withThrowingTaskGroup(of: Void.self) { group in
+                                            for try await el in upstream {
+                                                group.addTask {
                                                     try Task.checkCancellation()
                                                     for try await e in try await transform(el) {
                                                         continuation.yield(e)
                                                     }
-                                                } catch {
-                                                    continuation.finish(throwing: error)
                                                 }
                                             }
                                         }

--- a/Sources/Afluent/SequenceOperators/FlatMapSequence.swift
+++ b/Sources/Afluent/SequenceOperators/FlatMapSequence.swift
@@ -5,6 +5,7 @@
 //  Created by Tyler Thompson on 3/16/24.
 //
 
+import Atomics
 import Foundation
 
 extension AsyncSequences {
@@ -28,9 +29,11 @@ extension AsyncSequences {
                             iterator = AsyncThrowingStream<Element, Error> { [upstream, transform] continuation in
                                 Task { [transform] in
                                     do {
+                                        try Task.checkCancellation()
                                         for try await el in upstream {
                                             Task { [transform] in
                                                 do {
+                                                    try Task.checkCancellation()
                                                     for try await e in try await transform(el) {
                                                         continuation.yield(e)
                                                     }

--- a/Sources/Afluent/SequenceOperators/FlatMapSequence.swift
+++ b/Sources/Afluent/SequenceOperators/FlatMapSequence.swift
@@ -1,0 +1,74 @@
+//
+//  FlatMapSequence.swift
+//
+//
+//  Created by Tyler Thompson on 3/16/24.
+//
+
+import Foundation
+
+extension AsyncSequences {
+    public struct FlatMap<Upstream: AsyncSequence, SegmentOfResult: AsyncSequence>: AsyncSequence {
+        public typealias Element = SegmentOfResult.Element
+        let upstream: Upstream
+        let maxSubscriptons: SubscriptionDemand
+        let transform: (Upstream.Element) async throws -> SegmentOfResult
+
+        public struct AsyncIterator: AsyncIteratorProtocol {
+            var upstream: Upstream
+            let maxSubscriptons: SubscriptionDemand
+            let transform: (Upstream.Element) async throws -> SegmentOfResult
+            var iterator: AsyncThrowingStream<Element, Error>.Iterator?
+
+            public mutating func next() async throws -> SegmentOfResult.Element? {
+                try Task.checkCancellation()
+                switch maxSubscriptons {
+                    case .unlimited:
+                        if iterator == nil {
+                            iterator = AsyncThrowingStream<Element, Error> { [upstream, transform] continuation in
+                                Task { [transform] in
+                                    do {
+                                        for try await el in upstream {
+                                            Task { [transform] in
+                                                do {
+                                                    for try await e in try await transform(el) {
+                                                        continuation.yield(e)
+                                                    }
+                                                } catch {
+                                                    continuation.finish(throwing: error)
+                                                }
+                                            }
+                                        }
+
+                                        continuation.finish()
+                                    } catch {
+                                        continuation.finish(throwing: error)
+                                    }
+                                }
+                            }.makeAsyncIterator()
+                        }
+
+                        while let element = try await iterator?.next() {
+                            return element
+                        }
+
+                        return nil
+                }
+            }
+        }
+
+        public func makeAsyncIterator() -> AsyncIterator {
+            AsyncIterator(upstream: upstream, maxSubscriptons: maxSubscriptons, transform: transform)
+        }
+    }
+}
+
+extension AsyncSequence {
+    public func flatMap<SegmentOfResult: AsyncSequence>(maxSubscriptions: SubscriptionDemand, _ transform: @escaping (Self.Element) async throws -> SegmentOfResult) -> AsyncSequences.FlatMap<Self, SegmentOfResult> {
+        AsyncSequences.FlatMap(upstream: self, maxSubscriptons: maxSubscriptions, transform: transform)
+    }
+}
+
+public enum SubscriptionDemand {
+    case unlimited
+}

--- a/Tests/AfluentTests/SequenceTests/FlatMapSequenceTests.swift
+++ b/Tests/AfluentTests/SequenceTests/FlatMapSequenceTests.swift
@@ -1,0 +1,71 @@
+//
+//  FlatMapSequenceTests.swift
+//
+//
+//  Created by Tyler Thompson on 3/17/24.
+//
+
+import Foundation
+import XCTest
+
+final class FlatMapSequenceTests: XCTestCase {
+    func testFlatMapUnlimitedSequence() async throws {
+        struct Seq<Element>: AsyncSequence {
+            let val: Element
+
+            struct Iterator: AsyncIteratorProtocol {
+                let val: Element
+                var sent = false
+                mutating func next() async throws -> Element? {
+                    if !sent {
+                        defer { sent.toggle() }
+                        return val
+                    } else {
+                        return nil
+                    }
+                }
+            }
+
+            func makeAsyncIterator() -> Iterator {
+                Iterator(val: val)
+            }
+        }
+
+        struct SeqOfSeq<Element: AsyncSequence>: AsyncSequence {
+            let val1: Element
+            let val2: Element
+
+            struct Iterator: AsyncIteratorProtocol {
+                let val1: Element
+                let val2: Element
+                var sent1 = false
+                var sent2 = false
+                mutating func next() async throws -> Element? {
+                    if !sent1 {
+                        defer { sent1.toggle() }
+                        return val1
+                    } else if !sent2 {
+                        defer { sent2.toggle() }
+                        return val2
+                    } else {
+                        return nil
+                    }
+                }
+            }
+
+            func makeAsyncIterator() -> Iterator {
+                Iterator(val1: val1, val2: val2)
+            }
+        }
+
+        let seq1 = Seq(val: 1)
+        let seq2 = Seq(val: 2)
+
+        let results = try await SeqOfSeq(val1: seq1, val2: seq2)
+            .flatMap { $0 }
+            .collect()
+            .first()
+
+        XCTAssertEqual(try Set(XCTUnwrap(results)), [1, 2])
+    }
+}


### PR DESCRIPTION
The `flatMap` operator that comes with the standard library has the unfortunate side-effect of only creating one subscription to the upstream at a time. This is is opposite of the Combine behavior and reared its ugly head when testing the GroupBy operator. This PR adds a FlatMap implementation with no such limitations. 