### PR TITLE
Fix Package API used for Swift 6

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,7 @@ let package = Package(name: "Afluent",
                           .testTarget(name: "AfluentTests",
                                       dependencies: testDependencies()),
                       ],
-                      swiftLanguageVersions: [.version("5.10"), .version("6")])
+                      swiftLanguageModes: [.version("5.10"), .version("6")])
 
 func testDependencies() -> [PackageDescription.Target.Dependency] {
     #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)


### PR DESCRIPTION
Update to use the non-deprecated Package API for Swift 6.

Was previously using: https://developer.apple.com/documentation/packagedescription/package/init(name:defaultlocalization:platforms:pkgconfig:providers:products:dependencies:targets:swiftlanguageversions:clanguagestandard:cxxlanguagestandard:)

Now using: https://developer.apple.com/documentation/packagedescription/package/init(name:defaultlocalization:platforms:pkgconfig:providers:products:dependencies:targets:swiftlanguagemodes:clanguagestandard:cxxlanguagestandard:)