### PR TITLE
Added in experimental SPI and pulled in Broadcast Algorithm

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,11 +17,13 @@ let package = Package(name: "Afluent",
                           .package(url: "https://github.com/pointfreeco/swift-clocks.git", from: "1.0.2"),
                           .package(url: "https://github.com/pointfreeco/swift-concurrency-extras.git", from: "1.1.0"),
                           .package(url: "https://github.com/apple/swift-testing.git", from: "0.10.0"),
+                          .package(url: "https://github.com/apple/swift-async-algorithms.git", from: "1.0.0"),
                       ],
                       targets: [
                           .target(name: "Afluent",
                                   dependencies: [
                                       .product(name: "Atomics", package: "swift-atomics"),
+                                      .product(name: "AsyncAlgorithms", package: "swift-async-algorithms"),
                                   ],
                                   swiftSettings: [
                                       .enableExperimentalFeature("StrictConcurrency=complete"),

--- a/Package.swift
+++ b/Package.swift
@@ -18,14 +18,12 @@ let package = Package(name: "Afluent",
                           .package(url: "https://github.com/pointfreeco/swift-concurrency-extras.git", from: "1.1.0"),
                           .package(url: "https://github.com/apple/swift-testing.git", from: "0.10.0"),
                           .package(url: "https://github.com/apple/swift-async-algorithms.git", from: "1.0.0"),
-                          .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.0"),
                       ],
                       targets: [
                           .target(name: "Afluent",
                                   dependencies: [
                                       .product(name: "Atomics", package: "swift-atomics"),
                                       .product(name: "AsyncAlgorithms", package: "swift-async-algorithms"),
-                                      .product(name: "DequeModule", package: "swift-collections"),
                                   ],
                                   swiftSettings: [
                                       .enableExperimentalFeature("StrictConcurrency=complete"),

--- a/Package.swift
+++ b/Package.swift
@@ -18,12 +18,14 @@ let package = Package(name: "Afluent",
                           .package(url: "https://github.com/pointfreeco/swift-concurrency-extras.git", from: "1.1.0"),
                           .package(url: "https://github.com/apple/swift-testing.git", from: "0.10.0"),
                           .package(url: "https://github.com/apple/swift-async-algorithms.git", from: "1.0.0"),
+                          .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.0"),
                       ],
                       targets: [
                           .target(name: "Afluent",
                                   dependencies: [
                                       .product(name: "Atomics", package: "swift-atomics"),
                                       .product(name: "AsyncAlgorithms", package: "swift-async-algorithms"),
+                                      .product(name: "DequeModule", package: "swift-collections"),
                                   ],
                                   swiftSettings: [
                                       .enableExperimentalFeature("StrictConcurrency=complete"),

--- a/Package@swift-5.10.swift
+++ b/Package@swift-5.10.swift
@@ -17,11 +17,13 @@ let package = Package(name: "Afluent",
                           .package(url: "https://github.com/pointfreeco/swift-clocks.git", from: "1.0.2"),
                           .package(url: "https://github.com/pointfreeco/swift-concurrency-extras.git", from: "1.1.0"),
                           .package(url: "https://github.com/apple/swift-testing.git", from: "0.7.0"),
+                          .package(url: "https://github.com/apple/swift-async-algorithms.git", from: "1.0.0"),
                       ],
                       targets: [
                           .target(name: "Afluent",
                                   dependencies: [
                                       .product(name: "Atomics", package: "swift-atomics"),
+                                      .product(name: "AsyncAlgorithms", package: "swift-async-algorithms"),
                                   ],
                                   swiftSettings: [
                                       .enableExperimentalFeature("StrictConcurrency=complete"),

--- a/Package@swift-5.8.swift
+++ b/Package@swift-5.8.swift
@@ -16,11 +16,13 @@ let package = Package(name: "Afluent",
                           .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.52.11"),
                           .package(url: "https://github.com/pointfreeco/swift-clocks.git", from: "1.0.2"),
                           .package(url: "https://github.com/pointfreeco/swift-concurrency-extras.git", from: "1.1.0"),
+                          .package(url: "https://github.com/apple/swift-async-algorithms.git", from: "1.0.0"),
                       ],
                       targets: [
                           .target(name: "Afluent",
                                   dependencies: [
                                       .product(name: "Atomics", package: "swift-atomics"),
+                                      .product(name: "AsyncAlgorithms", package: "swift-async-algorithms"),
                                   ],
                                   swiftSettings: [
                                       .enableExperimentalFeature("StrictConcurrency=complete"),

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -16,11 +16,13 @@ let package = Package(name: "Afluent",
                           .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.52.11"),
                           .package(url: "https://github.com/pointfreeco/swift-clocks.git", from: "1.0.2"),
                           .package(url: "https://github.com/pointfreeco/swift-concurrency-extras.git", from: "1.1.0"),
+                          .package(url: "https://github.com/apple/swift-async-algorithms.git", from: "1.0.0"),
                       ],
                       targets: [
                           .target(name: "Afluent",
                                   dependencies: [
                                       .product(name: "Atomics", package: "swift-atomics"),
+                                      .product(name: "AsyncAlgorithms", package: "swift-async-algorithms"),
                                   ],
                                   swiftSettings: [
                                       .enableExperimentalFeature("StrictConcurrency=complete"),

--- a/Sources/Afluent/Rethrow.swift
+++ b/Sources/Afluent/Rethrow.swift
@@ -1,0 +1,41 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Async Algorithms open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+//
+//  Rethrow.swift
+//  Afluent
+//
+//  Modified by Tyler Thompson on 9/29/24.
+//
+
+// This is a hack around the fact that we don't have generic effects
+// alternatively in the use cases we would want `rethrows(unsafe)`
+// or something like that to avoid this nifty hack...
+
+@rethrows
+internal protocol _ErrorMechanism {
+    associatedtype Output
+    func get() throws -> Output
+}
+
+extension _ErrorMechanism {
+    // rethrow an error only in the cases where it is known to be reachable
+    internal func _rethrowError() rethrows -> Never {
+        _ = try _rethrowGet()
+        fatalError("materialized error without being in a throwing context")
+    }
+    
+    internal func _rethrowGet() rethrows -> Output {
+        return try get()
+    }
+}
+
+extension Result: _ErrorMechanism { }

--- a/Sources/Afluent/SequenceOperators/PlatformLock.swift
+++ b/Sources/Afluent/SequenceOperators/PlatformLock.swift
@@ -1,0 +1,149 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Async Algorithms open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+//
+//  PlatformLock.swift
+//  Afluent
+//
+//  Modified by Tyler Thompson on 9/29/24.
+//
+
+#if canImport(Darwin)
+@_implementationOnly import Darwin
+#elseif canImport(Glibc)
+@_implementationOnly import Glibc
+#elseif canImport(WinSDK)
+@_implementationOnly import WinSDK
+#endif
+
+internal struct Lock {
+#if canImport(Darwin)
+    typealias Primitive = os_unfair_lock
+#elseif canImport(Glibc)
+    typealias Primitive = pthread_mutex_t
+#elseif canImport(WinSDK)
+    typealias Primitive = SRWLOCK
+#endif
+    
+    typealias PlatformLock = UnsafeMutablePointer<Primitive>
+    let platformLock: PlatformLock
+    
+    private init(_ platformLock: PlatformLock) {
+        self.platformLock = platformLock
+    }
+    
+    fileprivate static func initialize(_ platformLock: PlatformLock) {
+#if canImport(Darwin)
+        platformLock.initialize(to: os_unfair_lock())
+#elseif canImport(Glibc)
+        pthread_mutex_init(platformLock, nil)
+#elseif canImport(WinSDK)
+        InitializeSRWLock(platformLock)
+#endif
+    }
+    
+    fileprivate static func deinitialize(_ platformLock: PlatformLock) {
+#if canImport(Glibc)
+        pthread_mutex_destroy(platformLock)
+#endif
+        platformLock.deinitialize(count: 1)
+    }
+    
+    fileprivate static func lock(_ platformLock: PlatformLock) {
+#if canImport(Darwin)
+        os_unfair_lock_lock(platformLock)
+#elseif canImport(Glibc)
+        pthread_mutex_lock(platformLock)
+#elseif canImport(WinSDK)
+        AcquireSRWLockExclusive(platformLock)
+#endif
+    }
+    
+    fileprivate static func unlock(_ platformLock: PlatformLock) {
+#if canImport(Darwin)
+        os_unfair_lock_unlock(platformLock)
+#elseif canImport(Glibc)
+        pthread_mutex_unlock(platformLock)
+#elseif canImport(WinSDK)
+        ReleaseSRWLockExclusive(platformLock)
+#endif
+    }
+    
+    static func allocate() -> Lock {
+        let platformLock = PlatformLock.allocate(capacity: 1)
+        initialize(platformLock)
+        return Lock(platformLock)
+    }
+    
+    func deinitialize() {
+        Lock.deinitialize(platformLock)
+    }
+    
+    func lock() {
+        Lock.lock(platformLock)
+    }
+    
+    func unlock() {
+        Lock.unlock(platformLock)
+    }
+    
+    /// Acquire the lock for the duration of the given block.
+    ///
+    /// This convenience method should be preferred to `lock` and `unlock` in
+    /// most situations, as it ensures that the lock will be released regardless
+    /// of how `body` exits.
+    ///
+    /// - Parameter body: The block to execute while holding the lock.
+    /// - Returns: The value returned by the block.
+    func withLock<T>(_ body: () throws -> T) rethrows -> T {
+        self.lock()
+        defer {
+            self.unlock()
+        }
+        return try body()
+    }
+    
+    // specialise Void return (for performance)
+    func withLockVoid(_ body: () throws -> Void) rethrows -> Void {
+        try self.withLock(body)
+    }
+}
+
+struct ManagedCriticalState<State> {
+    private final class LockedBuffer: ManagedBuffer<State, Lock.Primitive> {
+        deinit {
+            withUnsafeMutablePointerToElements { Lock.deinitialize($0) }
+        }
+    }
+    
+    private var buffer: ManagedBuffer<State, Lock.Primitive>
+    
+    init(_ initial: State) {
+        buffer = LockedBuffer.create(minimumCapacity: 1) { buffer in
+            buffer.withUnsafeMutablePointerToElements { Lock.initialize($0) }
+            return initial
+        }
+    }
+    
+    func withCriticalRegion<R>(_ critical: (inout State) throws -> R) rethrows -> R {
+        try buffer.withUnsafeMutablePointers { header, lock in
+            Lock.lock(lock)
+            defer { Lock.unlock(lock) }
+            return try critical(&header.pointee)
+        }
+    }
+    
+    mutating func isKnownUniquelyReferenced() -> Bool {
+        Swift.isKnownUniquelyReferenced(&buffer)
+    }
+}
+
+extension ManagedCriticalState: @unchecked Sendable where State: Sendable { }

--- a/Sources/Afluent/SequenceOperators/ShareSequence.swift
+++ b/Sources/Afluent/SequenceOperators/ShareSequence.swift
@@ -1,0 +1,258 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Async Algorithms open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+//
+//  ShareSequence.swift
+//  Afluent
+//
+//  Modified by Tyler Thompson on 9/29/24.
+//
+
+
+import DequeModule
+
+@_spi(Experimental) extension AsyncSequence where Self: Sendable, Element: Sendable {
+    public func broadcast() -> AsyncBroadcastSequence<Self> {
+        AsyncBroadcastSequence(self)
+    }
+    
+    public func share() -> AsyncBroadcastSequence<Self> {
+        AsyncBroadcastSequence(self)
+    }
+}
+
+@_spi(Experimental) public struct AsyncBroadcastSequence<Base: AsyncSequence>: Sendable where Base: Sendable, Base.Element: Sendable {
+    struct State : Sendable {
+        enum Terminal {
+            case failure(Error)
+            case finished
+        }
+        
+        struct Side {
+            var buffer = Deque<Element>()
+            var terminal: Terminal?
+            var continuation: UnsafeContinuation<Result<Element?, Error>, Never>?
+            
+            mutating func drain() {
+                if !buffer.isEmpty, let continuation {
+                    let element = buffer.removeFirst()
+                    continuation.resume(returning: .success(element))
+                    self.continuation = nil
+                } else if let terminal, let continuation {
+                    switch terminal {
+                    case .failure(let error):
+                        self.terminal = .finished
+                        continuation.resume(returning: .failure(error))
+                    case .finished:
+                        continuation.resume(returning: .success(nil))
+                    }
+                    self.continuation = nil
+                }
+            }
+            
+            mutating func cancel() {
+                buffer.removeAll()
+                terminal = .finished
+                drain()
+            }
+            
+            mutating func next(_ continuation: UnsafeContinuation<Result<Element?, Error>, Never>) {
+                assert(self.continuation == nil) // presume that the sides are NOT sendable iterators...
+                self.continuation = continuation
+                drain()
+            }
+            
+            mutating func emit(_ result: Result<Element?, Error>) {
+                switch result {
+                case .success(let element):
+                    if let element {
+                        buffer.append(element)
+                    } else {
+                        terminal = .finished
+                    }
+                case .failure(let error):
+                    terminal = .failure(error)
+                }
+                drain()
+            }
+        }
+        
+        var id = 0
+        var sides = [Int: Side]()
+        
+        init() { }
+        
+        mutating func establish() -> Int {
+            defer { id += 1 }
+            sides[id] = Side()
+            return id
+        }
+        
+        static func establish(_ state: ManagedCriticalState<State>) -> Int {
+            state.withCriticalRegion { $0.establish() }
+        }
+        
+        mutating func cancel(_ id: Int) {
+            if var side = sides.removeValue(forKey: id) {
+                side.cancel()
+            }
+        }
+        
+        static func cancel(_ state: ManagedCriticalState<State>, id: Int) {
+            state.withCriticalRegion { $0.cancel(id) }
+        }
+        
+        mutating func next(_ id: Int, continuation: UnsafeContinuation<Result<Element?, Error>, Never>) {
+            sides[id]?.next(continuation)
+        }
+        
+        static func next(_ state: ManagedCriticalState<State>, id: Int) async -> Result<Element?, Error> {
+            await withUnsafeContinuation { continuation in
+                state.withCriticalRegion { $0.next(id, continuation: continuation) }
+            }
+        }
+        
+        mutating func emit(_ result: Result<Element?, Error>) {
+            for id in sides.keys {
+                sides[id]?.emit(result)
+            }
+        }
+        
+        static func emit(_ state: ManagedCriticalState<State>, result: Result<Element?, Error>) {
+            state.withCriticalRegion { $0.emit(result) }
+        }
+    }
+    
+    struct Iteration {
+        enum Status {
+            case initial(Base)
+            case iterating(Task<Void, Never>)
+            case terminal
+        }
+        
+        var status: Status
+        
+        init(_ base: Base) {
+            status = .initial(base)
+        }
+        
+        static func task(_ state: ManagedCriticalState<State>, base: Base) -> Task<Void, Never> {
+            Task {
+                do {
+                    for try await element in base {
+                        State.emit(state, result: .success(element))
+                    }
+                    State.emit(state, result: .success(nil))
+                } catch {
+                    State.emit(state, result: .failure(error))
+                }
+            }
+        }
+        
+        mutating func start(_ state: ManagedCriticalState<State>) -> Bool {
+            switch status {
+            case .terminal:
+                return false
+            case .initial(let base):
+                status = .iterating(Iteration.task(state, base: base))
+            default:
+                break
+            }
+            return true
+        }
+        
+        mutating func cancel() {
+            switch status {
+            case .iterating(let task):
+                task.cancel()
+            default:
+                break
+            }
+            status = .terminal
+        }
+        
+        static func start(_ iteration: ManagedCriticalState<Iteration>, state: ManagedCriticalState<State>) -> Bool {
+            iteration.withCriticalRegion { $0.start(state) }
+        }
+        
+        static func cancel(_ iteration: ManagedCriticalState<Iteration>) {
+            iteration.withCriticalRegion { $0.cancel() }
+        }
+    }
+    
+    let state: ManagedCriticalState<State>
+    let iteration: ManagedCriticalState<Iteration>
+    
+    init(_ base: Base) {
+        state = ManagedCriticalState(State())
+        iteration = ManagedCriticalState(Iteration(base))
+    }
+}
+
+
+@_spi(Experimental) extension AsyncBroadcastSequence: AsyncSequence {
+    public typealias Element = Base.Element
+    
+    public struct Iterator: AsyncIteratorProtocol {
+        final class Context {
+            let state: ManagedCriticalState<State>
+            var iteration: ManagedCriticalState<Iteration>
+            let id: Int
+            
+            init(_ state: ManagedCriticalState<State>, _ iteration: ManagedCriticalState<Iteration>) {
+                self.state = state
+                self.iteration = iteration
+                self.id = State.establish(state)
+            }
+            
+            deinit {
+                State.cancel(state, id: id)
+                if iteration.isKnownUniquelyReferenced() {
+                    Iteration.cancel(iteration)
+                }
+            }
+            
+            func next() async rethrows -> Element? {
+                guard Iteration.start(iteration, state: state) else {
+                    return nil
+                }
+                defer {
+                    if Task.isCancelled && iteration.isKnownUniquelyReferenced() {
+                        Iteration.cancel(iteration)
+                    }
+                }
+                return try await withTaskCancellationHandler {
+                    let result = await State.next(state, id: id)
+                    return try result._rethrowGet()
+                } onCancel: { [state, id] in
+                    State.cancel(state, id: id)
+                }
+            }
+        }
+        
+        let context: Context
+        
+        init(_ state: ManagedCriticalState<State>, _ iteration: ManagedCriticalState<Iteration>) {
+            context = Context(state, iteration)
+        }
+        
+        public mutating func next() async rethrows -> Element? {
+            try await context.next()
+        }
+    }
+    
+    public func makeAsyncIterator() -> Iterator {
+        Iterator(state, iteration)
+    }
+}
+
+@available(*, unavailable)
+@_spi(Experimental) extension AsyncBroadcastSequence.Iterator: Sendable { }

--- a/Tests/AfluentTests/SequenceTests/ShareSequenceTests.swift
+++ b/Tests/AfluentTests/SequenceTests/ShareSequenceTests.swift
@@ -1,0 +1,323 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Async Algorithms open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+//
+//  ShareSequenceTests.swift
+//  Afluent
+//
+//  Modified by Tyler Thompson on 9/29/24.
+//
+
+import Testing
+import AsyncAlgorithms
+
+@_spi(Experimental) import Afluent
+
+@Suite struct ShareSequenceTests {
+    @Test func BasicBroadcasting() async {
+        let base = [1, 2, 3, 4].async
+        let a = base.broadcast()
+        let b = a
+        let results = await withTaskGroup(of: [Int].self) { group in
+            group.addTask {
+                await Array(a)
+            }
+            group.addTask {
+                await Array(b)
+            }
+            return await Array(group)
+        }
+        #expect(results[0] == results[1])
+    }
+    
+    @Test func BasicBroadcastingFromChannel() async {
+        let base = AsyncChannel<Int>()
+        let a = base.broadcast()
+        let b = a
+        let results = await withTaskGroup(of: [Int].self) { group in
+            group.addTask {
+                var sent = [Int]()
+                for i in 0..<10 {
+                    sent.append(i)
+                    await base.send(i)
+                }
+                base.finish()
+                return sent
+            }
+            group.addTask {
+                await Array(a)
+            }
+            group.addTask {
+                await Array(b)
+            }
+            return await Array(group)
+        }
+        #expect(results[0] == results[1])
+    }
+    
+    @Test func ABaseSequence_BroadcastingToTwoTasks_TheBaseSequenceIsIteratedOnce() async {
+        // Given
+        let elements = (0..<10).map { $0 }
+        let base = ReportingAsyncSequence(elements)
+        
+        let expectedNexts = elements.map { _ in ReportingAsyncSequence<Int>.Event.next }
+        
+        // When
+        let broadcasted = base.broadcast()
+        await withTaskGroup(of: Void.self) { group in
+            group.addTask {
+                for await _ in broadcasted {}
+            }
+            group.addTask {
+                for await _ in broadcasted {}
+            }
+            await group.waitForAll()
+        }
+        
+        // Then
+        #expect(base.events == [ReportingAsyncSequence<Int>.Event.makeAsyncIterator] + expectedNexts + [ReportingAsyncSequence<Int>.Event.next])
+    }
+    
+    @Test func ABaseSequence_BroadcastingToTwoTasks_TheyReceiveTheBaseElements() async {
+        // Given
+        let base = (0..<10).map { $0 }
+        let expected = (0...4).map { $0 }
+        
+        // When
+        let broadcasted = base.async.map { try throwOn(5, $0) }.broadcast()
+        let results = await withTaskGroup(of: [Int].self) { group in
+            group.addTask {
+                var received = [Int]()
+                do {
+                    for try await element in broadcasted {
+                        received.append(element)
+                    }
+                    Issue.record("The broadcast should fail before finish")
+                } catch {
+                    #expect(error is Failure)
+                }
+                
+                return received
+            }
+            group.addTask {
+                var received = [Int]()
+                do {
+                    for try await element in broadcasted {
+                        received.append(element)
+                    }
+                    Issue.record("The broadcast should fail before finish")
+                } catch {
+                    #expect(error is Failure)
+                }
+                
+                return received
+            }
+            
+            return await Array(group)
+        }
+        
+        // Then
+        #expect(results[0] == expected)
+        #expect(results[0] == results[1])
+    }
+    
+    @Test func AThrowingBaseSequence_BroadcastingToTwoTasks_TheyReceiveTheBaseElementsAndFailure() async {
+        // Given
+        let base = (0..<10).map { $0 }
+        
+        // When
+        let broadcasted = base.async.broadcast()
+        let results = await withTaskGroup(of: [Int].self) { group in
+            group.addTask {
+                await Array(broadcasted)
+            }
+            group.addTask {
+                await Array(broadcasted)
+            }
+            return await Array(group)
+        }
+        
+        // Then
+        #expect(results[0] == base)
+        #expect(results[0] == results[1])
+    }
+    
+    @Test func ABaseSequence_BroadcastingToTwoTasks_TheyReceiveFinishAndPastEndIsNil() async {
+        // Given
+        let base = (0..<10).map { $0 }
+        
+        // When
+        let broadcasted = base.async.broadcast()
+        await withTaskGroup(of: Void.self) { group in
+            group.addTask {
+                var iterator = broadcasted.makeAsyncIterator()
+                while let _ = await iterator.next() {}
+                let pastEnd = await iterator.next()
+                
+                // Then
+                #expect(pastEnd == nil)
+            }
+            group.addTask {
+                var iterator = broadcasted.makeAsyncIterator()
+                while let _ = await iterator.next() {}
+                let pastEnd = await iterator.next()
+                
+                // Then
+                #expect(pastEnd == nil)
+            }
+            
+            await group.waitForAll()
+        }
+    }
+    
+    @Test func ABaseSequence_BroadcastingToTwoTasks_TheBufferIsUsed() async {
+        let task1IsIsFinished = SingleValueSubject<Void>()
+        
+        // Given
+        let base = (0..<10).map { $0 }
+        
+        // When
+        let broadcasted = base.async.broadcast()
+        let results = await withTaskGroup(of: [Int].self) { group in
+            group.addTask {
+                let result = await Array(broadcasted)
+                try? task1IsIsFinished.send()
+                return result
+            }
+            group.addTask {
+                var result = [Int]()
+                var iterator = broadcasted.makeAsyncIterator()
+                let firstElement = await iterator.next()
+                result.append(firstElement!)
+                try? await task1IsIsFinished.execute()
+                
+                while let element = await iterator.next() {
+                    result.append(element)
+                }
+                
+                return result
+            }
+            return await Array(group)
+        }
+        
+        // Then
+        #expect(results[0] == base)
+        #expect(results[0] == results[1])
+    }
+    
+    @Test func AChannel_BroadcastingToTwoTasks_TheyReceivedTheChannelElements() async {
+        // Given
+        let elements = (0..<10).map { $0 }
+        let base = AsyncChannel<Int>()
+        
+        // When
+        let broadcasted = base.broadcast()
+        let results = await withTaskGroup(of: [Int].self) { group in
+            group.addTask {
+                var sent = [Int]()
+                for element in elements {
+                    sent.append(element)
+                    await base.send(element)
+                }
+                base.finish()
+                return sent
+            }
+            group.addTask {
+                await Array(broadcasted)
+            }
+            group.addTask {
+                await Array(broadcasted)
+            }
+            return await Array(group)
+        }
+        
+        // Then
+        #expect(results[0] == elements)
+        #expect(results[0] == results[1])
+    }
+}
+
+final class ReportingSequence<Element>: Sequence, IteratorProtocol {
+    enum Event: Equatable, CustomStringConvertible {
+        case next
+        case makeIterator
+        
+        var description: String {
+            switch self {
+            case .next: return "next()"
+            case .makeIterator: return "makeIterator()"
+            }
+        }
+    }
+    
+    var events = [Event]()
+    var elements: [Element]
+    
+    init(_ elements: [Element]) {
+        self.elements = elements
+    }
+    
+    func next() -> Element? {
+        events.append(.next)
+        guard elements.count > 0 else {
+            return nil
+        }
+        return elements.removeFirst()
+    }
+    
+    func makeIterator() -> ReportingSequence {
+        events.append(.makeIterator)
+        return self
+    }
+}
+
+final class ReportingAsyncSequence<Element: Sendable>: AsyncSequence, AsyncIteratorProtocol, @unchecked Sendable {
+    enum Event: Equatable, CustomStringConvertible {
+        case next
+        case makeAsyncIterator
+        
+        var description: String {
+            switch self {
+            case .next: return "next()"
+            case .makeAsyncIterator: return "makeAsyncIterator()"
+            }
+        }
+    }
+    
+    var events = [Event]()
+    var elements: [Element]
+    
+    init(_ elements: [Element]) {
+        self.elements = elements
+    }
+    
+    func next() async -> Element? {
+        events.append(.next)
+        guard elements.count > 0 else {
+            return nil
+        }
+        return elements.removeFirst()
+    }
+    
+    func makeAsyncIterator() -> ReportingAsyncSequence {
+        events.append(.makeAsyncIterator)
+        return self
+    }
+}
+
+struct Failure: Error, Equatable { }
+
+func throwOn<T: Equatable>(_ toThrowOn: T, _ value: T) throws -> T {
+    if value == toThrowOn {
+        throw Failure()
+    }
+    return value
+}


### PR DESCRIPTION
I must admit to some frustration, the swift-async-algorithms team has had a PR with 2 reasonable "Broadcast" algorithms for more than a year and a half without merging. There's some other really good PRs open as well. 

Given that Afluent is trying to occupy this strange space between the standard library and swift-async-algorithms this puts me in an awkward position. To get out of it I've decided to introduce an "Experimental" API. This is basically where I pull in the work that swift-async-algorithms hasn't. Expect API surfaces here to deprecate and eventually become obsoleted if and when Apple finally introduces them into the swift-async-algorithms project. 

Until then, pulling in Broadcast unlocks a host of new possibilities, such as subjects. To utilize this, simply:
`@_spi(Experimental) import Afluent` in any files where you'd like to make use of these experimental APIs