### PR TITLE
Fix building for non-macOS platforms

### DIFF
--- a/Sources/AfluentTesting/WaitUntilCondition.swift
+++ b/Sources/AfluentTesting/WaitUntilCondition.swift
@@ -8,6 +8,7 @@
 import Afluent
 
 /// Waits for some condition before proceeding, unless the specified timeout is reached, in which case an error is thrown.
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 public func wait(
     until condition: @autoclosure @escaping @Sendable () async -> Bool, timeout: Duration
 )
@@ -17,6 +18,7 @@ public func wait(
 }
 
 /// Waits for some condition before proceeding, unless the specified timeout is reached, in which case an error is thrown.
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 public func wait<C: Clock>(
     until condition: @autoclosure @escaping @Sendable () async -> Bool, timeout: C.Duration,
     clock: C


### PR DESCRIPTION
Missing some availability annotations that prevented building for non-macOS platforms.

The only way we can enable automated testing for this is to use a macOS runner or figure out some way to setup a simulator on linux.