### PR TITLE
Add TimerSequence type

### DIFF
--- a/Sources/Afluent/SequenceOperators/TimerSequence.swift
+++ b/Sources/Afluent/SequenceOperators/TimerSequence.swift
@@ -9,7 +9,7 @@ import Foundation
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
 extension AsyncSequences {
-    /// A sequence that repeatedly emits a time duration offsetn on a given interval.
+    /// A sequence that repeatedly emits an instant on a given interval.
     public struct TimerSequence<C: Clock>: AsyncSequence, Sendable {
         public typealias Element = C.Instant
 

--- a/Sources/Afluent/SequenceOperators/TimerSequence.swift
+++ b/Sources/Afluent/SequenceOperators/TimerSequence.swift
@@ -56,7 +56,7 @@ public typealias TimerSequence = AsyncSequences.TimerSequence
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
 extension TimerSequence where C == ContinuousClock {
-    /// Returns a sequence that repeatedly emits the current offset of a continuous clock on the given interval.
+    /// Returns a sequence that repeatedly emits an instant of a continuous clock on the given interval.
     ///
     /// - Parameters:
     ///   - interval: The time interval on which to publish events. For example, a value of `.milliseconds(1)` will publish an event approximately every 0.01 seconds.
@@ -70,7 +70,7 @@ extension TimerSequence where C == ContinuousClock {
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
 extension TimerSequence {
-    /// Returns a sequence that repeatedly emits the current offset of the passed clock on the given interval.
+    /// Returns a sequence that repeatedly emits an instant of the passed clock on the given interval.
     ///
     /// - Parameters:
     ///   - interval: The time interval on which to publish events. For example, a value of `.milliseconds(1)` will publish an event approximately every 0.01 seconds.

--- a/Sources/Afluent/SequenceOperators/TimerSequence.swift
+++ b/Sources/Afluent/SequenceOperators/TimerSequence.swift
@@ -1,0 +1,84 @@
+//
+//  TimerSequence.swift
+//  Afluent
+//
+//  Created by Annalise Mariottini on 11/9/24.
+//
+
+import Foundation
+
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
+extension AsyncSequences {
+    /// A sequence that repeatedly emits a time duration offsetn on a given interval.
+    public struct TimerSequence<C: Clock>: AsyncSequence, Sendable {
+        public typealias Element = C.Instant
+
+        init(interval: C.Duration, tolerance: C.Duration?, clock: C) {
+            self.interval = interval
+            self.tolerance = tolerance
+            self.clock = clock
+        }
+
+        private let interval: C.Duration
+        private let tolerance: C.Duration?
+        private let clock: C
+
+        public struct AsyncIterator: AsyncIteratorProtocol {
+            private var cancellables: Set<AnyCancellable> = []
+
+            init(interval: C.Duration, tolerance: C.Duration?, clock: C) {
+                let (stream, continuation) = AsyncStream<C.Instant>.makeStream()
+                self.iterator = stream.makeAsyncIterator()
+
+                DeferredTask {
+                    while true {
+                        try await clock.sleep(for: interval, tolerance: tolerance)
+                        continuation.yield(clock.now)
+                    }
+                }.subscribe().store(in: &cancellables)
+            }
+
+            private var iterator: AsyncStream<Element>.Iterator
+
+            public mutating func next() async -> Element? {
+                await iterator.next()
+            }
+        }
+
+        public func makeAsyncIterator() -> AsyncIterator {
+            AsyncIterator(interval: interval, tolerance: tolerance, clock: clock)
+        }
+    }
+}
+
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
+public typealias TimerSequence = AsyncSequences.TimerSequence
+
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
+extension TimerSequence where C == ContinuousClock {
+    /// Returns a sequence that repeatedly emits the current offset of a continuous clock on the given interval.
+    ///
+    /// - Parameters:
+    ///   - interval: The time interval on which to publish events. For example, a value of `.milliseconds(1)` will publish an event approximately every 0.01 seconds.
+    ///   - tolerance: The allowed timing variance when emitting events. Defaults to `nil`, which will schedule with the default tolerance strategy.
+    public static func publish(every interval: C.Duration, tolerance: C.Duration? = nil)
+        -> AsyncSequences.TimerSequence<C>
+    {
+        AsyncSequences.TimerSequence(interval: interval, tolerance: tolerance, clock: .init())
+    }
+}
+
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
+extension TimerSequence {
+    /// Returns a sequence that repeatedly emits the current offset of the passed clock on the given interval.
+    ///
+    /// - Parameters:
+    ///   - interval: The time interval on which to publish events. For example, a value of `.milliseconds(1)` will publish an event approximately every 0.01 seconds.
+    ///   - tolerance: The allowed timing variance when emitting events. Defaults to `nil`, which will schedule with the default tolerance strategy.
+    ///   - clock: The clock instance to utilize for sequence timing. For example, `ContinuousClock` or `SuspendingClock`.
+    public static func publish(every interval: C.Duration, tolerance: C.Duration? = nil, clock: C)
+        -> AsyncSequences.TimerSequence<C>
+    {
+        AsyncSequences.TimerSequence(interval: interval, tolerance: tolerance, clock: clock)
+    }
+}

--- a/Tests/AfluentTests/SequenceTests/TimerSequenceTests.swift
+++ b/Tests/AfluentTests/SequenceTests/TimerSequenceTests.swift
@@ -152,7 +152,6 @@ struct TimerSequenceTests {
                     }
                 }
             let actualOutput = await testOutput.output
-            print(actualOutput)
             #expect(actualOutput == expectedOutput)
 
             task.cancel()

--- a/Tests/AfluentTests/SequenceTests/TimerSequenceTests.swift
+++ b/Tests/AfluentTests/SequenceTests/TimerSequenceTests.swift
@@ -5,7 +5,7 @@
 //  Created by Annalise Mariottini on 11/9/24.
 //
 
-import Afluent
+@_spi(Experimental) import Afluent
 import Atomics
 import Clocks
 import ConcurrencyExtras
@@ -84,6 +84,123 @@ struct TimerSequenceTests {
 
         task1.cancel()
         task2.cancel()
+    }
+
+    // For this test case, we want to test infrequent demand that occurs off of the interval of the publisher
+    // In this specific test, we have a publisher emitting every 0.01 seconds
+    // But we only await the next value every 0.015 seconds
+    // The first element emitted will be at 0.01, but every element after that will "skew" to the cadence of the demand
+    // E.g. [0.01, 0.025, 0.04, 0.055, 0.07, 0.085, ...]
+    @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
+    @Test(arguments: [10])
+    func timerSequencePublishesOnInterval_whenNotContinuouslySubscribed(expectedCount: Int)
+        async throws
+    {
+        try await withMainSerialExecutor {
+            let testClock = TestClock()
+            let testOutput = TestOutput()
+
+            let skew = 1.5
+            let skewAmount = skew - 1.0
+
+            final class Wrapper<Iterator: AsyncIteratorProtocol>: @unchecked Sendable
+            where Iterator.Element: Sendable {
+                init(_ iterator: Iterator) {
+                    self.iterator = iterator
+                }
+                var iterator: Iterator
+                var nextCalled = PassthroughSubject<Void>()
+
+                func next() async throws -> Iterator.Element? {
+                    let task = Task {
+                        try await iterator.next()
+                    }
+                    await Task.yield()
+                    nextCalled.send()
+                    return try await task.value
+                }
+            }
+
+            let wrappedIterator = Wrapper(
+                TimerSequence.publish(every: .milliseconds(10), clock: testClock)
+                    .makeAsyncIterator())
+
+            let task = Task {
+                for _ in 0..<expectedCount {
+                    if let output = try await wrappedIterator.next() {
+                        await testOutput.append(output)
+                        await testClock.advance(by: .milliseconds(10) * skew)
+                    }
+                }
+            }
+
+            try await wrappedIterator.nextCalled.first()
+            await testClock.advance(by: .milliseconds(10) * skew)
+            try await wait(
+                until: await testOutput.output.count == expectedCount, timeout: .seconds(1))
+
+            let expectedOutput: [TestClock<Duration>.Instant] = Array(1...expectedCount)
+                .map {
+                    switch $0 {
+                        case 1:
+                            return .init(offset: .milliseconds(10))
+                        default:
+                            let multiplier = Double($0) * skew
+                            return .init(
+                                offset: .milliseconds(10 * multiplier)
+                                    - .milliseconds(10 * skewAmount))
+                    }
+                }
+            let actualOutput = await testOutput.output
+            print(actualOutput)
+            #expect(actualOutput == expectedOutput, "Unexpected output \(actualOutput)")
+
+            task.cancel()
+        }
+    }
+
+    @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
+    @Test(arguments: 1...10)
+    func timerSequencePublishesOnInterval_whenTimePassesBetweeIteratorCreationAndActualDemand(
+        expectedCount: Int
+    ) async throws {
+        let testClock = TestClock()
+        let testOutput = TestOutput()
+
+        let sequence = TimerSequence.publish(every: .milliseconds(10), clock: testClock)
+
+        let initialWaitIntervals = 5
+        let clockAdvanced = SingleValueSubject<Void>()
+
+        let task = Task {
+            var iterator = sequence.makeAsyncIterator()
+            await testClock.advance(by: .milliseconds(10) * initialWaitIntervals)
+            try clockAdvanced.send()
+            while let output = await iterator.next() {
+                await testOutput.append(output)
+            }
+        }
+
+        try await clockAdvanced.execute()
+        // this wait should fail, since the time interval advance occurred _before_ next() was called
+        await #expect(throws: TimeoutError.timedOut) {
+            try await wait(
+                until: await testOutput.output.count == initialWaitIntervals,
+                timeout: .milliseconds(1))
+        }
+        // now we advance the clock to our expected count interval amount
+        await testClock.advance(by: .milliseconds(10) * expectedCount)
+        try await wait(
+            until: await testOutput.output.count == expectedCount, timeout: .milliseconds(1))
+
+        // since time advanced before demand, there will be some initial offset in the output
+        let expectedOutput: [TestClock<Duration>.Instant] = Array(1...expectedCount)
+            .map { $0 + initialWaitIntervals }
+            .map { .init(offset: .milliseconds(10) * $0) }
+        let actualOutput = await testOutput.output
+        #expect(actualOutput == expectedOutput, "Unexpected output \(actualOutput)")
+
+        task.cancel()
     }
 
     @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)

--- a/Tests/AfluentTests/SequenceTests/TimerSequenceTests.swift
+++ b/Tests/AfluentTests/SequenceTests/TimerSequenceTests.swift
@@ -36,7 +36,7 @@ struct TimerSequenceTests {
             .init(offset: .milliseconds(10) * $0)
         }
         let actualOutput = await testOutput.output
-        #expect(actualOutput == expectedOutput, "Unexpected output \(actualOutput)")
+        #expect(actualOutput == expectedOutput)
 
         task.cancel()
     }
@@ -79,8 +79,8 @@ struct TimerSequenceTests {
         }
         let actualOutput1 = await testOutput1.output
         let actualOutput2 = await testOutput2.output
-        #expect(actualOutput1 == expectedOutput1, "Unexpected output \(actualOutput1)")
-        #expect(actualOutput2 == expectedOutput2, "Unexpected output \(actualOutput2)")
+        #expect(actualOutput1 == expectedOutput1)
+        #expect(actualOutput2 == expectedOutput2)
 
         task1.cancel()
         task2.cancel()
@@ -153,7 +153,7 @@ struct TimerSequenceTests {
                 }
             let actualOutput = await testOutput.output
             print(actualOutput)
-            #expect(actualOutput == expectedOutput, "Unexpected output \(actualOutput)")
+            #expect(actualOutput == expectedOutput)
 
             task.cancel()
         }
@@ -198,7 +198,7 @@ struct TimerSequenceTests {
             .map { $0 + initialWaitIntervals }
             .map { .init(offset: .milliseconds(10) * $0) }
         let actualOutput = await testOutput.output
-        #expect(actualOutput == expectedOutput, "Unexpected output \(actualOutput)")
+        #expect(actualOutput == expectedOutput)
 
         task.cancel()
     }
@@ -234,7 +234,7 @@ struct TimerSequenceTests {
             .init(offset: .milliseconds(10))
         ]
         let actualOutput = await testOutput.output
-        #expect(actualOutput == expectedOutput, "Unexpected output \(actualOutput)")
+        #expect(actualOutput == expectedOutput)
     }
 }
 

--- a/Tests/AfluentTests/SequenceTests/TimerSequenceTests.swift
+++ b/Tests/AfluentTests/SequenceTests/TimerSequenceTests.swift
@@ -1,0 +1,140 @@
+//
+//  TimerSequenceTests.swift
+//  Afluent
+//
+//  Created by Annalise Mariottini on 11/9/24.
+//
+
+import Afluent
+import Atomics
+import Clocks
+import ConcurrencyExtras
+import Foundation
+import Testing
+
+struct TimerSequenceTests {
+    @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
+    @Test(arguments: 1...10)
+    func timerSequencePublishesOnInterval(expectedCount: Int) async throws {
+        let testClock = TestClock()
+        let testOutput = TestOutput()
+
+        let task = Task {
+            for try await output in TimerSequence.publish(
+                every: .milliseconds(10), clock: testClock)
+            {
+                await testOutput.append(output)
+            }
+        }
+
+        await testClock.advance(by: .milliseconds(10) * expectedCount)
+
+        try await wait(
+            until: await testOutput.output.count == expectedCount, timeout: .milliseconds(1))
+
+        let expectedOutput: [TestClock<Duration>.Instant] = Array(1...expectedCount).map {
+            .init(offset: .milliseconds(10) * $0)
+        }
+        let actualOutput = await testOutput.output
+        #expect(actualOutput == expectedOutput, "Unexpected output \(actualOutput)")
+
+        task.cancel()
+    }
+
+    @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
+    @Test(arguments: 2...10)
+    func timerSequencePublishesOnInterval_withMultipleIterators(expectedCount: Int) async throws {
+        let testClock = TestClock()
+        let testOutput1 = TestOutput()
+        let testOutput2 = TestOutput()
+
+        let sequence = TimerSequence.publish(every: .milliseconds(10), clock: testClock)
+
+        let task1 = Task {
+            for try await output in sequence {
+                await testOutput1.append(output)
+            }
+        }
+
+        await testClock.advance(by: .milliseconds(10))
+        try await wait(until: await testOutput1.output.count == 1, timeout: .milliseconds(1))
+
+        let task2 = Task {
+            for try await output in sequence {
+                await testOutput2.append(output)
+            }
+        }
+
+        await testClock.advance(by: .milliseconds(10) * (expectedCount - 1))
+
+        try await wait(
+            until: await testOutput1.output.count == expectedCount, timeout: .milliseconds(1))
+
+        let expectedOutput1: [TestClock<Duration>.Instant] = Array(1...expectedCount).map {
+            .init(offset: .milliseconds(10) * $0)
+        }
+        // the second sequence subscribed after the 1st value was already published
+        let expectedOutput2: [TestClock<Duration>.Instant] = Array(2...expectedCount).map {
+            .init(offset: .milliseconds(10) * $0)
+        }
+        let actualOutput1 = await testOutput1.output
+        let actualOutput2 = await testOutput2.output
+        #expect(actualOutput1 == expectedOutput1, "Unexpected output \(actualOutput1)")
+        #expect(actualOutput2 == expectedOutput2, "Unexpected output \(actualOutput2)")
+
+        task1.cancel()
+        task2.cancel()
+    }
+
+    @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
+    @Test func timerSequenceProperlyCancels() async throws {
+        let testClock = TestClock()
+        let testOutput = TestOutput()
+
+        let taskCancelledSubject = SingleValueSubject<Void>()
+
+        let task = Task {
+            var iterator = TimerSequence.publish(every: .milliseconds(10), clock: testClock)
+                .makeAsyncIterator()
+
+            let instant1 = try #require(await iterator.next())
+            await testOutput.append(instant1)
+
+            // this would throw, since we're cancelled
+            try? await taskCancelledSubject.execute()
+
+            let instant2 = await iterator.next()
+            #expect(instant2 == nil)
+        }
+
+        await testClock.advance(by: .milliseconds(10))
+        try await wait(until: await testOutput.output.count == 1, timeout: .seconds(1))
+        task.cancel()
+        try taskCancelledSubject.send()
+        try await task.value
+
+        let expectedOutput: [TestClock<Duration>.Instant] = [
+            .init(offset: .milliseconds(10))
+        ]
+        let actualOutput = await testOutput.output
+        #expect(actualOutput == expectedOutput, "Unexpected output \(actualOutput)")
+    }
+}
+
+private actor TestOutput<Value> {
+    init(_ type: Value.Type) {
+        self.output = []
+    }
+
+    var output: [Value]
+
+    func append(_ instant: Value) {
+        self.output.append(instant)
+    }
+}
+
+extension TestOutput where Value == TestClock<Duration>.Instant {
+    init() {
+        self.init(Value.self)
+    }
+}

--- a/Tests/AfluentTests/SequenceTests/TimerSequenceTests.swift
+++ b/Tests/AfluentTests/SequenceTests/TimerSequenceTests.swift
@@ -136,7 +136,7 @@ struct TimerSequenceTests {
             }
 
             try await nextCalled
-            
+
             await testClock.advance(by: .milliseconds(10) * skew)
             try await wait(
                 until: await testOutput.output.count == expectedCount, timeout: .seconds(1))
@@ -254,17 +254,5 @@ private actor TestOutput<Value> {
 extension TestOutput where Value == TestClock<Duration>.Instant {
     init() {
         self.init(Value.self)
-    }
-}
-
-extension Task {
-    static func waitUntilScheduled(operation: sending @escaping @isolated(any) () async throws -> Success) async throws -> Task<Success, any Error> {
-        let sub = SingleValueSubject<Void>()
-        let t = Task<Success, any Error> {
-            try? sub.send()
-            return try await operation()
-        }
-        try await sub.execute()
-        return t
     }
 }

--- a/Tests/AfluentTests/WaitUntilCondition.swift
+++ b/Tests/AfluentTests/WaitUntilCondition.swift
@@ -1,0 +1,21 @@
+//
+//  WaitUntilCondition.swift
+//  Afluent
+//
+//  Created by Annalise Mariottini on 11/9/24.
+//
+
+import Afluent
+
+/// Waits for some condition to proceeds, unless the specified timeout is reached, in which case an error is thrown.
+func wait(until condition: @autoclosure @escaping @Sendable () async -> Bool, timeout: Duration)
+    async throws
+{
+    try await DeferredTask {
+        while await condition() == false {
+            try await Task.sleep(nanoseconds: 100)
+        }
+    }
+    .timeout(timeout)
+    .execute()
+}

--- a/Tests/AfluentTests/WaitUntilCondition.swift
+++ b/Tests/AfluentTests/WaitUntilCondition.swift
@@ -7,7 +7,7 @@
 
 import Afluent
 
-/// Waits for some condition to proceeds, unless the specified timeout is reached, in which case an error is thrown.
+/// Waits for some condition before proceeding, unless the specified timeout is reached, in which case an error is thrown.
 func wait(until condition: @autoclosure @escaping @Sendable () async -> Bool, timeout: Duration)
     async throws
 {

--- a/Tests/AfluentTests/WaitUntilCondition.swift
+++ b/Tests/AfluentTests/WaitUntilCondition.swift
@@ -26,6 +26,7 @@ func wait<C: Clock>(
         }
     }
     while await condition() == false {
+        await Task.yield()
         try checkTimeout()
         try await clock.sleep(for: clock.minimumResolution)
     }

--- a/Tests/AfluentTests/WaitUntilScheduled.swift
+++ b/Tests/AfluentTests/WaitUntilScheduled.swift
@@ -1,0 +1,23 @@
+//
+//  WaitUntilScheduled.swift
+//  Afluent
+//
+//  Created by Annalise Mariottini on 11/11/24.
+//
+
+import Afluent
+
+extension Task where Failure == Error {
+    /// Spawns a new Task to run some async operation and waits for that task to begin execution before proceeding.
+    static func waitUntilScheduled(
+        operation: sending @escaping @isolated(any) () async throws -> Success
+    ) async throws -> Self {
+        let sub = SingleValueSubject<Void>()
+        let task = Task {
+            try? sub.send()
+            return try await operation()
+        }
+        try await sub.execute()
+        return task
+    }
+}


### PR DESCRIPTION
## Description

Adds a `TimerSequence` type that emulates the behavior of [Timer.TimerPublisher](https://developer.apple.com/documentation/foundation/timer/timerpublisher).

Example usage:
```swift
Task {
    for try await instant in TimerSequence.publish(every: .seconds(1)) {
        print(instant)
    }
}

// prints:
// Instant(offset: 1 second)
// Instant(offset: 2 seconds)
// Instant(offset: 3 seconds)
// ...
```

[Since the usage of Timer doesn't seem to be advocated for in Swift concurrency](https://forums.swift.org/t/structured-concurrency-with-timers/47980), I chose to not define this type on `Timer`, but rather have it as part of the global namespace.

Additionally, as part of the effort to transition from things like `TimeInterval` and `Date`, I've chosen to have this sequence emit `clock.now`, which is of type `C.Instant`. If desired, consumers can easily compose together a sequence that would map this offset to a `Date` type.

Open for discussion on the design decisions made here.