### PR TITLE
[strict-concurrency] - Strict Concurrency Support - TT

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,6 +21,9 @@ let package = Package(name: "Afluent",
                           .target(name: "Afluent",
                                   dependencies: [
                                       .product(name: "Atomics", package: "swift-atomics"),
+                                  ],
+                                  swiftSettings: [
+                                      .enableExperimentalFeature("StrictConcurrency=complete"),
                                   ]),
                           .testTarget(name: "AfluentTests",
                                       dependencies: testDependencies()),

--- a/Sources/Afluent/Extensions/KeyPathExtensions.swift
+++ b/Sources/Afluent/Extensions/KeyPathExtensions.swift
@@ -1,0 +1,11 @@
+//
+//  KeyPathExtensions.swift
+//
+//
+//  Created by Tyler Thompson on 3/31/24.
+//
+
+import Foundation
+
+// https://forums.swift.org/t/sendablekeypath/67195
+extension KeyPath: @unchecked Sendable { }

--- a/Sources/Afluent/Extensions/KeyPathExtensions.swift
+++ b/Sources/Afluent/Extensions/KeyPathExtensions.swift
@@ -8,4 +8,4 @@
 import Foundation
 
 // https://forums.swift.org/t/sendablekeypath/67195
-extension KeyPath: @unchecked Sendable { }
+extension KeyPath: @unchecked Sendable where Value: Sendable { }

--- a/Sources/Afluent/SequenceOperators/AnyAsyncSequence.swift
+++ b/Sources/Afluent/SequenceOperators/AnyAsyncSequence.swift
@@ -37,7 +37,7 @@ extension AsyncSequences {
     }
 }
 
-extension AsyncSequence {
+extension AsyncSequence where Self: Sendable {
     /// Type erases the current sequence, useful when you need a concrete type that's easy to predict.
     public func eraseToAnyAsyncSequence() -> AsyncSequences.AnyAsyncSequence<Element> {
         AsyncSequences.AnyAsyncSequence(erasing: self)

--- a/Sources/Afluent/SequenceOperators/AssertNoFailureSequence.swift
+++ b/Sources/Afluent/SequenceOperators/AssertNoFailureSequence.swift
@@ -33,7 +33,7 @@ extension AsyncSequences {
     }
 }
 
-extension AsyncSequence {
+extension AsyncSequence where Self: Sendable {
     /// Raises a fatal error when its upstream sequence fails, and otherwise republishes all received input.
     public func assertNoFailure() -> AsyncSequences.AssertNoFailure<Self> {
         AsyncSequences.AssertNoFailure(upstream: self)

--- a/Sources/Afluent/SequenceOperators/BreakpointSequence.swift
+++ b/Sources/Afluent/SequenceOperators/BreakpointSequence.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-extension AsyncSequence {
+extension AsyncSequence where Self: Sendable {
     /// Introduces a breakpoint into the async sequence.
     ///
     /// This function allows you to introduce conditional breakpoints based on the output or error of the async sequence.

--- a/Sources/Afluent/SequenceOperators/CatchSequence.swift
+++ b/Sources/Afluent/SequenceOperators/CatchSequence.swift
@@ -46,7 +46,7 @@ extension AsyncSequences {
     }
 }
 
-extension AsyncSequence {
+extension AsyncSequence where Self: Sendable {
     /// Catches any errors emitted by the upstream `AsyncSequence` and handles them using the provided closure.
     ///
     /// - Parameters:

--- a/Sources/Afluent/SequenceOperators/CollectSequence.swift
+++ b/Sources/Afluent/SequenceOperators/CollectSequence.swift
@@ -35,7 +35,7 @@ extension AsyncSequences {
     }
 }
 
-extension AsyncSequence {
+extension AsyncSequence where Self: Sendable {
     /// Collects all received elements, and emits a single array of the collection when the upstream sequence finishes.
     /// ### Discussion:
     /// Use `collect()` to gather elements into an array that the operator emits after the upstream sequence finishes.

--- a/Sources/Afluent/SequenceOperators/DecodeSequence.swift
+++ b/Sources/Afluent/SequenceOperators/DecodeSequence.swift
@@ -32,7 +32,7 @@ extension AsyncSequences {
     }
 }
 
-extension AsyncSequence {
+extension AsyncSequence where Self: Sendable {
     /// Decodes the output from the upstream using a specified decoder.
     public func decode<T: Decodable, D: TopLevelDecoder>(type _: T.Type, decoder: D) -> AsyncSequences.Decode<Self, D, T> where Element == D.Input {
         AsyncSequences.Decode(upstream: self, decoder: decoder)

--- a/Sources/Afluent/SequenceOperators/DelaySequence.swift
+++ b/Sources/Afluent/SequenceOperators/DelaySequence.swift
@@ -9,7 +9,7 @@ import Foundation
 
 extension AsyncSequences {
     @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-    public struct Delay<Upstream: AsyncSequence, C: Clock>: AsyncSequence {
+    public struct Delay<Upstream: AsyncSequence & Sendable, C: Clock>: AsyncSequence {
         public typealias Element = Upstream.Element
         let upstream: Upstream
         let interval: C.Duration
@@ -61,7 +61,7 @@ extension AsyncSequences {
     }
 }
 
-extension AsyncSequence {
+extension AsyncSequence where Self: Sendable {
     /// Delays delivery of all output to the downstream receiver by a specified amount of time
     /// - Parameter interval: The amount of time to delay.
     @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)

--- a/Sources/Afluent/SequenceOperators/DematerializeSequence.swift
+++ b/Sources/Afluent/SequenceOperators/DematerializeSequence.swift
@@ -34,7 +34,7 @@ extension AsyncSequences {
     }
 }
 
-extension AsyncSequence {
+extension AsyncSequence where Self: Sendable {
     /// Transforms a sequence of `Event` values back into their original form in an `AsyncSequence`.
     ///
     /// This method is the inverse of `materialize`. It takes an `AsyncSequence` of `Event` values and transforms it back into an `AsyncSequence` of the original elements, propagating errors as thrown exceptions.

--- a/Sources/Afluent/SequenceOperators/DiscardOutputSequence.swift
+++ b/Sources/Afluent/SequenceOperators/DiscardOutputSequence.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-extension AsyncSequence {
+extension AsyncSequence where Self: Sendable {
     /// Discards the output values from the upstream `AsyncSequence`.
     ///
     /// - Returns: An `AsyncSequence` of type `Void` that emits a completion event when the upstream completes.

--- a/Sources/Afluent/SequenceOperators/EncodeSequence.swift
+++ b/Sources/Afluent/SequenceOperators/EncodeSequence.swift
@@ -32,7 +32,7 @@ extension AsyncSequences {
     }
 }
 
-extension AsyncSequence {
+extension AsyncSequence where Self: Sendable {
     /// Encodes the output from upstream using a specified encoder.
     public func encode<E: TopLevelEncoder>(encoder: E) -> AsyncSequences.Encode<Self, E> where Element: Encodable {
         AsyncSequences.Encode(upstream: self, encoder: encoder)

--- a/Sources/Afluent/SequenceOperators/GroupBySequence.swift
+++ b/Sources/Afluent/SequenceOperators/GroupBySequence.swift
@@ -12,18 +12,18 @@ extension AsyncSequences {
         public typealias Element = (key: Key, stream: AsyncThrowingStream<Upstream.Element, Error>)
         let upstream: Upstream
         let keySelector: (Upstream.Element) async -> Key
-        
+
         init(upstream: Upstream, keySelector: @escaping (Upstream.Element) async -> Key) {
             self.upstream = upstream
             self.keySelector = keySelector
         }
-        
+
         public struct AsyncIterator: AsyncIteratorProtocol {
             var upstream: Upstream.AsyncIterator
             let keySelector: (Upstream.Element) async -> Key
-            
+
             var keyedSequences = [Key: (stream: AsyncThrowingStream<Upstream.Element, Error>, continuation: AsyncThrowingStream<Upstream.Element, Error>.Continuation)]()
-            
+
             public mutating func next() async throws -> Element? {
                 do {
                     try Task.checkCancellation()
@@ -47,16 +47,15 @@ extension AsyncSequences {
                 }
             }
         }
-        
+
         public func makeAsyncIterator() -> AsyncIterator {
             AsyncIterator(upstream: upstream.makeAsyncIterator(), keySelector: keySelector)
         }
     }
 }
 
-extension AsyncSequence {
+extension AsyncSequence where Self: Sendable {
     public func groupBy<Key: Hashable>(keySelector: @escaping (Element) async -> Key) -> AsyncSequences.GroupBy<Self, Key> {
         AsyncSequences.GroupBy(upstream: self, keySelector: keySelector)
     }
 }
-

--- a/Sources/Afluent/SequenceOperators/HandleEventsSequence.swift
+++ b/Sources/Afluent/SequenceOperators/HandleEventsSequence.swift
@@ -60,7 +60,7 @@ extension AsyncSequences {
     }
 }
 
-extension AsyncSequence {
+extension AsyncSequence where Self: Sendable {
     /// Adds side-effects to the receiving events of the upstream `AsyncSequence`.
     ///
     /// - Parameters:

--- a/Sources/Afluent/SequenceOperators/MapErrorSequence.swift
+++ b/Sources/Afluent/SequenceOperators/MapErrorSequence.swift
@@ -34,7 +34,7 @@ extension AsyncSequences {
     }
 }
 
-extension AsyncSequence {
+extension AsyncSequence where Self: Sendable {
     /// Transforms the error produced by the `AsyncSequence`.
     ///
     /// This function allows you to modify or replace the error produced by the current sequence. It's useful for converting between error types or adding additional context to errors.

--- a/Sources/Afluent/SequenceOperators/MaterializeSequence.swift
+++ b/Sources/Afluent/SequenceOperators/MaterializeSequence.swift
@@ -50,7 +50,7 @@ extension AsyncSequences {
     }
 }
 
-extension AsyncSequence {
+extension AsyncSequence where Self: Sendable {
     /// Transforms the elements, completion, and errors of the current `AsyncSequence` into `Event` values.
     ///
     /// This method wraps the `AsyncSequence` and emits each of its elements, errors, and completion as distinct `Event` cases. It's useful for uniformly handling all aspects of the sequence's lifecycle.

--- a/Sources/Afluent/SequenceOperators/PrintSequence.swift
+++ b/Sources/Afluent/SequenceOperators/PrintSequence.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-extension AsyncSequence {
+extension AsyncSequence where Self: Sendable {
     /// Logs events from the upstream `AsyncSequence` to the console.
     ///
     /// - Parameters:

--- a/Sources/Afluent/SequenceOperators/ReplaceErrorSequence.swift
+++ b/Sources/Afluent/SequenceOperators/ReplaceErrorSequence.swift
@@ -35,7 +35,7 @@ extension AsyncSequences {
     }
 }
 
-extension AsyncSequence {
+extension AsyncSequence where Self: Sendable {
     /// Replaces any errors from the upstream `AsyncSequence` with the provided value.
     ///
     /// - Parameter value: The value to emit upon encountering an error.

--- a/Sources/Afluent/SequenceOperators/ReplaceNilSequence.swift
+++ b/Sources/Afluent/SequenceOperators/ReplaceNilSequence.swift
@@ -34,7 +34,7 @@ extension AsyncSequences {
     }
 }
 
-extension AsyncSequence {
+extension AsyncSequence where Self: Sendable {
     /// Replaces any `nil` values from the upstream `AsyncSequence` with the provided non-nil value.
     ///
     /// - Parameter value: The value to emit when the upstream emits `nil`.

--- a/Sources/Afluent/SequenceOperators/RetrySequence.swift
+++ b/Sources/Afluent/SequenceOperators/RetrySequence.swift
@@ -8,30 +8,38 @@
 import Foundation
 
 extension AsyncSequences {
-    public final actor Retry<Upstream: AsyncSequence>: AsyncSequence, AsyncIteratorProtocol {
+    public final actor Retry<Upstream: AsyncSequence & Sendable>: AsyncSequence, AsyncIteratorProtocol where Upstream.Element: Sendable, Upstream.AsyncIterator: Sendable {
         public typealias Element = Upstream.Element
         let upstream: Upstream
         var retries: UInt
-        lazy var iterator = upstream.makeAsyncIterator()
+        private lazy var iterator = upstream.makeAsyncIterator()
 
         init(upstream: Upstream, retries: UInt) {
             self.upstream = upstream
             self.retries = retries
         }
 
-        public func next() async throws -> Upstream.Element? {
+        private func setIterator(_ iterator: Upstream.AsyncIterator) {
+            self.iterator = iterator
+        }
+
+        private func decrementRetries() {
+            retries -= 1
+        }
+
+        public nonisolated func next() async throws -> Upstream.Element? {
             do {
                 try Task.checkCancellation()
-                var copy = iterator
+                var copy = await iterator
                 let next = try await copy.next()
-                iterator = copy
+                await setIterator(copy)
                 return next
             } catch {
                 guard !(error is CancellationError) else { throw error }
 
-                if retries > 0 {
-                    retries -= 1
-                    iterator = upstream.makeAsyncIterator()
+                if await retries > 0 {
+                    await decrementRetries()
+                    await setIterator(upstream.makeAsyncIterator())
                     return try await next()
                 } else {
                     throw error
@@ -42,7 +50,7 @@ extension AsyncSequences {
         public nonisolated func makeAsyncIterator() -> Retry<Upstream> { self }
     }
 
-    public final actor RetryOn<Upstream: AsyncSequence, Failure: Error & Equatable>: AsyncSequence, AsyncIteratorProtocol {
+    public final actor RetryOn<Upstream: AsyncSequence & Sendable, Failure: Error & Equatable>: AsyncSequence, AsyncIteratorProtocol where Upstream.Element: Sendable, Upstream.AsyncIterator: Sendable {
         public typealias Element = Upstream.Element
         let upstream: Upstream
         var retries: UInt
@@ -55,12 +63,20 @@ extension AsyncSequences {
             self.error = error
         }
 
-        public func next() async throws -> Upstream.Element? {
+        private func setIterator(_ iterator: Upstream.AsyncIterator) {
+            self.iterator = iterator
+        }
+
+        private func decrementRetries() {
+            retries -= 1
+        }
+
+        public nonisolated func next() async throws -> Upstream.Element? {
             do {
                 try Task.checkCancellation()
-                var copy = iterator
+                var copy = await iterator
                 let next = try await copy.next()
-                iterator = copy
+                await setIterator(copy)
                 return next
             } catch (let err) {
                 guard !(err is CancellationError) else { throw err }
@@ -69,9 +85,9 @@ extension AsyncSequences {
                       unwrappedError == error else {
                     throw err
                 }
-                if retries > 0 {
-                    retries -= 1
-                    iterator = upstream.makeAsyncIterator()
+                if await retries > 0 {
+                    await decrementRetries()
+                    await setIterator(upstream.makeAsyncIterator())
                     return try await next()
                 } else {
                     throw error
@@ -83,7 +99,7 @@ extension AsyncSequences {
     }
 }
 
-extension AsyncSequence {
+extension AsyncSequence where Self: Sendable, Element: Sendable, Self.AsyncIterator: Sendable {
     /// Retries the upstream `AsyncSequence` up to a specified number of times.
     ///
     /// - Parameter retries: The maximum number of times to retry the upstream, defaulting to 1.

--- a/Sources/Afluent/Subscription/AnyCancellable.swift
+++ b/Sources/Afluent/Subscription/AnyCancellable.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// Stores an erased unit of work and provides a mechanism to cancel it
 /// - NOTE: The unit of work will be cancelled when the AnyCancellable is deinitialized
-public final class AnyCancellable: Hashable {
+public final class AnyCancellable: Hashable, Sendable {
     public static func == (lhs: AnyCancellable, rhs: AnyCancellable) -> Bool {
         lhs === rhs
     }
@@ -51,15 +51,15 @@ extension AsynchronousUnitOfWork {
     }
 }
 
-extension AsyncSequence {
+extension AsyncSequence where Self: Sendable {
     /// Executes the current async sequence and returns an AnyCancellable token to cancel the subscription.
     ///
     /// - Parameters:
     ///   - receiveCompletion: A function that is executed when the stream has completed normally with `nil` or an error.
     ///   - receiveOutput: A function that is executed when output is received from the sequence.
     ///   If this function throws an error, then the stream is completed.
-    public func sink(receiveCompletion: ((AsyncSequences.Completion<Error>) async -> Void)? = nil,
-                     receiveOutput: ((Element) async throws -> Void)? = nil) -> AnyCancellable {
+    public func sink(receiveCompletion: (@Sendable (AsyncSequences.Completion<Error>) async -> Void)? = nil,
+                     receiveOutput: (@Sendable (Element) async throws -> Void)? = nil) -> AnyCancellable {
         DeferredTask {
             do {
                 for try await output in self {

--- a/Sources/Afluent/Workers/Assign.swift
+++ b/Sources/Afluent/Workers/Assign.swift
@@ -12,7 +12,7 @@ extension AsynchronousUnitOfWork {
     ///  - Parameter keyPath: The key path to assign the output to.
     ///  - Parameter object: The object to assign the output to.
     ///  - Note: This method will not retain the object passed in. If the object is deallocated the assignment will stop.
-    public func assign<Root: AnyObject>(to keyPath: ReferenceWritableKeyPath<Root, Success>, on object: Root) async throws {
+    public func assign<Root: AnyObject & Sendable>(to keyPath: ReferenceWritableKeyPath<Root, Success>, on object: Root) async throws {
         _ = try await handleEvents(receiveOutput: { [weak object] in
             object?[keyPath: keyPath] = $0
         }).execute()

--- a/Sources/Afluent/Workers/Breakpoint.swift
+++ b/Sources/Afluent/Workers/Breakpoint.swift
@@ -18,7 +18,7 @@ extension AsynchronousUnitOfWork {
     ///   - receiveError: A closure that takes any error produced by the operation. If this closure returns `true`, a breakpoint is triggered. Default is `nil`.
     ///
     /// - Returns: An asynchronous unit of work with the breakpoint conditions applied.
-    @_transparent @_alwaysEmitIntoClient @inlinable public func breakpoint(receiveOutput: ((Success) async throws -> Bool)? = nil, receiveError: ((Error) async throws -> Bool)? = nil) -> some AsynchronousUnitOfWork<Success> {
+    @_transparent @_alwaysEmitIntoClient @inlinable public func breakpoint(receiveOutput: (@Sendable (Success) async throws -> Bool)? = nil, receiveError: (@Sendable (Error) async throws -> Bool)? = nil) -> some AsynchronousUnitOfWork<Success> {
         handleEvents(receiveOutput: { output in
             if try await receiveOutput?(output) == true {
                 raise(SIGTRAP)

--- a/Sources/Afluent/Workers/Decode.swift
+++ b/Sources/Afluent/Workers/Decode.swift
@@ -38,7 +38,7 @@ extension AsynchronousUnitOfWork {
     /// - Returns: An `AsynchronousUnitOfWork` whose output is the decoded `T` type object.
     ///
     /// - Note: The generic constraint `Success == D.Input` ensures that the upstream unit of work emits a compatible type for the decoder.
-    public func decode<T: Decodable, D: TopLevelDecoder>(type _: T.Type, decoder: D) -> some AsynchronousUnitOfWork<T> where Success == D.Input {
+    public func decode<T: Decodable & Sendable, D: TopLevelDecoder & Sendable>(type _: T.Type, decoder: D) -> some AsynchronousUnitOfWork<T> where Success == D.Input {
         Workers.Decode(upstream: self, decoder: decoder)
     }
 }

--- a/Sources/Afluent/Workers/Encode.swift
+++ b/Sources/Afluent/Workers/Encode.swift
@@ -36,7 +36,7 @@ extension AsynchronousUnitOfWork {
     /// - Returns: An `AsynchronousUnitOfWork` emitting the encoded values as output of type `E.Output`.
     ///
     /// - Note: The returned `AsynchronousUnitOfWork` will fail if the encoding process fails.
-    public func encode<E: TopLevelEncoder>(encoder: E) -> some AsynchronousUnitOfWork<E.Output> where Success: Encodable {
+    public func encode<E: TopLevelEncoder & Sendable>(encoder: E) -> some AsynchronousUnitOfWork<E.Output> where Success: Encodable, E.Output: Sendable {
         Workers.Encode(upstream: self, encoder: encoder)
     }
 }

--- a/Sources/Afluent/Workers/HandleEvents.swift
+++ b/Sources/Afluent/Workers/HandleEvents.swift
@@ -11,12 +11,12 @@ extension Workers {
     actor HandleEvents<Upstream: AsynchronousUnitOfWork, Success: Sendable>: AsynchronousUnitOfWork where Upstream.Success == Success {
         let state = TaskState<Success>()
         let upstream: Upstream
-        let receiveOperation: (() async throws -> Void)?
-        let receiveOutput: ((Success) async throws -> Void)?
-        let receiveError: ((Error) async throws -> Void)?
-        let receiveCancel: (() async throws -> Void)?
+        let receiveOperation: (@Sendable () async throws -> Void)?
+        let receiveOutput: (@Sendable (Success) async throws -> Void)?
+        let receiveError: (@Sendable (Error) async throws -> Void)?
+        let receiveCancel: (@Sendable () async throws -> Void)?
 
-        init(upstream: Upstream, @_inheritActorContext @_implicitSelfCapture receiveOperation: (() async throws -> Void)?, @_inheritActorContext @_implicitSelfCapture receiveOutput: ((Success) async throws -> Void)?, @_inheritActorContext @_implicitSelfCapture receiveError: ((Error) async throws -> Void)?, @_inheritActorContext @_implicitSelfCapture receiveCancel: (() async throws -> Void)?) {
+        init(upstream: Upstream, @_inheritActorContext @_implicitSelfCapture receiveOperation: (@Sendable () async throws -> Void)?, @_inheritActorContext @_implicitSelfCapture receiveOutput: (@Sendable (Success) async throws -> Void)?, @_inheritActorContext @_implicitSelfCapture receiveError: (@Sendable (Error) async throws -> Void)?, @_inheritActorContext @_implicitSelfCapture receiveCancel: (@Sendable () async throws -> Void)?) {
             self.upstream = upstream
             self.receiveOperation = receiveOperation
             self.receiveOutput = receiveOutput
@@ -59,7 +59,7 @@ extension AsynchronousUnitOfWork {
     /// - Returns: An `AsynchronousUnitOfWork` that performs the side-effects for the specified receiving events.
     ///
     /// - Note: The returned `AsynchronousUnitOfWork` forwards all receiving events from the upstream unit of work.
-    public func handleEvents(@_inheritActorContext @_implicitSelfCapture receiveOperation: (() async throws -> Void)? = nil, @_inheritActorContext @_implicitSelfCapture receiveOutput: ((Success) async throws -> Void)? = nil, @_inheritActorContext @_implicitSelfCapture receiveError: ((Error) async throws -> Void)? = nil, @_inheritActorContext @_implicitSelfCapture receiveCancel: (() async throws -> Void)? = nil) -> some AsynchronousUnitOfWork<Success> {
+    public func handleEvents(@_inheritActorContext @_implicitSelfCapture receiveOperation: (@Sendable () async throws -> Void)? = nil, @_inheritActorContext @_implicitSelfCapture receiveOutput: (@Sendable (Success) async throws -> Void)? = nil, @_inheritActorContext @_implicitSelfCapture receiveError: (@Sendable (Error) async throws -> Void)? = nil, @_inheritActorContext @_implicitSelfCapture receiveCancel: (@Sendable () async throws -> Void)? = nil) -> some AsynchronousUnitOfWork<Success> {
         Workers.HandleEvents(upstream: self, receiveOperation: receiveOperation, receiveOutput: receiveOutput, receiveError: receiveError, receiveCancel: receiveCancel)
     }
 }

--- a/Sources/Afluent/Workers/Map.swift
+++ b/Sources/Afluent/Workers/Map.swift
@@ -60,7 +60,7 @@ extension AsynchronousUnitOfWork {
     ///   - keyPath: A key path to a property of the upstream's output type.
     ///
     /// - Returns: An `AsynchronousUnitOfWork` that emits the value of the property specified by the key path.
-    public func map<T>(_ keyPath: KeyPath<Success, T>) -> some AsynchronousUnitOfWork<T> {
+    public func map<T: Sendable>(_ keyPath: KeyPath<Success, T>) -> some AsynchronousUnitOfWork<T> {
         Workers.Map(upstream: self) {
             $0[keyPath: keyPath]
         }

--- a/Sources/Afluent/Workers/MapError.swift
+++ b/Sources/Afluent/Workers/MapError.swift
@@ -11,9 +11,9 @@ extension Workers {
     actor MapError<Upstream: AsynchronousUnitOfWork, Success: Sendable>: AsynchronousUnitOfWork where Success == Upstream.Success {
         let state = TaskState<Success>()
         let upstream: Upstream
-        let transform: (Error) -> Error
+        let transform: @Sendable (Error) -> Error
 
-        init(upstream: Upstream, transform: @escaping (Error) -> Error) {
+        init(upstream: Upstream, transform: @escaping @Sendable (Error) -> Error) {
             self.upstream = upstream
             self.transform = transform
         }
@@ -42,7 +42,7 @@ extension AsynchronousUnitOfWork {
     /// - Parameter transform: A closure that takes the original error and returns a transformed error.
     ///
     /// - Returns: An asynchronous unit of work that produces the transformed error.
-    public func mapError(_ transform: @escaping (Error) -> Error) -> some AsynchronousUnitOfWork<Success> {
+    public func mapError(_ transform: @escaping @Sendable (Error) -> Error) -> some AsynchronousUnitOfWork<Success> {
         Workers.MapError(upstream: self, transform: transform)
     }
 
@@ -55,7 +55,7 @@ extension AsynchronousUnitOfWork {
     ///   - transform: A closure that takes the matched error and returns a transformed error.
     ///
     /// - Returns: An asynchronous unit of work that produces either the transformed error (if a match was found) or the original error.
-    public func mapError<E: Error & Equatable>(_ error: E, _ transform: @escaping (Error) -> Error) -> some AsynchronousUnitOfWork<Success> {
+    public func mapError<E: Error & Equatable>(_ error: E, _ transform: @escaping @Sendable (Error) -> Error) -> some AsynchronousUnitOfWork<Success> {
         mapError {
             if let e = $0 as? E, e == error { return transform(e) }
             return $0

--- a/Sources/Afluent/Workers/UnwrapOrThrow.swift
+++ b/Sources/Afluent/Workers/UnwrapOrThrow.swift
@@ -9,7 +9,7 @@ import Foundation
 
 extension AsynchronousUnitOfWork {
     /// Unwraps the optional value if present, or throws an error.
-    public func unwrap<T>(orThrow error: @escaping @autoclosure () -> Error) -> some AsynchronousUnitOfWork<T> where Success == T? {
+    public func unwrap<T>(orThrow error: @escaping @Sendable @autoclosure () -> Error) -> some AsynchronousUnitOfWork<T> where Success == T? {
         tryMap { output in
             switch output {
                 case .some(let value):

--- a/Sources/Afluent/Workers/WithUnretained.swift
+++ b/Sources/Afluent/Workers/WithUnretained.swift
@@ -20,7 +20,7 @@ extension AsynchronousUnitOfWork {
     ///   - obj: The object to provide an unretained reference on.
     ///   - resultSelector: A function to combine the unretained referenced on `obj` and the value of the observable sequence.
     /// - Returns: An AsynchronousUnitOfWork that contains the result of `resultSelector` being called with an unretained reference on `obj` and the values of the original sequence.
-    public func withUnretained<Object: AnyObject, Out>(_ obj: Object, resultSelector: @escaping (Object, Success) -> Out) -> some AsynchronousUnitOfWork<Out> {
+    public func withUnretained<Object: AnyObject & Sendable, Out: Sendable>(_ obj: Object, resultSelector: @escaping @Sendable (Object, Success) -> Out) -> some AsynchronousUnitOfWork<Out> {
         tryMap { [weak obj] element -> Out in
             guard let obj = obj else { throw UnretainedError.failedRetaining }
             return resultSelector(obj, element)


### PR DESCRIPTION
Make some potentially breaking changes (one of my tests broke) but all of them in favor of supporting strict concurrency with Swift 6. All warnings and errors are resolved and I *think* the resolution is reasonable. I might ask @aim2120 for a sanity check before merging this one, though.

Strict concurrency is kind of a pain. Most of the changes involve making things explicitly `Sendable` that theoretically apple should've already marked `Sendable`, like `KeyPath` and `AsyncSequence`. 

One change that deserves extra scrutiny is the Retry and RetryAfterFlatMapping *sequence* tweaks. It took forever to make strict concurrency happy and I landed on this particular solution by reading: https://forums.swift.org/t/cannot-understand-the-nature-of-data-race-warnings-in-swift-5-10/70472/1