### PR TITLE
Added PassthroughSubject

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,8 +11,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    container: swift:5.10
+    container: swift:6.0
     steps:
       - uses: actions/checkout@v4
       - name: Run TESTS
-        run: swift test
+        run: swift test --use-integrated-swift-driver

--- a/.github/workflows/PR_CI.yml
+++ b/.github/workflows/PR_CI.yml
@@ -5,15 +5,15 @@ on: [ workflow_dispatch, pull_request ]
 jobs:
   test:
     runs-on: ubuntu-latest
-    container: swift:5.10
+    container: swift:6.0
     steps:
       - uses: actions/checkout@v4
       - name: Run TESTS
-        run: swift test
-  test_future:
-    runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-6.0-jammy
-    steps:
-      - uses: actions/checkout@v4
-      - name: Run TESTS on Swift 6
         run: swift test --use-integrated-swift-driver
+  # test_future:
+  #   runs-on: ubuntu-latest
+  #   container: swiftlang/swift:nightly-6.0-jammy
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - name: Run TESTS on Swift 6
+  #       run: swift test --use-integrated-swift-driver

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -8,11 +8,11 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    container: swift:5.10
+    container: swift:6.0
     steps:
       - uses: actions/checkout@v4
       - name: Run TESTS
-        run: swift test
+        run: swift test --use-integrated-swift-driver
   deploy:
     needs: test
     runs-on: ubuntu-22.04

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,6 @@ let package = Package(name: "Afluent",
                           .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.52.11"),
                           .package(url: "https://github.com/pointfreeco/swift-clocks.git", from: "1.0.2"),
                           .package(url: "https://github.com/pointfreeco/swift-concurrency-extras.git", from: "1.1.0"),
-                          .package(url: "https://github.com/apple/swift-testing.git", from: "0.10.0"),
                           .package(url: "https://github.com/apple/swift-async-algorithms.git", from: "1.0.0"),
                       ],
                       targets: [
@@ -41,14 +40,12 @@ func testDependencies() -> [PackageDescription.Target.Dependency] {
             .product(name: "OHHTTPStubsSwift", package: "OHHTTPStubs"),
             .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
             .product(name: "Clocks", package: "swift-clocks"),
-            .product(name: "Testing", package: "swift-testing"),
         ]
     #else
         [
             "Afluent",
             .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
             .product(name: "Clocks", package: "swift-clocks"),
-            .product(name: "Testing", package: "swift-testing"),
         ]
     #endif
 }

--- a/Sources/Afluent/PassthroughSubject.swift
+++ b/Sources/Afluent/PassthroughSubject.swift
@@ -1,0 +1,73 @@
+//
+//  PassthroughSubject.swift
+//  Afluent
+//
+//  Created by Tyler Thompson on 10/12/24.
+//
+
+import Atomics
+
+@_spi(Experimental) public final class PassthroughSubject<Element: Sendable>: AsyncSequence, @unchecked Sendable {
+    private let continuation: AsyncThrowingStream<Element, any Error>.Continuation
+    private let streamIterator: () -> AsyncBroadcastSequence<AsyncThrowingStream<Element, any Error>>.AsyncIterator
+    private let finished: ManagedAtomic<Bool> = .init(false)
+    private let finishedSubject = SingleValueSubject<Void>()
+    
+    public init() {
+        let (s, c) = AsyncThrowingStream<Element, any Error>.makeStream()
+        continuation = c
+        let shared = s.share()
+        streamIterator = { shared.makeAsyncIterator() }
+    }
+    
+    public class Iterator: AsyncIteratorProtocol, @unchecked Sendable {
+        var upstream: AsyncBroadcastSequence<AsyncThrowingStream<Element, any Error>>.AsyncIterator
+        let finished: @Sendable () async throws -> Void
+        
+        init(upstream: AsyncBroadcastSequence<AsyncThrowingStream<Element, any Error>>.AsyncIterator, finished: @Sendable @escaping () async throws -> Void) {
+            self.upstream = upstream
+            self.finished = finished
+        }
+        
+        public func next() async throws -> Element? {
+            return try await Race {
+                try await finished()
+                return nil
+            } against: {
+                try await self.upstream.next()
+            }
+        }
+    }
+    
+    public func makeAsyncIterator() -> AsyncBroadcastSequence<AsyncThrowingStream<Element, any Error>>.AsyncIterator {
+        streamIterator()
+//        Iterator(upstream: streamIterator(), finished: { try await self.finishedSubject.execute() })
+    }
+    
+    public func send(_ element: Element) {
+        guard !finished.load(ordering: .sequentiallyConsistent) else { return }
+        continuation.yield(element)
+    }
+    
+    public func send() where Element == Void {
+        
+    }
+    
+    public func send(completion: Completion<any Error>) {
+        defer {
+            finished.store(true, ordering: .sequentiallyConsistent)
+            try? finishedSubject.send()
+        }
+        switch completion {
+        case .finished: continuation.finish()
+        case .failure(let error): break
+        }
+    }
+}
+
+@_spi(Experimental) extension PassthroughSubject {
+    public enum Completion<Failure: Error> {
+        case finished
+        case failure(Failure)
+    }
+}

--- a/Sources/Afluent/PassthroughSubject.swift
+++ b/Sources/Afluent/PassthroughSubject.swift
@@ -19,7 +19,6 @@ import Atomics
     private let continuation: AsyncThrowingStream<Element, any Error>.Continuation
     private let streamIterator: () -> AsyncBroadcastSequence<AsyncThrowingStream<Element, any Error>>.AsyncIterator
     private let state = State()
-    private let finished: ManagedAtomic<Bool> = .init(false)
     
     public init() {
         let (s, c) = AsyncThrowingStream<Element, any Error>.makeStream()

--- a/Sources/Afluent/PassthroughSubject.swift
+++ b/Sources/Afluent/PassthroughSubject.swift
@@ -8,8 +8,17 @@
 import Atomics
 
 @_spi(Experimental) public final class PassthroughSubject<Element: Sendable>: AsyncSequence, @unchecked Sendable {
+    private class State: @unchecked Sendable {
+        private let lock = Lock.allocate()
+        private var _finishedResult: Result<Element?, any Error>?
+        var finishedResult: Result<Element?, any Error>? {
+            get { lock.withLock { _finishedResult } }
+            set { lock.withLockVoid { _finishedResult = newValue } }
+        }
+    }
     private let continuation: AsyncThrowingStream<Element, any Error>.Continuation
     private let streamIterator: () -> AsyncBroadcastSequence<AsyncThrowingStream<Element, any Error>>.AsyncIterator
+    private let state = State()
     private let finished: ManagedAtomic<Bool> = .init(false)
     
     public init() {
@@ -21,33 +30,37 @@ import Atomics
     
     public struct Iterator: AsyncIteratorProtocol, @unchecked Sendable {
         var upstream: AsyncBroadcastSequence<AsyncThrowingStream<Element, any Error>>.AsyncIterator
-        let finished: Bool
+        let finished: Result<Element?, any Error>?
         
         public mutating func next() async throws -> Element? {
-            guard !finished else { return nil }
+            guard finished == nil else { return try finished?.get() }
             return try await upstream.next()
         }
     }
     
     public func makeAsyncIterator() -> Iterator {
-        .init(upstream: streamIterator(), finished: finished.load(ordering: .sequentiallyConsistent))
-//        streamIterator()
+        .init(upstream: streamIterator(), finished: state.finishedResult)
     }
     
     public func send(_ element: Element) {
-        guard !finished.load(ordering: .sequentiallyConsistent) else { return }
+        guard state.finishedResult == nil else { return }
         continuation.yield(element)
     }
     
     public func send() where Element == Void {
-        
+        guard state.finishedResult == nil else { return }
+        continuation.yield()
     }
     
     public func send(completion: Completion<any Error>) {
-        defer { finished.store(true, ordering: .sequentiallyConsistent) }
+        guard state.finishedResult == nil else { return }
         switch completion {
-        case .finished: continuation.finish()
-        case .failure(let error): break
+        case .finished:
+            defer { state.finishedResult = .success(nil) }
+            continuation.finish()
+        case .failure(let error):
+            defer { state.finishedResult = .failure(error) }
+            continuation.finish(throwing: error)
         }
     }
 }

--- a/Tests/AfluentTests/PassthroughSubjectTests.swift
+++ b/Tests/AfluentTests/PassthroughSubjectTests.swift
@@ -142,4 +142,104 @@ struct PassthroughSubjectTests {
 
         #expect(await test.values == [1, 2, 3])
     }
+    
+    @Test func passthroughSubjectCanCompleteWithError() async throws {
+        enum Err: Error, Equatable {
+            case e1
+        }
+        
+        actor Test {
+            var values = [Int]()
+            func appendValue(_ value: Int) {
+                values.append(value)
+            }
+        }
+        let test = Test()
+        let subject = PassthroughSubject<Int>()
+        let taskStartedSubject = SingleValueSubject<Void>()
+
+        let task = Task {
+            for try await value in subject {
+                try? taskStartedSubject.send()
+                await test.appendValue(value)
+            }
+        }
+        
+        #expect(await test.values.isEmpty)
+        
+        subject.send(1)
+        try await taskStartedSubject.execute()
+        subject.send(completion: .failure(Err.e1))
+        subject.send(3)
+        subject.send(completion: .finished)
+        
+        let task1Result = await task.result
+        try #require(throws: Err.e1, performing: { try task1Result.get() })
+        
+        let task2StartedSubject = SingleValueSubject<Void>()
+        let task2 = Task {
+            for try await value in subject.handleEvents(receiveMakeIterator: {
+                try? task2StartedSubject.send()
+            }) {
+                await test.appendValue(value)
+            }
+        }
+
+        try await task2StartedSubject.execute()
+
+        subject.send(4)
+        
+        let task2Result = await task2.result
+        try #require(throws: Err.e1, performing: { try task2Result.get() })
+
+        #expect(await test.values == [1])
+    }
+    
+    @Test func passthroughSubjectCanSendVoidValues() async throws {
+        actor Test {
+            var count = 0
+            func appendValue() {
+                count += 1
+            }
+        }
+        let test = Test()
+        let subject = PassthroughSubject<Void>()
+        let taskStartedSubject = SingleValueSubject<Void>()
+
+        let task = Task {
+            for try await _ in subject.handleEvents(receiveMakeIterator: {
+                try? taskStartedSubject.send()
+            }) {
+                await test.appendValue()
+            }
+        }
+        
+        try await taskStartedSubject.execute()
+
+        #expect(await test.count == 0)
+        
+        subject.send()
+        subject.send()
+        subject.send()
+        subject.send(completion: .finished)
+        
+        _ = try await task.value
+        
+        let task2StartedSubject = SingleValueSubject<Void>()
+        let task2 = Task {
+            for try await _ in subject.handleEvents(receiveMakeIterator: {
+                try? task2StartedSubject.send()
+            }) {
+                await test.appendValue()
+            }
+        }
+
+        try await task2StartedSubject.execute()
+
+        subject.send()
+        
+        _ = try await task2.value
+
+        #expect(await test.count == 3)
+    }
 }

--- a/Tests/AfluentTests/PassthroughSubjectTests.swift
+++ b/Tests/AfluentTests/PassthroughSubjectTests.swift
@@ -1,0 +1,119 @@
+//
+//  PassthroughSubjectTests.swift
+//  Afluent
+//
+//  Created by Tyler Thompson on 10/12/24.
+//
+
+import Testing
+@_spi(Experimental) import Afluent
+
+struct PassthroughSubjectTests {
+    @Test func passthroughSubjectCanSendValuesAndFinish() async throws {
+        actor Test {
+            var values = [Int]()
+            func appendValue(_ value: Int) {
+                values.append(value)
+            }
+        }
+        let test = Test()
+        let subject = PassthroughSubject<Int>()
+        
+        let task = Task {
+            for try await value in subject {
+                await test.appendValue(value)
+            }
+        }
+        
+        #expect(await test.values.isEmpty)
+        
+        subject.send(1)
+        subject.send(2)
+        subject.send(3)
+        subject.send(completion: .finished)
+        
+        _ = try await task.value
+        
+        #expect(await test.values == [1, 2, 3])
+    }
+    
+    @Test func passthroughSubjectCanSendValues_ToMultipleConsumers_AndFinish() async throws {
+        actor Test {
+            var values = [Int]()
+            func appendValue(_ value: Int) {
+                values.append(value)
+            }
+        }
+        let test = Test()
+        let test2 = Test()
+        let subject = PassthroughSubject<Int>()
+        
+        let task = Task {
+            for try await value in subject {
+                await test.appendValue(value)
+            }
+        }
+        
+        let task2 = Task {
+            for try await value in subject {
+                await test2.appendValue(value)
+            }
+        }
+        
+        #expect(await test.values.isEmpty)
+        #expect(await test2.values.isEmpty)
+
+        subject.send(1)
+        subject.send(2)
+        subject.send(3)
+        subject.send(completion: .finished)
+        
+        _ = try await task.value
+        _ = try await task2.value
+
+        let v = await test.values
+        let v2 = await test2.values
+        print(v)
+        print(v2)
+        #expect(await test.values == [1, 2, 3])
+        #expect(await test2.values == [1, 2, 3])
+    }
+    
+//    @Test func passthroughSubjectStopsSendingValuesUponFinish() async throws {
+//        actor Test {
+//            var values = [Int]()
+//            func appendValue(_ value: Int) {
+//                values.append(value)
+//            }
+//        }
+//        let test = Test()
+//        let subject = PassthroughSubject<Int>()
+//        
+//        let task = Task {
+//            for try await value in subject {
+//                await test.appendValue(value)
+//            }
+//        }
+//        
+//        #expect(await test.values.isEmpty)
+//        
+//        subject.send(1)
+//        subject.send(2)
+//        subject.send(3)
+//        subject.send(completion: .finished)
+//        
+//        _ = try await task.value
+//        
+//        let task2 = Task {
+//            for try await value in subject {
+//                await test.appendValue(value)
+//            }
+//        }
+//        
+//        subject.send(4)
+//        
+//        _ = try await task2.value
+//
+//        #expect(await test.values == [1, 2, 3])
+//    }
+}

--- a/Tests/AfluentTests/PassthroughSubjectTests.swift
+++ b/Tests/AfluentTests/PassthroughSubjectTests.swift
@@ -90,47 +90,56 @@ struct PassthroughSubjectTests {
 
         let v = await test.values
         let v2 = await test2.values
-        print(v)
-        print(v2)
+
         #expect(await test.values == [1, 2, 3])
         #expect(await test2.values == [1, 2, 3])
     }
     
-//    @Test func passthroughSubjectStopsSendingValuesUponFinish() async throws {
-//        actor Test {
-//            var values = [Int]()
-//            func appendValue(_ value: Int) {
-//                values.append(value)
-//            }
-//        }
-//        let test = Test()
-//        let subject = PassthroughSubject<Int>()
-//        
-//        let task = Task {
-//            for try await value in subject {
-//                await test.appendValue(value)
-//            }
-//        }
-//        
-//        #expect(await test.values.isEmpty)
-//        
-//        subject.send(1)
-//        subject.send(2)
-//        subject.send(3)
-//        subject.send(completion: .finished)
-//        
-//        _ = try await task.value
-//        
-//        let task2 = Task {
-//            for try await value in subject {
-//                await test.appendValue(value)
-//            }
-//        }
-//        
-//        subject.send(4)
-//        
-//        _ = try await task2.value
-//
-//        #expect(await test.values == [1, 2, 3])
-//    }
+    @Test func passthroughSubjectStopsSendingValuesUponFinish() async throws {
+        actor Test {
+            var values = [Int]()
+            func appendValue(_ value: Int) {
+                values.append(value)
+            }
+        }
+        let test = Test()
+        let subject = PassthroughSubject<Int>()
+        let taskStartedSubject = SingleValueSubject<Void>()
+
+        let task = Task {
+            for try await value in subject.handleEvents(receiveMakeIterator: {
+                try? taskStartedSubject.send()
+            }) {
+                await test.appendValue(value)
+            }
+        }
+        
+        try await taskStartedSubject.execute()
+
+        #expect(await test.values.isEmpty)
+        
+        subject.send(1)
+        subject.send(2)
+        subject.send(3)
+        subject.send(completion: .finished)
+        
+        _ = try await task.value
+        
+        let task2StartedSubject = SingleValueSubject<Void>()
+        let task2 = Task {
+            for try await value in subject.handleEvents(receiveMakeIterator: {
+                try? task2StartedSubject.send()
+            }) {
+                await test.appendValue(value)
+            }
+        }
+
+        try await task2StartedSubject.execute()
+
+        subject.send(4)
+        
+        _ = try await task2.value
+
+        #expect(await test.values == [1, 2, 3])
+    }
 }


### PR DESCRIPTION
This PR adds a much needed PassthroughSubject to Afluent! This mimics the behavior of Combine's PassthroughSubject and supports multiple consumers. 