### PR TITLE
[collect-sequence-finish-fix] - Collect actually finishes! - TT

### DIFF
--- a/Sources/Afluent/SequenceOperators/CollectSequence.swift
+++ b/Sources/Afluent/SequenceOperators/CollectSequence.swift
@@ -15,13 +15,16 @@ extension AsyncSequences {
         public struct AsyncIterator: AsyncIteratorProtocol {
             var upstreamIterator: Upstream.AsyncIterator
             var collected = Element()
+            var finished = false
 
             public mutating func next() async throws -> Element? {
                 try Task.checkCancellation()
+                guard !finished else { return nil }
                 while let next = try await upstreamIterator.next() {
                     try Task.checkCancellation()
                     collected.append(next)
                 }
+                defer { finished = true }
                 return collected
             }
         }

--- a/Tests/AfluentTests/SequenceTests/CollectSequenceTests.swift
+++ b/Tests/AfluentTests/SequenceTests/CollectSequenceTests.swift
@@ -28,6 +28,12 @@ final class CollectSequenceTests: XCTestCase {
         XCTAssertEqual(collected, [42], "Collect should return an array with the single element")
     }
 
+    func testCollectWithSequenceFinishes() async throws {
+        let singleElementSequence = [42].async
+        let collected = try await singleElementSequence.collect().dropFirst().first()
+        XCTAssertNil(collected)
+    }
+
     func testCollectWithSequenceThrowingError() async throws {
         enum TestError: Error, Equatable {
             case someError


### PR DESCRIPTION
Previously the `collect` sequence operator had a nasty habit of just always returning the collected array instead of emitting it once then finishing its own sequence. 