### PR TITLE
Adds Timeout error type

### DIFF
--- a/Sources/Afluent/Errors/TimeoutError.swift
+++ b/Sources/Afluent/Errors/TimeoutError.swift
@@ -1,0 +1,37 @@
+//
+//  TimeoutError.swift
+//
+//
+//  Created by Annalise Mariottini on 11/7/24.
+//
+
+import Foundation
+
+/// An error indicating a timeout has occurred.
+///
+/// Potentially thrown by ``AsynchronousUnitOfWork/timeout(_:customError:)`` and ``AsynchronousUnitOfWork/timeout(_:clock:tolerance:customError:)``.
+public enum TimeoutError: Swift.Error, LocalizedError {
+    /// A timeout occurred, with the duration timeout.
+    ///
+    /// Checking two `timedOut` cases for equality does not consider the `duration`.
+    case timedOut(duration: any DurationProtocol)
+
+    /// A timeout occurred, with no specific duration.
+    ///
+    /// Can be used to easily check if some existential error is a ``TimeoutError/timedOut(duration:)`` error.
+    public static var timedOut: Self { .timedOut(duration: Duration.zero) }
+
+    public var errorDescription: String? {
+        switch self {
+        case .timedOut(let duration): return "Timed out after waiting \(duration)"
+        }
+    }
+}
+
+extension TimeoutError: Equatable {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        switch (lhs, rhs) {
+        case (.timedOut, .timedOut): return true
+        }
+    }
+}

--- a/Tests/AfluentTests/WorkerTests/TimeoutTests.swift
+++ b/Tests/AfluentTests/WorkerTests/TimeoutTests.swift
@@ -42,6 +42,27 @@ struct TimeoutTests {
     }
 
     @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
+    @Test func taskTimesOutIfItTakesTooLong_AndCanCatchTimeoutError() async throws {
+        let clock = TestClock()
+
+        let task = Task {
+            try await DeferredTask { "test" }
+                .delay(for: .milliseconds(20), clock: clock)
+                .timeout(.milliseconds(10), clock: clock)
+                .catch(TimeoutError.timedOut) { error in
+                    DeferredTask { "caught" }
+                }
+                .execute()
+        }
+
+        await clock.advance(by: .milliseconds(11))
+
+        let val = try await task.value
+
+        #expect(val == "caught")
+    }
+
+    @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
     @Test func taskTimesOutIfItTakesTooLong_WithCustomError() async throws {
         let clock = TestClock()
 

--- a/Tests/AfluentTests/WorkerTests/TimeoutTests.swift
+++ b/Tests/AfluentTests/WorkerTests/TimeoutTests.swift
@@ -36,7 +36,9 @@ struct TimeoutTests {
         await clock.advance(by: .milliseconds(11))
 
         let res = await task.result
-        #expect(throws: (any Error).self) { try res.get() }
+        #expect { try res.get() } throws: { error in 
+            error.localizedDescription == "Timed out after waiting \(Duration.milliseconds(10))"
+        }
     }
 
     @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)


### PR DESCRIPTION
## Description

The use of `CancellationError` by the `Timeout` type makes it difficult to discern when a timeout has occurred v.s. when some work has been cancelled via other methods.

This MR proposes that we change the error thrown to a specific `Error` type that makes it clear that failure occurred due to timeout.

When thrown, the localized description takes the form: `Timed out after waiting 0.01 seconds` (example)