### PR TITLE
Refactor AUOWCache.Strategy to be a protocol

### DIFF
--- a/Sources/Afluent/AUOWCacheStrategies/AUOWCache+CacheUntilCompletionOrCancellation.swift
+++ b/Sources/Afluent/AUOWCacheStrategies/AUOWCache+CacheUntilCompletionOrCancellation.swift
@@ -1,0 +1,39 @@
+//
+//  AUOWCache+CacheUntilCompletionOrCancellation.swift
+//
+//
+//  Created by Annalise Mariottini on 12/17/24.
+//
+
+import Foundation
+
+extension AUOWCache {
+    public struct CacheUntilCompletionOrCancellation: AUOWCacheStrategy {
+        public func handle<A: AsynchronousUnitOfWork>(
+            unitOfWork: A, keyedBy key: Int, storedIn cache: AUOWCache
+        ) -> AnyAsynchronousUnitOfWork<A.Success> {
+            cache.retrieveOrCreate(
+                unitOfWork: unitOfWork.handleEvents(
+                    receiveOutput: { [weak cache] _ in
+                        cache?.clearAsynchronousUnitOfWork(withKey: key)
+                    },
+                    receiveError: { [weak cache] _ in
+                        cache?.clearAsynchronousUnitOfWork(withKey: key)
+                    },
+                    receiveCancel: { [weak cache] in
+                        cache?.clearAsynchronousUnitOfWork(withKey: key)
+                    }
+                ).share(),
+                keyedBy: key
+            ).eraseToAnyUnitOfWork()
+        }
+    }
+}
+
+extension AUOWCacheStrategy where Self == AUOWCache.CacheUntilCompletionOrCancellation {
+    /// With the `.cacheUntilCompletionOrCancellation` strategy, the cache
+    /// retains the result until the unit of work completes or is cancelled.
+    public static var cacheUntilCompletionOrCancellation: Self {
+        AUOWCache.CacheUntilCompletionOrCancellation()
+    }
+}

--- a/Sources/Afluent/AUOWCacheStrategies/AUOWCache+CancelAndRetry.swift
+++ b/Sources/Afluent/AUOWCacheStrategies/AUOWCache+CancelAndRetry.swift
@@ -1,0 +1,39 @@
+//
+//  AUOWCache+CancelAndRetry.swift
+//
+//
+//  Created by Annalise Mariottini on 12/17/24.
+//
+
+import Foundation
+
+extension AUOWCache {
+    public struct CancelAndRetry: AUOWCacheStrategy {
+        public func handle<A: AsynchronousUnitOfWork>(
+            unitOfWork: A, keyedBy key: Int, storedIn cache: AUOWCache
+        ) -> AnyAsynchronousUnitOfWork<A.Success> {
+            if let cachedWork = cache.retrieve(keyedBy: key) {
+                cachedWork.cancel()
+            }
+            return cache.create(
+                unitOfWork: unitOfWork.handleEvents(
+                    receiveOutput: { [weak cache] _ in
+                        cache?.clearAsynchronousUnitOfWork(withKey: key)
+                    },
+                    receiveError: { [weak cache] _ in
+                        cache?.clearAsynchronousUnitOfWork(withKey: key)
+                    },
+                    receiveCancel: { [weak cache] in
+                        cache?.clearAsynchronousUnitOfWork(withKey: key)
+                    }
+                ).share(),
+                keyedBy: key
+            ).eraseToAnyUnitOfWork()
+        }
+    }
+}
+
+extension AUOWCacheStrategy where Self == AUOWCache.CancelAndRetry {
+    /// This strategy indicates that any existing work should be cancelled before restarting the upstream work again.
+    public static var cancelAndRestart: Self { AUOWCache.CancelAndRetry() }
+}

--- a/Sources/Afluent/AUOWCacheStrategies/AUOWCacheStrategy.swift
+++ b/Sources/Afluent/AUOWCacheStrategies/AUOWCacheStrategy.swift
@@ -1,0 +1,16 @@
+//
+//  AUOWCache+Strategy.swift
+//
+//
+//  Created by Annalise Mariottini on 12/17/24.
+//
+
+import Foundation
+
+/// ``AUOWCacheStrategy`` represents the available caching strategies for the ``AUOWCache``.
+public protocol AUOWCacheStrategy {
+    /// A caching strategy implementation that handles some work, keyed by some hashed key, which may be stored in or retrieved from the passed cache.
+    func handle<A: AsynchronousUnitOfWork>(
+        unitOfWork: A, keyedBy key: Int, storedIn cache: AUOWCache
+    ) -> AnyAsynchronousUnitOfWork<A.Success>
+}

--- a/Sources/Afluent/Workers/ShareFromCache.swift
+++ b/Sources/Afluent/Workers/ShareFromCache.swift
@@ -9,7 +9,8 @@ import Foundation
 
 extension AsynchronousUnitOfWork {
     func _shareFromCache(
-        _ cache: AUOWCache, strategy: AUOWCache.Strategy, hasher: inout Hasher, fileId: String = "",
+        _ cache: AUOWCache, strategy: any AUOWCacheStrategy, hasher: inout Hasher,
+        fileId: String = "",
         function: String = "", line: UInt = 0, column: UInt = 0
     ) -> some AsynchronousUnitOfWork<Success> {
         hasher.combine(fileId)
@@ -18,46 +19,7 @@ extension AsynchronousUnitOfWork {
         hasher.combine(column)
         let key = hasher.finalize()
 
-        let workToReturn: AnyAsynchronousUnitOfWork<Success>
-
-        switch strategy {
-            case .cacheUntilCompletionOrCancellation:
-                workToReturn =
-                    cache.retrieveOrCreate(
-                        unitOfWork: handleEvents(
-                            receiveOutput: { [weak cache] _ in
-                                cache?.clearAsynchronousUnitOfWork(withKey: key)
-                            },
-                            receiveError: { [weak cache] _ in
-                                cache?.clearAsynchronousUnitOfWork(withKey: key)
-                            },
-                            receiveCancel: { [weak cache] in
-                                cache?.clearAsynchronousUnitOfWork(withKey: key)
-                            }
-                        ).share(),
-                        keyedBy: key
-                    ).eraseToAnyUnitOfWork()
-            case .cancelAndRestart:
-                if let cachedWork = cache.retrieve(keyedBy: key) {
-                    cachedWork.cancel()
-                }
-                workToReturn =
-                    cache.create(
-                        unitOfWork: handleEvents(
-                            receiveOutput: { [weak cache] _ in
-                                cache?.clearAsynchronousUnitOfWork(withKey: key)
-                            },
-                            receiveError: { [weak cache] _ in
-                                cache?.clearAsynchronousUnitOfWork(withKey: key)
-                            },
-                            receiveCancel: { [weak cache] in
-                                cache?.clearAsynchronousUnitOfWork(withKey: key)
-                            }
-                        ).share(),
-                        keyedBy: key
-                    ).eraseToAnyUnitOfWork()
-        }
-        return workToReturn
+        return strategy.handle(unitOfWork: self, keyedBy: key, storedIn: cache)
     }
 
     /// Shares data from the given cache based on a specified caching strategy and additional context information.
@@ -71,7 +33,7 @@ extension AsynchronousUnitOfWork {
     ///   - column: The column where this function is called. Defaults to `#column`.
     /// - Returns: An asynchronous unit of work encapsulating the operation's success or failure.
     public func shareFromCache(
-        _ cache: AUOWCache, strategy: AUOWCache.Strategy, fileId: String = #fileID,
+        _ cache: AUOWCache, strategy: any AUOWCacheStrategy, fileId: String = #fileID,
         function: String = #function, line: UInt = #line, column: UInt = #column
     ) -> some AsynchronousUnitOfWork<Success> {
         var hasher = Hasher()
@@ -88,7 +50,7 @@ extension AsynchronousUnitOfWork {
     ///   - keys: One or more hashable keys used to look up the data in the cache.
     /// - Returns: An asynchronous unit of work encapsulating the operation's success or failure.
     public func shareFromCache<H0: Hashable>(
-        _ cache: AUOWCache, strategy: AUOWCache.Strategy, keys k0: H0
+        _ cache: AUOWCache, strategy: any AUOWCacheStrategy, keys k0: H0
     ) -> some AsynchronousUnitOfWork<Success> {
         var hasher = Hasher()
         hasher.combine(k0)
@@ -103,7 +65,7 @@ extension AsynchronousUnitOfWork {
     ///   - keys: One or more hashable keys used to look up the data in the cache.
     /// - Returns: An asynchronous unit of work encapsulating the operation's success or failure.
     public func shareFromCache<H0: Hashable, H1: Hashable>(
-        _ cache: AUOWCache, strategy: AUOWCache.Strategy, keys k0: H0, _ k1: H1
+        _ cache: AUOWCache, strategy: any AUOWCacheStrategy, keys k0: H0, _ k1: H1
     ) -> some AsynchronousUnitOfWork<Success> {
         var hasher = Hasher()
         hasher.combine(k0)
@@ -119,7 +81,7 @@ extension AsynchronousUnitOfWork {
     ///   - keys: One or more hashable keys used to look up the data in the cache.
     /// - Returns: An asynchronous unit of work encapsulating the operation's success or failure.
     public func shareFromCache<H0: Hashable, H1: Hashable, H2: Hashable>(
-        _ cache: AUOWCache, strategy: AUOWCache.Strategy, keys k0: H0, _ k1: H1, _ k2: H2
+        _ cache: AUOWCache, strategy: any AUOWCacheStrategy, keys k0: H0, _ k1: H1, _ k2: H2
     ) -> some AsynchronousUnitOfWork<Success> {
         var hasher = Hasher()
         hasher.combine(k0)
@@ -136,7 +98,7 @@ extension AsynchronousUnitOfWork {
     ///   - keys: One or more hashable keys used to look up the data in the cache.
     /// - Returns: An asynchronous unit of work encapsulating the operation's success or failure.
     public func shareFromCache<H0: Hashable, H1: Hashable, H2: Hashable, H3: Hashable>(
-        _ cache: AUOWCache, strategy: AUOWCache.Strategy, keys k0: H0, _ k1: H1, _ k2: H2, _ k3: H3
+        _ cache: AUOWCache, strategy: any AUOWCacheStrategy, keys k0: H0, _ k1: H1, _ k2: H2, _ k3: H3
     ) -> some AsynchronousUnitOfWork<Success> {
         var hasher = Hasher()
         hasher.combine(k0)
@@ -156,7 +118,7 @@ extension AsynchronousUnitOfWork {
     public func shareFromCache<
         H0: Hashable, H1: Hashable, H2: Hashable, H3: Hashable, H4: Hashable
     >(
-        _ cache: AUOWCache, strategy: AUOWCache.Strategy, keys k0: H0, _ k1: H1, _ k2: H2, _ k3: H3,
+        _ cache: AUOWCache, strategy: any AUOWCacheStrategy, keys k0: H0, _ k1: H1, _ k2: H2, _ k3: H3,
         _ k4: H4
     ) -> some AsynchronousUnitOfWork<Success> {
         var hasher = Hasher()
@@ -178,7 +140,7 @@ extension AsynchronousUnitOfWork {
     public func shareFromCache<
         H0: Hashable, H1: Hashable, H2: Hashable, H3: Hashable, H4: Hashable, H5: Hashable
     >(
-        _ cache: AUOWCache, strategy: AUOWCache.Strategy, keys k0: H0, _ k1: H1, _ k2: H2, _ k3: H3,
+        _ cache: AUOWCache, strategy: any AUOWCacheStrategy, keys k0: H0, _ k1: H1, _ k2: H2, _ k3: H3,
         _ k4: H4, _ k5: H5
     ) -> some AsynchronousUnitOfWork<Success> {
         var hasher = Hasher()
@@ -202,7 +164,7 @@ extension AsynchronousUnitOfWork {
         H0: Hashable, H1: Hashable, H2: Hashable, H3: Hashable, H4: Hashable, H5: Hashable,
         H6: Hashable
     >(
-        _ cache: AUOWCache, strategy: AUOWCache.Strategy, keys k0: H0, _ k1: H1, _ k2: H2, _ k3: H3,
+        _ cache: AUOWCache, strategy: any AUOWCacheStrategy, keys k0: H0, _ k1: H1, _ k2: H2, _ k3: H3,
         _ k4: H4, _ k5: H5, _ k6: H6
     ) -> some AsynchronousUnitOfWork<Success> {
         var hasher = Hasher()
@@ -227,7 +189,7 @@ extension AsynchronousUnitOfWork {
         H0: Hashable, H1: Hashable, H2: Hashable, H3: Hashable, H4: Hashable, H5: Hashable,
         H6: Hashable, H7: Hashable
     >(
-        _ cache: AUOWCache, strategy: AUOWCache.Strategy, keys k0: H0, _ k1: H1, _ k2: H2, _ k3: H3,
+        _ cache: AUOWCache, strategy: any AUOWCacheStrategy, keys k0: H0, _ k1: H1, _ k2: H2, _ k3: H3,
         _ k4: H4, _ k5: H5, _ k6: H6, _ k7: H7
     ) -> some AsynchronousUnitOfWork<Success> {
         var hasher = Hasher()
@@ -253,7 +215,7 @@ extension AsynchronousUnitOfWork {
         H0: Hashable, H1: Hashable, H2: Hashable, H3: Hashable, H4: Hashable, H5: Hashable,
         H6: Hashable, H7: Hashable, H8: Hashable
     >(
-        _ cache: AUOWCache, strategy: AUOWCache.Strategy, keys k0: H0, _ k1: H1, _ k2: H2, _ k3: H3,
+        _ cache: AUOWCache, strategy: any AUOWCacheStrategy, keys k0: H0, _ k1: H1, _ k2: H2, _ k3: H3,
         _ k4: H4, _ k5: H5, _ k6: H6, _ k7: H7, _ k8: H8
     ) -> some AsynchronousUnitOfWork<Success> {
         var hasher = Hasher()
@@ -280,7 +242,7 @@ extension AsynchronousUnitOfWork {
         H0: Hashable, H1: Hashable, H2: Hashable, H3: Hashable, H4: Hashable, H5: Hashable,
         H6: Hashable, H7: Hashable, H8: Hashable, H9: Hashable
     >(
-        _ cache: AUOWCache, strategy: AUOWCache.Strategy, keys k0: H0, _ k1: H1, _ k2: H2, _ k3: H3,
+        _ cache: AUOWCache, strategy: any AUOWCacheStrategy, keys k0: H0, _ k1: H1, _ k2: H2, _ k3: H3,
         _ k4: H4, _ k5: H5, _ k6: H6, _ k7: H7, _ k8: H8, _ 🐶: H9
     ) -> some AsynchronousUnitOfWork<Success> {
         var hasher = Hasher()


### PR DESCRIPTION
## Description

As suggested in #164, this PR refactors `AUOWCache.Strategy` to be a protocol that may be implemented by consumers. The refactor attempts to minimize the possibility of consumer breakage.