### PR TITLE
Fix GITHUB_TOKEN in workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,6 @@ jobs:
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs
  

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -27,7 +27,7 @@ jobs:
       id: bump_version
       uses: anothrNick/github-tag-action@1.67.0
       env:
-        GITHUB_TOKEN: ${{ secrets.TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         WITH_V: false
         DEFAULT_BUMP: patch
         RELEASE_BRANCHES: main
@@ -37,5 +37,5 @@ jobs:
       with:
         tag_name: ${{ steps.bump_version.outputs.new_tag }}
         name: Release ${{ steps.bump_version.outputs.new_tag }}
-        token: ${{ secrets.TOKEN }}
+        token: ${{ secrets.GITHUB_TOKEN }}
         discussion_category_name: Releases


### PR DESCRIPTION
The [latest deploy](https://github.com/Tyler-Keith-Thompson/Afluent/actions/runs/11727458864/job/32672558023) failed due to a 401 on tagging. Taking a closer look, it seems we're using `secrets.TOKEN` for the auth token. According to [GitHub's docs](https://github.com/Tyler-Keith-Thompson/Afluent/actions/runs/11727458864/job/32672558023), we should be using `secrets.GITHUB_TOKEN`.

I'm not sure if `secrets.TOKEN` used to be the correct method, but was changed? I'm not intimately familiar with GitHub workflows, just going off the docs.