### PR TITLE
Fix Share worker cancellation of Upstream worker

### DIFF
--- a/Sources/Afluent/Workers/Share.swift
+++ b/Sources/Afluent/Workers/Share.swift
@@ -38,6 +38,11 @@ extension Workers {
         public nonisolated func run() {
             Task { try await task.value }
         }
+
+        public nonisolated func cancel() {
+            state.cancel()
+            Task { await task.cancel() }
+        }
     }
 }
 

--- a/Tests/AfluentTests/WorkerTests/ShareTests.swift
+++ b/Tests/AfluentTests/WorkerTests/ShareTests.swift
@@ -6,6 +6,7 @@
 //
 
 import Afluent
+import Clocks
 import ConcurrencyExtras
 import Foundation
 import Testing
@@ -111,14 +112,50 @@ struct ShareTests {
 
     @Test func sharedTaskExecutesOnce_WithResult_SharedToAllSubscribers() async throws {
         let t = DeferredTask {
-            1
+            UUID().uuidString
         }.share()
 
         let v1 = try await t.execute()
         let v2 = try await t.execute()
         let v3 = try await t.execute()
-        #expect(v1 == 1)
-        #expect(v2 == 1)
-        #expect(v3 == 1)
+        #expect(v1 == v2)
+        #expect(v2 == v3)
+    }
+
+    @Test func sharedTask_cancelsUpstreamWhenCancelled() async throws {
+        let clock = TestClock()
+        let startedSleeping = SingleValueSubject<Void>()
+
+        let t = DeferredTask {
+            async let _sleep = Result { try await Task.sleep(for: .milliseconds(10), clock: clock) }
+            try startedSleeping.send()
+            let sleep = await _sleep
+            #expect(throws: CancellationError.self) {
+                try sleep.get()
+            }
+            return UUID().uuidString
+        }.share()
+
+        async let _r1 = Result { try await t.execute() }
+        async let _r2 = Result { try await t.execute() }
+        async let _r3 = Result { try await t.execute() }
+
+        try await startedSleeping.execute()
+        t.cancel()
+        await clock.advance(by: .milliseconds(11))
+
+        let r1 = await _r1
+        let r2 = await _r2
+        let r3 = await _r3
+
+        #expect(throws: CancellationError.self) {
+            try r1.get()
+        }
+        #expect(throws: CancellationError.self) {
+            try r2.get()
+        }
+        #expect(throws: CancellationError.self) {
+            try r3.get()
+        }
     }
 }


### PR DESCRIPTION
## Description

The `Share` worker was not properly cancelling upstream work when it itself was cancelled.

The reason for this is that the `Share` worker creates its own `Task` that it manages. That means that in addition to cancelling the `TaskState` (which is the storage that controls the executing work from the consumer's perspective), we also need to cancel that internally stored `Task`.

A test has been added to prove that the upstream is properly cancelled (this test does not pass with the previous implementation). I've verified the test succeeds on repeated runs.

I've also made 1 change to another `ShareTests` test that did not seem to be robust in its validation.