### PR TITLE
Revert "Refactor ShareFromCache to use variadic generics (#162)"

### DIFF
--- a/Sources/Afluent/Workers/ShareFromCache.swift
+++ b/Sources/Afluent/Workers/ShareFromCache.swift
@@ -87,11 +87,213 @@ extension AsynchronousUnitOfWork {
     ///   - strategy: The caching strategy to use.
     ///   - keys: One or more hashable keys used to look up the data in the cache.
     /// - Returns: An asynchronous unit of work encapsulating the operation's success or failure.
-    public func shareFromCache<each H: Hashable>(
-        _ cache: AUOWCache, strategy: AUOWCache.Strategy, keys: repeat each H
+    public func shareFromCache<H0: Hashable>(
+        _ cache: AUOWCache, strategy: AUOWCache.Strategy, keys k0: H0
     ) -> some AsynchronousUnitOfWork<Success> {
         var hasher = Hasher()
-        repeat hasher.combine(each keys)
+        hasher.combine(k0)
+        return _shareFromCache(cache, strategy: strategy, hasher: &hasher)
+    }
+
+    /// Shares data from the given cache based on a specified caching strategy and hashable keys.
+    ///
+    /// - Parameters:
+    ///   - cache: The cache from which to share data.
+    ///   - strategy: The caching strategy to use.
+    ///   - keys: One or more hashable keys used to look up the data in the cache.
+    /// - Returns: An asynchronous unit of work encapsulating the operation's success or failure.
+    public func shareFromCache<H0: Hashable, H1: Hashable>(
+        _ cache: AUOWCache, strategy: AUOWCache.Strategy, keys k0: H0, _ k1: H1
+    ) -> some AsynchronousUnitOfWork<Success> {
+        var hasher = Hasher()
+        hasher.combine(k0)
+        hasher.combine(k1)
+        return _shareFromCache(cache, strategy: strategy, hasher: &hasher)
+    }
+
+    /// Shares data from the given cache based on a specified caching strategy and hashable keys.
+    ///
+    /// - Parameters:
+    ///   - cache: The cache from which to share data.
+    ///   - strategy: The caching strategy to use.
+    ///   - keys: One or more hashable keys used to look up the data in the cache.
+    /// - Returns: An asynchronous unit of work encapsulating the operation's success or failure.
+    public func shareFromCache<H0: Hashable, H1: Hashable, H2: Hashable>(
+        _ cache: AUOWCache, strategy: AUOWCache.Strategy, keys k0: H0, _ k1: H1, _ k2: H2
+    ) -> some AsynchronousUnitOfWork<Success> {
+        var hasher = Hasher()
+        hasher.combine(k0)
+        hasher.combine(k1)
+        hasher.combine(k2)
+        return _shareFromCache(cache, strategy: strategy, hasher: &hasher)
+    }
+
+    /// Shares data from the given cache based on a specified caching strategy and hashable keys.
+    ///
+    /// - Parameters:
+    ///   - cache: The cache from which to share data.
+    ///   - strategy: The caching strategy to use.
+    ///   - keys: One or more hashable keys used to look up the data in the cache.
+    /// - Returns: An asynchronous unit of work encapsulating the operation's success or failure.
+    public func shareFromCache<H0: Hashable, H1: Hashable, H2: Hashable, H3: Hashable>(
+        _ cache: AUOWCache, strategy: AUOWCache.Strategy, keys k0: H0, _ k1: H1, _ k2: H2, _ k3: H3
+    ) -> some AsynchronousUnitOfWork<Success> {
+        var hasher = Hasher()
+        hasher.combine(k0)
+        hasher.combine(k1)
+        hasher.combine(k2)
+        hasher.combine(k3)
+        return _shareFromCache(cache, strategy: strategy, hasher: &hasher)
+    }
+
+    /// Shares data from the given cache based on a specified caching strategy and hashable keys.
+    ///
+    /// - Parameters:
+    ///   - cache: The cache from which to share data.
+    ///   - strategy: The caching strategy to use.
+    ///   - keys: One or more hashable keys used to look up the data in the cache.
+    /// - Returns: An asynchronous unit of work encapsulating the operation's success or failure.
+    public func shareFromCache<
+        H0: Hashable, H1: Hashable, H2: Hashable, H3: Hashable, H4: Hashable
+    >(
+        _ cache: AUOWCache, strategy: AUOWCache.Strategy, keys k0: H0, _ k1: H1, _ k2: H2, _ k3: H3,
+        _ k4: H4
+    ) -> some AsynchronousUnitOfWork<Success> {
+        var hasher = Hasher()
+        hasher.combine(k0)
+        hasher.combine(k1)
+        hasher.combine(k2)
+        hasher.combine(k3)
+        hasher.combine(k4)
+        return _shareFromCache(cache, strategy: strategy, hasher: &hasher)
+    }
+
+    /// Shares data from the given cache based on a specified caching strategy and hashable keys.
+    ///
+    /// - Parameters:
+    ///   - cache: The cache from which to share data.
+    ///   - strategy: The caching strategy to use.
+    ///   - keys: One or more hashable keys used to look up the data in the cache.
+    /// - Returns: An asynchronous unit of work encapsulating the operation's success or failure.
+    public func shareFromCache<
+        H0: Hashable, H1: Hashable, H2: Hashable, H3: Hashable, H4: Hashable, H5: Hashable
+    >(
+        _ cache: AUOWCache, strategy: AUOWCache.Strategy, keys k0: H0, _ k1: H1, _ k2: H2, _ k3: H3,
+        _ k4: H4, _ k5: H5
+    ) -> some AsynchronousUnitOfWork<Success> {
+        var hasher = Hasher()
+        hasher.combine(k0)
+        hasher.combine(k1)
+        hasher.combine(k2)
+        hasher.combine(k3)
+        hasher.combine(k4)
+        hasher.combine(k5)
+        return _shareFromCache(cache, strategy: strategy, hasher: &hasher)
+    }
+
+    /// Shares data from the given cache based on a specified caching strategy and hashable keys.
+    ///
+    /// - Parameters:
+    ///   - cache: The cache from which to share data.
+    ///   - strategy: The caching strategy to use.
+    ///   - keys: One or more hashable keys used to look up the data in the cache.
+    /// - Returns: An asynchronous unit of work encapsulating the operation's success or failure.
+    public func shareFromCache<
+        H0: Hashable, H1: Hashable, H2: Hashable, H3: Hashable, H4: Hashable, H5: Hashable,
+        H6: Hashable
+    >(
+        _ cache: AUOWCache, strategy: AUOWCache.Strategy, keys k0: H0, _ k1: H1, _ k2: H2, _ k3: H3,
+        _ k4: H4, _ k5: H5, _ k6: H6
+    ) -> some AsynchronousUnitOfWork<Success> {
+        var hasher = Hasher()
+        hasher.combine(k0)
+        hasher.combine(k1)
+        hasher.combine(k2)
+        hasher.combine(k3)
+        hasher.combine(k4)
+        hasher.combine(k5)
+        hasher.combine(k6)
+        return _shareFromCache(cache, strategy: strategy, hasher: &hasher)
+    }
+
+    /// Shares data from the given cache based on a specified caching strategy and hashable keys.
+    ///
+    /// - Parameters:
+    ///   - cache: The cache from which to share data.
+    ///   - strategy: The caching strategy to use.
+    ///   - keys: One or more hashable keys used to look up the data in the cache.
+    /// - Returns: An asynchronous unit of work encapsulating the operation's success or failure.
+    public func shareFromCache<
+        H0: Hashable, H1: Hashable, H2: Hashable, H3: Hashable, H4: Hashable, H5: Hashable,
+        H6: Hashable, H7: Hashable
+    >(
+        _ cache: AUOWCache, strategy: AUOWCache.Strategy, keys k0: H0, _ k1: H1, _ k2: H2, _ k3: H3,
+        _ k4: H4, _ k5: H5, _ k6: H6, _ k7: H7
+    ) -> some AsynchronousUnitOfWork<Success> {
+        var hasher = Hasher()
+        hasher.combine(k0)
+        hasher.combine(k1)
+        hasher.combine(k2)
+        hasher.combine(k3)
+        hasher.combine(k4)
+        hasher.combine(k5)
+        hasher.combine(k6)
+        hasher.combine(k7)
+        return _shareFromCache(cache, strategy: strategy, hasher: &hasher)
+    }
+
+    /// Shares data from the given cache based on a specified caching strategy and hashable keys.
+    ///
+    /// - Parameters:
+    ///   - cache: The cache from which to share data.
+    ///   - strategy: The caching strategy to use.
+    ///   - keys: One or more hashable keys used to look up the data in the cache.
+    /// - Returns: An asynchronous unit of work encapsulating the operation's success or failure.
+    public func shareFromCache<
+        H0: Hashable, H1: Hashable, H2: Hashable, H3: Hashable, H4: Hashable, H5: Hashable,
+        H6: Hashable, H7: Hashable, H8: Hashable
+    >(
+        _ cache: AUOWCache, strategy: AUOWCache.Strategy, keys k0: H0, _ k1: H1, _ k2: H2, _ k3: H3,
+        _ k4: H4, _ k5: H5, _ k6: H6, _ k7: H7, _ k8: H8
+    ) -> some AsynchronousUnitOfWork<Success> {
+        var hasher = Hasher()
+        hasher.combine(k0)
+        hasher.combine(k1)
+        hasher.combine(k2)
+        hasher.combine(k3)
+        hasher.combine(k4)
+        hasher.combine(k5)
+        hasher.combine(k6)
+        hasher.combine(k7)
+        hasher.combine(k8)
+        return _shareFromCache(cache, strategy: strategy, hasher: &hasher)
+    }
+
+    /// Shares data from the given cache based on a specified caching strategy and hashable keys.
+    ///
+    /// - Parameters:
+    ///   - cache: The cache from which to share data.
+    ///   - strategy: The caching strategy to use.
+    ///   - keys: One or more hashable keys used to look up the data in the cache.
+    /// - Returns: An asynchronous unit of work encapsulating the operation's success or failure.
+    public func shareFromCache<
+        H0: Hashable, H1: Hashable, H2: Hashable, H3: Hashable, H4: Hashable, H5: Hashable,
+        H6: Hashable, H7: Hashable, H8: Hashable, H9: Hashable
+    >(
+        _ cache: AUOWCache, strategy: AUOWCache.Strategy, keys k0: H0, _ k1: H1, _ k2: H2, _ k3: H3,
+        _ k4: H4, _ k5: H5, _ k6: H6, _ k7: H7, _ k8: H8, _ 🐶: H9
+    ) -> some AsynchronousUnitOfWork<Success> {
+        var hasher = Hasher()
+        hasher.combine(k0)
+        hasher.combine(k1)
+        hasher.combine(k2)
+        hasher.combine(k3)
+        hasher.combine(k4)
+        hasher.combine(k5)
+        hasher.combine(k6)
+        hasher.combine(k7)
+        hasher.combine(k8)
+        hasher.combine(🐶)
         return _shareFromCache(cache, strategy: strategy, hasher: &hasher)
     }
 }

--- a/Tests/AfluentTests/WorkerTests/ShareFromCacheTests.swift
+++ b/Tests/AfluentTests/WorkerTests/ShareFromCacheTests.swift
@@ -54,9 +54,8 @@ struct ShareFromCacheTests {
                 .execute()
 
             await clock.advance(by: .milliseconds(15))
-            let d1Value = try await d1
-            let d2Value = try await d2
-            #expect(d1Value == d2Value)
+            _ = try await d1
+            _ = try await d2
 
             let callCount = await test.callCount
             #expect(callCount == 1)
@@ -98,10 +97,9 @@ struct ShareFromCacheTests {
                 .execute()
 
             await clock.advance(by: .milliseconds(11))
-            let d1Value = try await d1
+            _ = try await d1
             await clock.advance(by: .milliseconds(16))
-            let d2Value = try await d2
-            #expect(d1Value != d2Value)
+            _ = try await d2
 
             let callCount = await test.callCount
             #expect(callCount == 2)
@@ -174,10 +172,6 @@ struct ShareFromCacheTests {
             actor Test {
                 var callCount = 0
 
-                func reset() {
-                    callCount = 0
-                }
-
                 func increment() {
                     callCount += 1
                 }
@@ -186,120 +180,29 @@ struct ShareFromCacheTests {
             let cache = AUOWCache()
             let clock = TestClock()
 
-            @Sendable func unitOfWork<H: Hashable>(key: H) -> some AsynchronousUnitOfWork<String> {
+            @Sendable func unitOfWork() -> some AsynchronousUnitOfWork<String> {
                 DeferredTask {
                     await test.increment()
                     return UUID().uuidString
                 }
                 .delay(for: .milliseconds(10), clock: clock)
-                .shareFromCache(cache, strategy: .cacheUntilCompletionOrCancellation, keys: key)
+                .shareFromCache(cache, strategy: .cacheUntilCompletionOrCancellation, keys: 1)
             }
 
-            try await {
-                let uow = unitOfWork(key: 1)
-                async let d1 = uow.execute()
-                #expect(!cache.cache.isEmpty)
-                async let d2 = DeferredTask {}
-                    .delay(for: .milliseconds(5), clock: clock)
-                    .flatMap { unitOfWork(key: 1) }
-                    .execute()
+            let uow = unitOfWork()
+            async let d1 = uow.execute()
+            #expect(!cache.cache.isEmpty)
+            async let d2 = DeferredTask {}
+                .delay(for: .milliseconds(5), clock: clock)
+                .flatMap { unitOfWork() }
+                .execute()
 
-                await clock.advance(by: .milliseconds(11))
-                let d1Value = try await d1
-                let d2Value = try await d2
-                #expect(d1Value == d2Value)
+            await clock.advance(by: .milliseconds(11))
+            _ = try await d1
+            _ = try await d2
 
-                let callCount = await test.callCount
-                #expect(callCount == 1)
-            }()
-
-            await test.reset()
-
-            try await {
-                let uow = unitOfWork(key: 1)
-                async let d1 = uow.execute()
-                #expect(!cache.cache.isEmpty)
-                async let d2 = DeferredTask {}
-                    .delay(for: .milliseconds(5), clock: clock)
-                    .flatMap { unitOfWork(key: 2) }
-                    .execute()
-
-                await clock.advance(by: .milliseconds(21))
-                let d1Value = try await d1
-                let d2Value = try await d2
-                #expect(d1Value != d2Value)
-
-                let callCount = await test.callCount
-                #expect(callCount == 2)
-            }()
-        }
-    }
-
-    @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
-    @Test func sharingFromCacheWithManyKeys() async throws {
-        try await withMainSerialExecutor {
-            actor Test {
-                var callCount = 0
-
-                func reset() {
-                    callCount = 0
-                }
-
-                func increment() {
-                    callCount += 1
-                }
-            }
-            let test = Test()
-            let cache = AUOWCache()
-            let clock = TestClock()
-
-            @Sendable func unitOfWork<H: Hashable>(key: H) -> some AsynchronousUnitOfWork<String> {
-                DeferredTask {
-                    await test.increment()
-                    return UUID().uuidString
-                }
-                .delay(for: .milliseconds(10), clock: clock)
-                .shareFromCache(
-                    cache, strategy: .cacheUntilCompletionOrCancellation, keys: key, "a", 0.0, true)
-            }
-
-            try await {
-                let uow = unitOfWork(key: true)
-                async let d1 = uow.execute()
-                #expect(!cache.cache.isEmpty)
-                async let d2 = DeferredTask {}
-                    .delay(for: .milliseconds(5), clock: clock)
-                    .flatMap { unitOfWork(key: true) }
-                    .execute()
-
-                await clock.advance(by: .milliseconds(11))
-                let d1Value = try await d1
-                let d2Value = try await d2
-                #expect(d1Value == d2Value)
-
-                let callCount = await test.callCount
-                #expect(callCount == 1)
-            }()
-
-            await test.reset()
-
-            try await {
-                let uow = unitOfWork(key: 1)
-                async let d1 = uow.execute()
-                #expect(!cache.cache.isEmpty)
-                async let d2 = DeferredTask {}
-                    .delay(for: .milliseconds(5), clock: clock)
-                    .flatMap { unitOfWork(key: 2) }
-                    .execute()
-
-                await clock.advance(by: .milliseconds(21))
-                let d1Value = try await d1
-                let d2Value = try await d2
-                #expect(d1Value != d2Value)
-
-                let callCount = await test.callCount
-                #expect(callCount == 2)
-            }()
+            let callCount = await test.callCount
+            #expect(callCount == 1)
         }
     }
 


### PR DESCRIPTION
This reverts commit 268acffc5a5979d461a75674943e7dc44aed6500.

Unfortunately variadic generics was causing compiler build issues when using Swift 5.10 (via Xcode 15.4).