### PR TITLE
Fix ExecutePriorityTests

### DIFF
--- a/Tests/AfluentTests/WorkerTests/ExecutePriorityTests.swift
+++ b/Tests/AfluentTests/WorkerTests/ExecutePriorityTests.swift
@@ -23,12 +23,15 @@ struct ExecutePriorityTests {
         // https://forums.swift.org/t/taskpriority-of-task-groups-child-tasks/74877/4
         // https://forums.swift.org/t/task-priority-elevation-for-task-groups-and-async-let/61100
 
+        // One more caveat: it appears Task.currentPriority may change while a Task is executing
+        // This behavior is difficult to test, so we're avoiding checking Task.currentPriority for this test
+        // since we more care about the priority we asked for, not necessarily the one the work actually has
+
         let expectedCurrentPriority = max(Task.currentPriority, priority)
 
         try await DeferredTask { }
             .handleEvents(receiveOutput: {
                 #expect(Task.basePriority == priority)
-                #expect(Task.currentPriority == expectedCurrentPriority)
                 try completed.send()
             })
             .execute(priority: priority)


### PR DESCRIPTION
## Issue

We encountered some flakes in the `ExecutePriorityTest.executesWithExpectedPriority` test case when the expected `currentPriority` was incorrect.

## Investigation

I _believe_ this has to do with the `currentPriority` changing while a Task is executing.
It appears that [Swift's own tests around priority escalation](https://github.com/swiftlang/swift/blob/f6a0f5527db09da6b50c3ea4040207bf9244ba65/test/Concurrency/async_task_priority.swift#L107) need to wait for priority to be escalated while the Task is executing.

## Fix

I did try out a fix that waited for the Task's priority to match what we expected, but even with a 100 millisecond timeout, this sometimes was not enough time.

Since this test is really about testing the priority we asked for, not necessarily the one we get, I decided to ignore what Swift sets the `currentPriority` to, and just check the `basePriority`.

Note that the other tests in this suite do not have issues, because they do not have escalated priority to deal with (since they're not awaited in the test context).

