### PR TITLE
AfluentTesting target

### DIFF
--- a/.github/workflows/docc-release.yml
+++ b/.github/workflows/docc-release.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   release:
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
       - name: Generate DocC Static Site

--- a/.github/workflows/docc-release.yml
+++ b/.github/workflows/docc-release.yml
@@ -6,6 +6,9 @@ on:
       target:
         required: true
         type: string
+    secrets:
+      TOKEN:
+        required: true
 
 jobs:
   release:

--- a/.github/workflows/docc-release.yml
+++ b/.github/workflows/docc-release.yml
@@ -1,0 +1,33 @@
+name: DocC Release
+
+on:
+  workflow_call:
+    inputs:
+      target:
+        required: true
+        type: string
+
+jobs:
+  release:
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      - name: Generate DocC Static Site
+        run: |
+            swift package --allow-writing-to-directory ./docs \
+              generate-documentation --target $target \
+              --disable-indexing \
+              --transform-for-static-hosting \
+              --hosting-base-path Afluent/ \
+              --include-extended-types \
+              --source-service github \
+              --source-service-base-url https://github.com/Tyler-Keith-Thompson/Afluent/blob/main \
+              --checkout-path "$(pwd)" \
+              --output-path ./docs
+        with:
+          target: ${{ inputs.target }}
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.TOKEN }}
+          publish_dir: ./docs

--- a/.github/workflows/docc-release.yml
+++ b/.github/workflows/docc-release.yml
@@ -24,7 +24,7 @@ jobs:
               --source-service-base-url https://github.com/Tyler-Keith-Thompson/Afluent/blob/main \
               --checkout-path "$(pwd)" \
               --output-path ./docs
-        with:
+        env:
           target: ${{ inputs.target }}
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,25 +6,12 @@ on:
   pull_request:
 
 jobs:
-  release:
-    runs-on: macos-14
-    steps:
-      - uses: actions/checkout@v4
-      - name: Generate DocC Static Site
-        run: |
-            swift package --allow-writing-to-directory ./docs \
-              generate-documentation --target Afluent \
-              --disable-indexing \
-              --transform-for-static-hosting \
-              --hosting-base-path Afluent/ \
-              --include-extended-types \
-              --source-service github \
-              --source-service-base-url https://github.com/Tyler-Keith-Thompson/Afluent/blob/main \
-              --checkout-path "$(pwd)" \
-              --output-path ./docs
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.TOKEN }}
-          publish_dir: ./docs
+  release-afluent:
+    uses: ./.github/workflows/docc-release.yml
+    with:
+      target: ${{ "Afluent" }}
+  release-afluent-testing:
+    uses: ./.github/workflows/docc-release.yml
+    with:
+      target: ${{ "AfluentTesting" }}
  

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   release:
     types: [ created ]
+  pull_request:
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,12 @@ jobs:
     uses: ./.github/workflows/docc-release.yml
     with:
       target: ${{ 'Afluent' }}
+    secrets:
+      TOKEN: ${{ secrets.TOKEN }}
   release-afluent-testing:
     uses: ./.github/workflows/docc-release.yml
     with:
       target: ${{ 'AfluentTesting' }}
+    secrets:
+      TOKEN: ${{ secrets.TOKEN }}
  

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,6 @@ name: Release
 on:
   release:
     types: [ created ]
-  pull_request:
 
 jobs:
   release-afluent:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
     secrets:
       TOKEN: ${{ secrets.TOKEN }}
   release-afluent-testing:
+    needs: release-afluent # run serially
     uses: ./.github/workflows/docc-release.yml
     with:
       target: ${{ 'AfluentTesting' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,9 @@ jobs:
   release-afluent:
     uses: ./.github/workflows/docc-release.yml
     with:
-      target: ${{ "Afluent" }}
+      target: ${{ 'Afluent' }}
   release-afluent-testing:
     uses: ./.github/workflows/docc-release.yml
     with:
-      target: ${{ "AfluentTesting" }}
+      target: ${{ 'AfluentTesting' }}
  

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,10 @@ let package = Package(
     products: [
         .library(
             name: "Afluent",
-            targets: ["Afluent"])
+            targets: ["Afluent"]),
+        .library(
+            name: "AfluentTesting",
+            targets: ["AfluentTesting"]),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.2.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -3,36 +3,51 @@
 
 import PackageDescription
 
-let package = Package(name: "Afluent",
-                      platforms: [.iOS(.v15), .macOS(.v13), .macCatalyst(.v15), .tvOS(.v16), .watchOS(.v9), .visionOS(.v1)],
-                      products: [
-                          .library(name: "Afluent",
-                                   targets: ["Afluent"]),
-                      ],
-                      dependencies: [
-                          .package(url: "https://github.com/apple/swift-atomics.git", from: "1.2.0"),
-                          .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
-                          .package(url: "https://github.com/AliSoftware/OHHTTPStubs.git", from: "9.1.0"),
-                          .package(url: "https://github.com/pointfreeco/swift-clocks.git", from: "1.0.2"),
-                          .package(url: "https://github.com/pointfreeco/swift-concurrency-extras.git", from: "1.1.0"),
-                      ],
-                      targets: [
-                          .target(name: "Afluent",
-                                  dependencies: [
-                                      .product(name: "Atomics", package: "swift-atomics"),
-                                  ],
-                                  swiftSettings: [
-                                      .enableExperimentalFeature("StrictConcurrency=complete"),
-                                  ]),
-                          .testTarget(name: "AfluentTests",
-                                      dependencies: testDependencies()),
-                      ],
-                      swiftLanguageModes: [.version("5.10"), .version("6")])
+let package = Package(
+    name: "Afluent",
+    platforms: [
+        .iOS(.v15), .macOS(.v13), .macCatalyst(.v15), .tvOS(.v16), .watchOS(.v9), .visionOS(.v1),
+    ],
+    products: [
+        .library(
+            name: "Afluent",
+            targets: ["Afluent"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-atomics.git", from: "1.2.0"),
+        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
+        .package(url: "https://github.com/AliSoftware/OHHTTPStubs.git", from: "9.1.0"),
+        .package(url: "https://github.com/pointfreeco/swift-clocks.git", from: "1.0.2"),
+        .package(url: "https://github.com/pointfreeco/swift-concurrency-extras.git", from: "1.1.0"),
+    ],
+    targets: [
+        .target(
+            name: "Afluent",
+            dependencies: [
+                .product(name: "Atomics", package: "swift-atomics")
+            ],
+            swiftSettings: [
+                .enableExperimentalFeature("StrictConcurrency=complete")
+            ]),
+        .target(
+            name: "AfluentTesting",
+            dependencies: [
+                "Afluent"
+            ],
+            swiftSettings: [
+                .enableExperimentalFeature("StrictConcurrency=complete")
+            ]),
+        .testTarget(
+            name: "AfluentTests",
+            dependencies: testDependencies()),
+    ],
+    swiftLanguageModes: [.version("5.10"), .version("6")])
 
 func testDependencies() -> [PackageDescription.Target.Dependency] {
     #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
         [
             "Afluent",
+            "AfluentTesting",
             .product(name: "OHHTTPStubs", package: "OHHTTPStubs"),
             .product(name: "OHHTTPStubsSwift", package: "OHHTTPStubs"),
             .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
@@ -41,6 +56,7 @@ func testDependencies() -> [PackageDescription.Target.Dependency] {
     #else
         [
             "Afluent",
+            "AfluentTesting",
             .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
             .product(name: "Clocks", package: "swift-clocks"),
         ]

--- a/Package@swift-5.10.swift
+++ b/Package@swift-5.10.swift
@@ -3,36 +3,51 @@
 
 import PackageDescription
 
-let package = Package(name: "Afluent",
-                      platforms: [.iOS(.v15), .macOS(.v13), .macCatalyst(.v15), .tvOS(.v16), .watchOS(.v9), .visionOS(.v1)],
-                      products: [
-                          .library(name: "Afluent",
-                                   targets: ["Afluent"]),
-                      ],
-                      dependencies: [
-                          .package(url: "https://github.com/apple/swift-atomics.git", from: "1.2.0"),
-                          .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
-                          .package(url: "https://github.com/AliSoftware/OHHTTPStubs.git", from: "9.1.0"),
-                          .package(url: "https://github.com/pointfreeco/swift-clocks.git", from: "1.0.2"),
-                          .package(url: "https://github.com/pointfreeco/swift-concurrency-extras.git", from: "1.1.0"),
-                          .package(url: "https://github.com/apple/swift-testing.git", from: "0.7.0"),
-                      ],
-                      targets: [
-                          .target(name: "Afluent",
-                                  dependencies: [
-                                      .product(name: "Atomics", package: "swift-atomics"),
-                                  ],
-                                  swiftSettings: [
-                                      .enableExperimentalFeature("StrictConcurrency=complete"),
-                                  ]),
-                          .testTarget(name: "AfluentTests",
-                                      dependencies: testDependencies()),
-                      ])
+let package = Package(
+    name: "Afluent",
+    platforms: [
+        .iOS(.v15), .macOS(.v13), .macCatalyst(.v15), .tvOS(.v16), .watchOS(.v9), .visionOS(.v1),
+    ],
+    products: [
+        .library(
+            name: "Afluent",
+            targets: ["Afluent"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-atomics.git", from: "1.2.0"),
+        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
+        .package(url: "https://github.com/AliSoftware/OHHTTPStubs.git", from: "9.1.0"),
+        .package(url: "https://github.com/pointfreeco/swift-clocks.git", from: "1.0.2"),
+        .package(url: "https://github.com/pointfreeco/swift-concurrency-extras.git", from: "1.1.0"),
+        .package(url: "https://github.com/apple/swift-testing.git", from: "0.7.0"),
+    ],
+    targets: [
+        .target(
+            name: "Afluent",
+            dependencies: [
+                .product(name: "Atomics", package: "swift-atomics")
+            ],
+            swiftSettings: [
+                .enableExperimentalFeature("StrictConcurrency=complete")
+            ]),
+        .target(
+            name: "AfluentTesting",
+            dependencies: [
+                "Afluent"
+            ],
+            swiftSettings: [
+                .enableExperimentalFeature("StrictConcurrency=complete")
+            ]),
+        .testTarget(
+            name: "AfluentTests",
+            dependencies: testDependencies()),
+    ])
 
 func testDependencies() -> [PackageDescription.Target.Dependency] {
     #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
         [
             "Afluent",
+            "AfluentTesting",
             .product(name: "OHHTTPStubs", package: "OHHTTPStubs"),
             .product(name: "OHHTTPStubsSwift", package: "OHHTTPStubs"),
             .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
@@ -42,6 +57,7 @@ func testDependencies() -> [PackageDescription.Target.Dependency] {
     #else
         [
             "Afluent",
+            "AfluentTesting",
             .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
             .product(name: "Clocks", package: "swift-clocks"),
             .product(name: "Testing", package: "swift-testing"),

--- a/Package@swift-5.10.swift
+++ b/Package@swift-5.10.swift
@@ -11,7 +11,10 @@ let package = Package(
     products: [
         .library(
             name: "Afluent",
-            targets: ["Afluent"])
+            targets: ["Afluent"]),
+        .library(
+            name: "AfluentTesting",
+            targets: ["AfluentTesting"]),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.2.0"),

--- a/Package@swift-5.8.swift
+++ b/Package@swift-5.8.swift
@@ -9,7 +9,10 @@ let package = Package(
     products: [
         .library(
             name: "Afluent",
-            targets: ["Afluent"])
+            targets: ["Afluent"]),
+        .library(
+            name: "AfluentTesting",
+            targets: ["AfluentTesting"]),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.2.0"),

--- a/Package@swift-5.8.swift
+++ b/Package@swift-5.8.swift
@@ -3,35 +3,48 @@
 
 import PackageDescription
 
-let package = Package(name: "Afluent",
-                      platforms: [.iOS(.v15), .macOS(.v13), .macCatalyst(.v15), .tvOS(.v16), .watchOS(.v9)],
-                      products: [
-                          .library(name: "Afluent",
-                                   targets: ["Afluent"]),
-                      ],
-                      dependencies: [
-                          .package(url: "https://github.com/apple/swift-atomics.git", from: "1.2.0"),
-                          .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
-                          .package(url: "https://github.com/AliSoftware/OHHTTPStubs.git", from: "9.1.0"),
-                          .package(url: "https://github.com/pointfreeco/swift-clocks.git", from: "1.0.2"),
-                          .package(url: "https://github.com/pointfreeco/swift-concurrency-extras.git", from: "1.1.0"),
-                      ],
-                      targets: [
-                          .target(name: "Afluent",
-                                  dependencies: [
-                                      .product(name: "Atomics", package: "swift-atomics"),
-                                  ],
-                                  swiftSettings: [
-                                      .enableExperimentalFeature("StrictConcurrency=complete"),
-                                  ]),
-                          .testTarget(name: "AfluentTests",
-                                      dependencies: testDependencies()),
-                      ])
+let package = Package(
+    name: "Afluent",
+    platforms: [.iOS(.v15), .macOS(.v13), .macCatalyst(.v15), .tvOS(.v16), .watchOS(.v9)],
+    products: [
+        .library(
+            name: "Afluent",
+            targets: ["Afluent"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-atomics.git", from: "1.2.0"),
+        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
+        .package(url: "https://github.com/AliSoftware/OHHTTPStubs.git", from: "9.1.0"),
+        .package(url: "https://github.com/pointfreeco/swift-clocks.git", from: "1.0.2"),
+        .package(url: "https://github.com/pointfreeco/swift-concurrency-extras.git", from: "1.1.0"),
+    ],
+    targets: [
+        .target(
+            name: "Afluent",
+            dependencies: [
+                .product(name: "Atomics", package: "swift-atomics")
+            ],
+            swiftSettings: [
+                .enableExperimentalFeature("StrictConcurrency=complete")
+            ]),
+        .target(
+            name: "AfluentTesting",
+            dependencies: [
+                "Afluent"
+            ],
+            swiftSettings: [
+                .enableExperimentalFeature("StrictConcurrency=complete")
+            ]),
+        .testTarget(
+            name: "AfluentTests",
+            dependencies: testDependencies()),
+    ])
 
 func testDependencies() -> [PackageDescription.Target.Dependency] {
     #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
         [
             "Afluent",
+            "AfluentTesting",
             .product(name: "OHHTTPStubs", package: "OHHTTPStubs"),
             .product(name: "OHHTTPStubsSwift", package: "OHHTTPStubs"),
             .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
@@ -40,6 +53,7 @@ func testDependencies() -> [PackageDescription.Target.Dependency] {
     #else
         [
             "Afluent",
+            "AfluentTesting",
             .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
             .product(name: "Clocks", package: "swift-clocks"),
         ]

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -9,7 +9,10 @@ let package = Package(
     products: [
         .library(
             name: "Afluent",
-            targets: ["Afluent"])
+            targets: ["Afluent"]),
+        .library(
+            name: "AfluentTesting",
+            targets: ["AfluentTesting"]),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.2.0"),

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -3,35 +3,48 @@
 
 import PackageDescription
 
-let package = Package(name: "Afluent",
-                      platforms: [.iOS(.v15), .macOS(.v13), .macCatalyst(.v15), .tvOS(.v16), .watchOS(.v9)],
-                      products: [
-                          .library(name: "Afluent",
-                                   targets: ["Afluent"]),
-                      ],
-                      dependencies: [
-                          .package(url: "https://github.com/apple/swift-atomics.git", from: "1.2.0"),
-                          .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
-                          .package(url: "https://github.com/AliSoftware/OHHTTPStubs.git", from: "9.1.0"),
-                          .package(url: "https://github.com/pointfreeco/swift-clocks.git", from: "1.0.2"),
-                          .package(url: "https://github.com/pointfreeco/swift-concurrency-extras.git", from: "1.1.0"),
-                      ],
-                      targets: [
-                          .target(name: "Afluent",
-                                  dependencies: [
-                                      .product(name: "Atomics", package: "swift-atomics"),
-                                  ],
-                                  swiftSettings: [
-                                      .enableExperimentalFeature("StrictConcurrency=complete"),
-                                  ]),
-                          .testTarget(name: "AfluentTests",
-                                      dependencies: testDependencies()),
-                      ])
+let package = Package(
+    name: "Afluent",
+    platforms: [.iOS(.v15), .macOS(.v13), .macCatalyst(.v15), .tvOS(.v16), .watchOS(.v9)],
+    products: [
+        .library(
+            name: "Afluent",
+            targets: ["Afluent"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-atomics.git", from: "1.2.0"),
+        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
+        .package(url: "https://github.com/AliSoftware/OHHTTPStubs.git", from: "9.1.0"),
+        .package(url: "https://github.com/pointfreeco/swift-clocks.git", from: "1.0.2"),
+        .package(url: "https://github.com/pointfreeco/swift-concurrency-extras.git", from: "1.1.0"),
+    ],
+    targets: [
+        .target(
+            name: "Afluent",
+            dependencies: [
+                .product(name: "Atomics", package: "swift-atomics")
+            ],
+            swiftSettings: [
+                .enableExperimentalFeature("StrictConcurrency=complete")
+            ]),
+        .target(
+            name: "AfluentTesting",
+            dependencies: [
+                "Afluent"
+            ],
+            swiftSettings: [
+                .enableExperimentalFeature("StrictConcurrency=complete")
+            ]),
+        .testTarget(
+            name: "AfluentTests",
+            dependencies: testDependencies()),
+    ])
 
 func testDependencies() -> [PackageDescription.Target.Dependency] {
     #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
         [
             "Afluent",
+            "AfluentTesting",
             .product(name: "OHHTTPStubs", package: "OHHTTPStubs"),
             .product(name: "OHHTTPStubsSwift", package: "OHHTTPStubs"),
             .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
@@ -40,6 +53,7 @@ func testDependencies() -> [PackageDescription.Target.Dependency] {
     #else
         [
             "Afluent",
+            "AfluentTesting",
             .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
             .product(name: "Clocks", package: "swift-clocks"),
         ]

--- a/README.md
+++ b/README.md
@@ -32,17 +32,19 @@ dependencies: [
 Then, add the Afluent target as a dependency to your package targets:
 
 ```swift
-dependencies: [
-    .product(name: "Afluent", package: "Afluent"),
-]
+.target(name: "MyLib",
+        dependencies: [
+            .product(name: "Afluent", package: "Afluent"),
+        ])
 ```
 
 For test targets where you'd like to use Afluent's testing utilities, add the AfluentTesting target as a dependency:
 
 ```swift
-dependencies: [
-    .product(name: "AfluentTesting", package: "Afluent"),
-]
+.testTarget(name: "MyLibTests",
+            dependencies: [
+                .product(name: "AfluentTesting", package: "Afluent"),
+            ])
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 ![AfluentLogo](https://github.com/Tyler-Keith-Thompson/Afluent/assets/33705774/ba1b24b2-cd70-4c9c-824a-e89ee89348a8)
 
 
-[Click here for documentation](https://tyler-keith-thompson.github.io/Afluent/documentation/afluent/)
+Documentation:
+- [Afluent](https://tyler-keith-thompson.github.io/Afluent/documentation/afluent/)
+- [AfluentTesting](https://tyler-keith-thompson.github.io/Afluent/documentation/afluenttesting/)
 
 Afluent is a Swift library that lives between [swift-async-algorithms](https://github.com/apple/swift-async-algorithms) and foundation, adding reactive operators to async/await and AsyncSequence. The goal of Afluent is to provide a reactive friendly operator style API to enhance Apple's offerings. As a consequence, Afluent will add features that Apple has either already built or is actively building.
 While async/await has simplified asynchronous code, it doesn't offer the full suite of operations for transforming, combining, and error-handling that Combine does. Afluent deliberately keeps as much of the Combine API as makes sense to make moving from Combine to Afluent much easier. As a consequence, you may have some minor symbol collisions when you import both Combine and Afluent in the same file.
@@ -13,6 +15,7 @@ While async/await has simplified asynchronous code, it doesn't offer the full su
 - Fluent, chainable interface
 - A rich set of built-in methods like `map`, `flatMap`, `catch`, `retry`, and many more
 - Built to work seamlessly with Swift's new `async/await` syntax
+- Test utilities to facilitate common `async/await` testing needs
 
 ## Installation
 
@@ -26,6 +29,21 @@ dependencies: [
 ]
 ```
 
+Then, add the Afluent target as a dependency to your package targets:
+
+```swift
+dependencies: [
+    .product(name: "Afluent", package: "Afluent"),
+]
+```
+
+For test targets where you'd like to use Afluent's testing utilities, add the AfluentTesting target as a dependency:
+
+```swift
+dependencies: [
+    .product(name: "AfluentTesting", package: "Afluent"),
+]
+```
 
 ## Usage
 

--- a/Sources/AfluentTesting/WaitUntilCondition.swift
+++ b/Sources/AfluentTesting/WaitUntilCondition.swift
@@ -8,14 +8,16 @@
 import Afluent
 
 /// Waits for some condition before proceeding, unless the specified timeout is reached, in which case an error is thrown.
-func wait(until condition: @autoclosure @escaping @Sendable () async -> Bool, timeout: Duration)
+public func wait(
+    until condition: @autoclosure @escaping @Sendable () async -> Bool, timeout: Duration
+)
     async throws
 {
     try await wait(until: await condition(), timeout: timeout, clock: ContinuousClock())
 }
 
 /// Waits for some condition before proceeding, unless the specified timeout is reached, in which case an error is thrown.
-func wait<C: Clock>(
+public func wait<C: Clock>(
     until condition: @autoclosure @escaping @Sendable () async -> Bool, timeout: C.Duration,
     clock: C
 ) async throws {

--- a/Sources/AfluentTesting/WaitUntilScheduled.swift
+++ b/Sources/AfluentTesting/WaitUntilScheduled.swift
@@ -1,5 +1,5 @@
 //
-//  WaitUntilScheduled.swift
+//  WaitUntilExecutionStarted.swift
 //  Afluent
 //
 //  Created by Annalise Mariottini on 11/11/24.
@@ -9,7 +9,7 @@ import Afluent
 
 extension Task where Failure == Error {
     /// Spawns a new Task to run some async operation and waits for that task to begin execution before proceeding.
-    public static func waitUntilScheduled(
+    public static func waitUntilExecutionStarted(
         operation: @escaping @Sendable () async throws -> Success
     ) async throws -> Self {
         let sub = SingleValueSubject<Void>()

--- a/Sources/AfluentTesting/WaitUntilScheduled.swift
+++ b/Sources/AfluentTesting/WaitUntilScheduled.swift
@@ -10,7 +10,7 @@ import Afluent
 extension Task where Failure == Error {
     /// Spawns a new Task to run some async operation and waits for that task to begin execution before proceeding.
     public static func waitUntilScheduled(
-        operation: sending @escaping @isolated(any) () async throws -> Success
+        operation: @escaping @Sendable () async throws -> Success
     ) async throws -> Self {
         let sub = SingleValueSubject<Void>()
         let task = Task {

--- a/Sources/AfluentTesting/WaitUntilScheduled.swift
+++ b/Sources/AfluentTesting/WaitUntilScheduled.swift
@@ -9,7 +9,7 @@ import Afluent
 
 extension Task where Failure == Error {
     /// Spawns a new Task to run some async operation and waits for that task to begin execution before proceeding.
-    static func waitUntilScheduled(
+    public static func waitUntilScheduled(
         operation: sending @escaping @isolated(any) () async throws -> Success
     ) async throws -> Self {
         let sub = SingleValueSubject<Void>()

--- a/Tests/AfluentTests/SequenceTests/TimerSequenceTests.swift
+++ b/Tests/AfluentTests/SequenceTests/TimerSequenceTests.swift
@@ -20,7 +20,7 @@ struct TimerSequenceTests {
         let testClock = TestClock()
         let testOutput = TestOutput()
 
-        let task = try await Task.waitUntilScheduled {
+        let task = try await Task.waitUntilExecutionStarted {
             for try await output in TimerSequence.publish(
                 every: .milliseconds(10), clock: testClock)
             {
@@ -51,7 +51,7 @@ struct TimerSequenceTests {
 
         let sequence = TimerSequence.publish(every: .milliseconds(10), clock: testClock)
 
-        let task1 = try await Task.waitUntilScheduled {
+        let task1 = try await Task.waitUntilExecutionStarted {
             for try await output in sequence {
                 await testOutput1.append(output)
             }
@@ -60,7 +60,7 @@ struct TimerSequenceTests {
         await testClock.advance(by: .milliseconds(10))
         try await wait(until: await testOutput1.output.count == 1, timeout: .milliseconds(1))
 
-        let task2 = try await Task.waitUntilScheduled {
+        let task2 = try await Task.waitUntilExecutionStarted {
             for try await output in sequence {
                 await testOutput2.append(output)
             }
@@ -127,7 +127,7 @@ struct TimerSequenceTests {
                     .makeAsyncIterator())
 
             async let nextCalled: Void? = try await wrappedIterator.nextCalled.first()
-            let task = try await Task.waitUntilScheduled {
+            let task = try await Task.waitUntilExecutionStarted {
                 for _ in 0..<expectedCount {
                     if let output = try await wrappedIterator.next() {
                         await testOutput.append(output)
@@ -174,7 +174,7 @@ struct TimerSequenceTests {
         let initialWaitIntervals = 5
         let clockAdvanced = SingleValueSubject<Void>()
 
-        let task = try await Task.waitUntilScheduled {
+        let task = try await Task.waitUntilExecutionStarted {
             var iterator = sequence.makeAsyncIterator()
             await testClock.advance(by: .milliseconds(10) * initialWaitIntervals)
             try clockAdvanced.send()
@@ -212,7 +212,7 @@ struct TimerSequenceTests {
 
         let taskCancelledSubject = SingleValueSubject<Void>()
 
-        let task = try await Task.waitUntilScheduled {
+        let task = try await Task.waitUntilExecutionStarted {
             var iterator = TimerSequence.publish(every: .milliseconds(10), clock: testClock)
                 .makeAsyncIterator()
 

--- a/Tests/AfluentTests/SequenceTests/TimerSequenceTests.swift
+++ b/Tests/AfluentTests/SequenceTests/TimerSequenceTests.swift
@@ -6,6 +6,7 @@
 //
 
 @_spi(Experimental) import Afluent
+import AfluentTesting
 import Atomics
 import Clocks
 import ConcurrencyExtras

--- a/Tests/AfluentTests/SequenceTests/TimerSequenceTests.swift
+++ b/Tests/AfluentTests/SequenceTests/TimerSequenceTests.swift
@@ -20,7 +20,7 @@ struct TimerSequenceTests {
         let testClock = TestClock()
         let testOutput = TestOutput()
 
-        let task = try await Task<Void, any Error>.waitUntilScheduled {
+        let task = try await Task.waitUntilScheduled {
             for try await output in TimerSequence.publish(
                 every: .milliseconds(10), clock: testClock)
             {
@@ -51,7 +51,7 @@ struct TimerSequenceTests {
 
         let sequence = TimerSequence.publish(every: .milliseconds(10), clock: testClock)
 
-        let task1 = try await Task<Void, any Error>.waitUntilScheduled {
+        let task1 = try await Task.waitUntilScheduled {
             for try await output in sequence {
                 await testOutput1.append(output)
             }
@@ -60,7 +60,7 @@ struct TimerSequenceTests {
         await testClock.advance(by: .milliseconds(10))
         try await wait(until: await testOutput1.output.count == 1, timeout: .milliseconds(1))
 
-        let task2 = try await Task<Void, any Error>.waitUntilScheduled {
+        let task2 = try await Task.waitUntilScheduled {
             for try await output in sequence {
                 await testOutput2.append(output)
             }
@@ -127,7 +127,7 @@ struct TimerSequenceTests {
                     .makeAsyncIterator())
 
             async let nextCalled: Void? = try await wrappedIterator.nextCalled.first()
-            let task = try await Task<Void, any Error>.waitUntilScheduled {
+            let task = try await Task.waitUntilScheduled {
                 for _ in 0..<expectedCount {
                     if let output = try await wrappedIterator.next() {
                         await testOutput.append(output)
@@ -174,7 +174,7 @@ struct TimerSequenceTests {
         let initialWaitIntervals = 5
         let clockAdvanced = SingleValueSubject<Void>()
 
-        let task = try await Task<Void, any Error>.waitUntilScheduled {
+        let task = try await Task.waitUntilScheduled {
             var iterator = sequence.makeAsyncIterator()
             await testClock.advance(by: .milliseconds(10) * initialWaitIntervals)
             try clockAdvanced.send()
@@ -212,7 +212,7 @@ struct TimerSequenceTests {
 
         let taskCancelledSubject = SingleValueSubject<Void>()
 
-        let task = try await Task<Void, any Error>.waitUntilScheduled {
+        let task = try await Task.waitUntilScheduled {
             var iterator = TimerSequence.publish(every: .milliseconds(10), clock: testClock)
                 .makeAsyncIterator()
 


### PR DESCRIPTION
## Description

Adds an AfluentTesting target that contains some of the test functions that we'd like to make available publicly.

### AfluentTesting

Adds the `wait(until:timeout)` and `Task.waitUntilScheduled` test utilities to a new AfluentTesting target.

For `waitUntilScheduled`, I changed `sending @isolated(any)` to `@Sendable`, which is supported by Swift < 6 and Swift 6 compilers. @Tyler-Keith-Thompson if there's a particular reason why you used the former, let me know, because we'd need to use a conditional compiler directive to support Swift < 6.

### DocC Publishing Changes

Adds DocC publishing for the AfluentTesting target, in addition to the Afluent target.

I did this by using a [reusable workflow](https://docs.github.com/en/actions/sharing-automations/reusing-workflows). Open to suggestions on if there's a more preferred way to achieve the same effect.

I've temporarily added PR releasing to ensure the publishing works as expected.
See the docs published here:
- [Afluent](https://tyler-keith-thompson.github.io/Afluent/documentation/afluent/)
- [AfluentTesting](https://tyler-keith-thompson.github.io/Afluent/documentation/afluenttesting/)

I also went ahead and updated the runner to macos-15, since it's available.

### README

Added a few changes to the README:
- Links to both Afluent and AfluentTesting docs
- New "Feature" bullet
- How to add the Afluent and AfluentTesting targets