### PR TITLE
Add task executor and priority features

### DIFF
--- a/Sources/Afluent/Additions/QueueExecutor.swift
+++ b/Sources/Afluent/Additions/QueueExecutor.swift
@@ -1,0 +1,53 @@
+//
+//  QueueExecutor.swift
+//
+//
+//  Created by Annalise Mariottini on 10/10/24.
+//
+
+import Foundation
+
+#if swift(>=6)
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+public final class QueueExecutor: TaskExecutor, Sendable, CustomStringConvertible {
+    let queue: DispatchQueue
+
+    init(queue: DispatchQueue) {
+        self.queue = queue
+    }
+
+    public func enqueue(_ job: consuming ExecutorJob) {
+        let job = UnownedJob(job)
+        queue.async {
+            job.runSynchronously(on: self.asUnownedTaskExecutor())
+        }
+    }
+
+    public var description: String {
+        "\(Self.self)\(ObjectIdentifier(self))"
+    }
+}
+
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+extension TaskExecutor where Self == QueueExecutor {
+    public static var mainQueue: QueueExecutor {
+        QueueExecutor(queue: .main)
+    }
+
+    public static func globalQueue(qos: DispatchQoS.QoSClass = .default) -> QueueExecutor {
+        QueueExecutor(queue: .global(qos: qos))
+    }
+
+    public static func queue(label: String,
+                             qos: DispatchQoS = .unspecified,
+                             attributes: DispatchQueue.Attributes = [],
+                             autoreleaseFrequency: DispatchQueue.AutoreleaseFrequency = .inherit,
+                             target: DispatchQueue? = nil) -> QueueExecutor {
+        queue(DispatchQueue(label: label, qos: qos, attributes: attributes, autoreleaseFrequency: autoreleaseFrequency, target: target))
+    }
+
+    public static func queue(_ queue: DispatchQueue) -> QueueExecutor {
+        QueueExecutor(queue: queue)
+    }
+}
+#endif

--- a/Sources/Afluent/Additions/QueueExecutor.swift
+++ b/Sources/Afluent/Additions/QueueExecutor.swift
@@ -26,16 +26,39 @@ public final class QueueExecutor: TaskExecutor, Sendable, CustomStringConvertibl
     public var description: String {
         "\(Self.self)\(ObjectIdentifier(self))"
     }
+
+    fileprivate static let main = QueueExecutor(queue: .main)
+    fileprivate static let globalBackground = QueueExecutor(queue: .global(qos: .background))
+    fileprivate static let globalUtility = QueueExecutor(queue: .global(qos: .utility))
+    fileprivate static let globalDefault = QueueExecutor(queue: .global(qos: .default))
+    fileprivate static let globalUserInitiated = QueueExecutor(queue: .global(qos: .userInitiated))
+    fileprivate static let globalUserInteractive = QueueExecutor(queue: .global(qos: .userInteractive))
+    fileprivate static let globalUnspecified = QueueExecutor(queue: .global(qos: .unspecified))
 }
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension TaskExecutor where Self == QueueExecutor {
     public static var mainQueue: QueueExecutor {
-        QueueExecutor(queue: .main)
+        QueueExecutor.main
     }
 
     public static func globalQueue(qos: DispatchQoS.QoSClass = .default) -> QueueExecutor {
-        QueueExecutor(queue: .global(qos: qos))
+        switch qos {
+        case .background:
+            return .globalBackground
+        case .utility:
+            return .globalUtility
+        case .default:
+            return .globalDefault
+        case .userInitiated:
+            return .globalUserInitiated
+        case .userInteractive:
+            return .globalUserInteractive
+        case .unspecified:
+            return .globalUnspecified
+        @unknown default:
+            return .init(queue: .global(qos: qos))
+        }
     }
 
     public static func queue(label: String,

--- a/Sources/Afluent/Protocols/AsynchronousUnitOfWork.swift
+++ b/Sources/Afluent/Protocols/AsynchronousUnitOfWork.swift
@@ -14,12 +14,23 @@ public protocol AsynchronousUnitOfWork<Success>: Sendable where Success: Sendabl
     /// The result of the operation (will execute the task)
     var result: Result<Success, Error> { get async throws }
 
-    /// Executes the task
-    func run()
+    /// Executes the task with an optional task priority.
+    func run(priority: TaskPriority?)
 
-    /// Executes the task and waits for the result.
+    /// Executes the task with an optional task priority and waits for the result.
     /// - Returns: The result of the task.
-    @discardableResult func execute() async throws -> Success
+    @discardableResult func execute(priority: TaskPriority?) async throws -> Success
+
+#if swift(>=6)
+    /// Executes the task with an optional task executor and priority.
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func run(executorPreference taskExecutor: (any TaskExecutor)?, priority: TaskPriority?)
+
+    /// Executes the task with an optional task executor and priority and waits for the result.
+    /// - Returns: The result of the task.
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    @discardableResult func execute(executorPreference taskExecutor: (any TaskExecutor)?, priority: TaskPriority?) async throws -> Success
+#endif
 
     /// Only useful when creating operators, defines the async function that should execute when the operator executes
     @Sendable func _operation() async throws -> AsynchronousOperation<Success>
@@ -32,20 +43,44 @@ extension AsynchronousUnitOfWork {
     public var result: Result<Success, Error> {
         get async throws {
             await withTaskCancellationHandler {
-                await state.createTask(operation: operation).result
+                await state.createTask(priority: nil, operation: operation).result
             } onCancel: {
                 cancel()
             }
         }
     }
 
-    public func run() {
-        state.createTask(operation: operation)
+    public func run(priority: TaskPriority? = nil) {
+        state.createTask(priority: priority, operation: operation)
     }
 
-    @discardableResult public func execute() async throws -> Success {
-        try await result.get()
+    @discardableResult public func execute(priority: TaskPriority? = nil) async throws -> Success {
+        try await withTaskCancellationHandler {
+            try await state.createTask(priority: priority, operation: operation).value
+        } onCancel: {
+            cancel()
+        }
     }
+
+#if swift(>=6)
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    public func run(executorPreference taskExecutor: (any TaskExecutor)?, priority: TaskPriority? = nil) {
+        state.createTask(taskExecutor: taskExecutor,
+                         priority: priority,
+                         operation: operation)
+    }
+
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    @discardableResult public func execute(executorPreference taskExecutor: (any TaskExecutor)?, priority: TaskPriority? = nil) async throws -> Success {
+        try await withTaskCancellationHandler {
+            try await state.createTask(taskExecutor: taskExecutor,
+                                       priority: priority,
+                                       operation: operation).value
+        } onCancel: {
+            cancel()
+        }
+    }
+#endif
 
     public func cancel() {
         state.cancel()
@@ -83,13 +118,32 @@ public final class TaskState<Success: Sendable>: @unchecked Sendable {
 
     public init() { }
 
-    @discardableResult func createTask(operation: @Sendable @escaping () async throws -> Success) -> Task<Success, Error> {
+#if swift(>=6)
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    @discardableResult func createTask(taskExecutor: (any TaskExecutor)?,
+                                       priority: TaskPriority?,
+                                       operation: @Sendable @escaping () async throws -> Success) -> Task<Success, Error> {
         guard !isCancelled else {
             let task = Task<Success, Error> { throw CancellationError() }
             task.cancel()
             return task
         }
-        let task = Task { try await operation() }
+        let task = Task(executorPreference: taskExecutor, priority: priority) { try await operation() }
+        lock.protect {
+            tasks.append(task)
+        }
+        return task
+    }
+#endif
+
+    @discardableResult func createTask(priority: TaskPriority?,
+                                       operation: @Sendable @escaping () async throws -> Success) -> Task<Success, Error> {
+        guard !isCancelled else {
+            let task = Task<Success, Error> { throw CancellationError() }
+            task.cancel()
+            return task
+        }
+        let task = Task(priority: priority) { try await operation() }
         lock.protect {
             tasks.append(task)
         }

--- a/Sources/Afluent/Subscription/AnyCancellable.swift
+++ b/Sources/Afluent/Subscription/AnyCancellable.swift
@@ -45,10 +45,19 @@ public final class AnyCancellable: Hashable, Sendable {
 
 extension AsynchronousUnitOfWork {
     /// Executes the current asynchronous unit of work and returns an AnyCancellable token to cancel the subscription
-    public func subscribe() -> AnyCancellable {
-        defer { run() }
+    public func subscribe(priority: TaskPriority? = nil) -> AnyCancellable {
+        defer { run(priority: priority) }
         return AnyCancellable(self)
     }
+
+#if swift(>=6)
+    /// Executes the current asynchronous unit of work and returns an AnyCancellable token to cancel the subscription
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    public func subscribe(executorPreference taskExecutor: (any TaskExecutor)?, priority: TaskPriority? = nil) -> AnyCancellable {
+        defer { run(executorPreference: taskExecutor, priority: priority) }
+        return AnyCancellable(self)
+    }
+#endif
 }
 
 extension AsyncSequence where Self: Sendable {

--- a/Tests/AfluentTests/QueueExecutorTests.swift
+++ b/Tests/AfluentTests/QueueExecutorTests.swift
@@ -53,26 +53,26 @@ struct QueueExecutorTests {
 
         #expect(Context.value == nil)
 
-        Context.$value.withValue(expectedValue) {
-            Task(executorPreference: .mainQueue) {
+        await Context.$value.withValue(expectedValue) {
+            await Task(executorPreference: .mainQueue) {
                 dispatchPrecondition(condition: .onQueue(.main))
                 #expect(Context.value == expectedValue)
-            }
+            }.value
         }
 
-        Context.$value.withValue(expectedValue) {
-            Task(executorPreference: .globalQueue(qos: .background)) {
+        await Context.$value.withValue(expectedValue) {
+            await Task(executorPreference: .globalQueue(qos: .background)) {
                 dispatchPrecondition(condition: .onQueue(.global(qos: .background)))
                 #expect(Context.value == expectedValue)
-            }
+            }.value
         }
 
         let queue = DispatchQueue(label: "\(String(describing: Self.self))\(UUID().uuidString)")
-        Context.$value.withValue(expectedValue) {
-            Task(executorPreference: .queue(queue)) {
+        await Context.$value.withValue(expectedValue) {
+            await Task(executorPreference: .queue(queue)) {
                 dispatchPrecondition(condition: .onQueue(queue))
                 #expect(Context.value == expectedValue)
-            }
+            }.value
         }
     }
 }

--- a/Tests/AfluentTests/QueueExecutorTests.swift
+++ b/Tests/AfluentTests/QueueExecutorTests.swift
@@ -26,5 +26,54 @@ struct QueueExecutorTests {
             dispatchPrecondition(condition: .onQueue(queue))
         }.value
     }
+
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    @Test func hasSharedMainQueueInstance() {
+        let executor1 = QueueExecutor.mainQueue
+        let executor2 = QueueExecutor.mainQueue
+        #expect(executor1 === executor2)
+    }
+
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    @Test(arguments: [
+        DispatchQoS.QoSClass.background, .default, .unspecified, .userInitiated, .userInteractive,
+    ]) func hasSharedGlobalQOSInstances(qos: DispatchQoS.QoSClass) {
+        let executor1 = QueueExecutor.globalQueue(qos: qos)
+        let executor2 = QueueExecutor.globalQueue(qos: qos)
+        #expect(executor1 === executor2)
+    }
+
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    @Test func forwardsTaskLocalsWhenUsed() async throws {
+        enum Context {
+            @TaskLocal static var value: String?
+        }
+
+        let expectedValue = UUID().uuidString
+
+        #expect(Context.value == nil)
+
+        Context.$value.withValue(expectedValue) {
+            Task(executorPreference: .mainQueue) {
+                dispatchPrecondition(condition: .onQueue(.main))
+                #expect(Context.value == expectedValue)
+            }
+        }
+
+        Context.$value.withValue(expectedValue) {
+            Task(executorPreference: .globalQueue(qos: .background)) {
+                dispatchPrecondition(condition: .onQueue(.global(qos: .background)))
+                #expect(Context.value == expectedValue)
+            }
+        }
+
+        let queue = DispatchQueue(label: "\(String(describing: Self.self))\(UUID().uuidString)")
+        Context.$value.withValue(expectedValue) {
+            Task(executorPreference: .queue(queue)) {
+                dispatchPrecondition(condition: .onQueue(queue))
+                #expect(Context.value == expectedValue)
+            }
+        }
+    }
 }
 #endif

--- a/Tests/AfluentTests/QueueExecutorTests.swift
+++ b/Tests/AfluentTests/QueueExecutorTests.swift
@@ -1,0 +1,30 @@
+//
+//  QueueExecutorTasks.swift
+//
+//
+//  Created by Annalise Mariottini on 10/10/24.
+//
+
+@testable import Afluent
+import Foundation
+import Testing
+
+#if swift(>=6)
+struct QueueExecutorTests {
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    @Test func runsOnExpectedQueue() async throws {
+        await Task.detached(executorPreference: .mainQueue) {
+            dispatchPrecondition(condition: .onQueue(.main))
+        }.value
+
+        await Task.detached(executorPreference: .globalQueue(qos: .background)) {
+            dispatchPrecondition(condition: .onQueue(.global(qos: .background)))
+        }.value
+
+        let queue = DispatchQueue(label: "\(String(describing: Self.self))\(UUID().uuidString)")
+        await Task.detached(executorPreference: .queue(queue)) {
+            dispatchPrecondition(condition: .onQueue(queue))
+        }.value
+    }
+}
+#endif

--- a/Tests/AfluentTests/QueueExecutorTests.swift
+++ b/Tests/AfluentTests/QueueExecutorTests.swift
@@ -76,4 +76,9 @@ struct QueueExecutorTests {
         }
     }
 }
+
+#if os(Linux)
+extension DispatchQoS.QoSClass: @unchecked Sendable { }
+#endif
+
 #endif

--- a/Tests/AfluentTests/WorkerTests/ExecuteOnTaskExecutorTests.swift
+++ b/Tests/AfluentTests/WorkerTests/ExecuteOnTaskExecutorTests.swift
@@ -1,0 +1,67 @@
+//
+//  ExecuteOnTaskExecutorTests.swift
+//  Afluent
+//
+//  Created by Annalise Mariottini on 10/10/24.
+//
+
+import Afluent
+import Foundation
+import Testing
+
+#if swift(>=6)
+struct ExecuteOnTaskExecutorTests {
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    @Test func testExecutesOnExpectedExecutor() async throws {
+        try await DeferredTask { }
+            .handleEvents(receiveOutput: { _ in
+                dispatchPrecondition(condition: .onQueue(.main))
+            })
+            .execute(executorPreference: .mainQueue)
+
+        try await DeferredTask { }
+            .handleEvents(receiveOutput: { _ in
+                dispatchPrecondition(condition: .onQueue(.global(qos: .background)))
+            })
+            .execute(executorPreference: .globalQueue(qos: .background))
+
+        let queue = DispatchQueue(label: "\(String(describing: Self.self))\(UUID().uuidString)")
+        try await DeferredTask { }
+            .handleEvents(receiveOutput: { _ in
+                dispatchPrecondition(condition: .onQueue(queue))
+            })
+            .execute(executorPreference: .queue(queue))
+    }
+
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    @Test func testRunsOnExpectedExecutor() async throws {
+        let (stream, continuation) = AsyncStream<Void>.makeStream()
+
+        DeferredTask { }
+            .handleEvents(receiveOutput: { _ in
+                dispatchPrecondition(condition: .onQueue(.main))
+                continuation.yield()
+            })
+            .run(executorPreference: .mainQueue)
+
+        DeferredTask { }
+            .handleEvents(receiveOutput: { _ in
+                dispatchPrecondition(condition: .onQueue(.global(qos: .background)))
+                continuation.yield()
+            })
+            .run(executorPreference: .globalQueue(qos: .background))
+
+        let queue = DispatchQueue(label: "\(String(describing: Self.self))\(UUID().uuidString)")
+        DeferredTask { }
+            .handleEvents(receiveOutput: { _ in
+                dispatchPrecondition(condition: .onQueue(queue))
+                continuation.yield()
+            })
+            .run(executorPreference: .queue(queue))
+
+        for await _ in stream.chunks(ofCount: 3) {
+            break
+        }
+    }
+}
+#endif

--- a/Tests/AfluentTests/WorkerTests/ExecutePriorityTests.swift
+++ b/Tests/AfluentTests/WorkerTests/ExecutePriorityTests.swift
@@ -1,0 +1,45 @@
+//
+//  ExecutePriorityTests.swift
+//  Afluent
+//
+//  Created by Annalise Mariottini on 10/10/24.
+//
+
+import Afluent
+import Foundation
+@_spi(Experimental) import Testing
+
+#if swift(>=6)
+struct ExecutePriorityTests {
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    @Test(.serialized, arguments: [TaskPriority.background, .low, .medium, .high, .userInitiated].map(\.rawValue))
+    func testExecutesWithExpectedPriority(priority: UInt8) async throws {
+        let executor = TestExecutor()
+        try await DeferredTask { }
+            .execute(executorPreference: executor, priority: TaskPriority(rawValue: priority))
+        let receivedPriority = try await executor.receivedPriority.execute()
+        #expect(receivedPriority == priority)
+    }
+
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    @Test(.serialized, arguments: [TaskPriority.background, .low, .medium, .high, .userInitiated].map(\.rawValue))
+    func testRunsWithExpectedPriority(priority: UInt8) async throws {
+        let executor = TestExecutor()
+        DeferredTask { }
+            .run(executorPreference: executor, priority: TaskPriority(rawValue: priority))
+        let receivedPriority = try await executor.receivedPriority.execute()
+        #expect(receivedPriority == priority)
+    }
+}
+
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+private final class TestExecutor: TaskExecutor, Sendable {
+    init() { }
+    let receivedPriority = SingleValueSubject<UInt8>()
+
+    func enqueue(_ job: consuming ExecutorJob) {
+        try? self.receivedPriority.send(job.priority.rawValue)
+        job.runSynchronously(on: self.asUnownedTaskExecutor())
+    }
+}
+#endif


### PR DESCRIPTION
## Description

This PR adds the ability to specify a [task executor preference](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0417-task-executor-preference.md) and task priority. Note that the former is only available with Swift 6.

Additionally, a `QueueExecutor` implementation of `TaskExecutor` has been added that allows for Tasks to be executed with GCD while still retaining the benefits of using Swift concurrency (e.g. `TaskLocal` values).

## Details

The `run` and `execute` APIs on `AsynchronousUnitOfWork` have additional parameters added to forward a `taskExecutor` and `priority`. Calling without any arguments is still supported. By providing these parameters, the work is executed with the specified parameters.

The addition of a `QueueExecutor` additionally allows for consumers to schedule work with GCD if necessary, while still using Swift concurrency as the main mechanism for execution.

This bit from the "Task Executor Preference" evolution doc I think helps explain the role of `TaskExecutor` types:
> As an intuitive way to think about TaskExecutor and SerialExecutor, one can think of the prior as being a "source of threads" to execute work on, and the latter being something that "provides serial isolation" and is a crucial part of Swift actors. The two share similarities, however the task executor has a more varied application space.
[Link](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0417-task-executor-preference.md#:~:text=As%20an%20intuitive,varied%20application%20space.)

If it seems ill-advised to add a GCD-based type here, I'm open to leaving off the `QueueExecutor` type from this PR. However, I thought it was a useful exercise to demonstrate that we can have GCD-based scheduling used while still primarily relying on Swift concurrency. In particular, even though the executor is GCD-based, it is still forwarded when structured concurrency is used. Also note that we still have access to `TaskLocal` values as well.

E.g.
```swift
func doSomethingAsync() async {
  // this will be run on the background dispatch queue
}
Task(executorPreference: .globalQueue(qos: .background)) {
  async let work = doSomethingAsync()
  await work
}
```