### PR TITLE
Refactor Throttle operator to avoid while loops

### DIFF
--- a/Sources/Afluent/Workers/SingleValueSubject.swift
+++ b/Sources/Afluent/Workers/SingleValueSubject.swift
@@ -23,6 +23,12 @@ public final class SingleValueSubject<Success: Sendable>: AsynchronousUnitOfWork
 
     private let _lock = NSRecursiveLock()
     public let state = TaskState<Success>()
+    var alreadySent: Bool {
+        switch subjectState {
+            case .sentValue, .sentError: return true
+            case .noValue, .hasContinuation: return false
+        }
+    }
     private var subjectState = State.noValue
 
     /// Creates a new `SingleValueSubject`.


### PR DESCRIPTION
## Description

In consumer usage of the throttle operator, we observed hangs in UI tests that only occurred when the `throttle` operator was used.

This seems to be related to the `while` loop that was used to await next elements. If the upstream was not emitting more elements, it seems the `while` loop caused issues with app execution.

To Do:
- [x] Run ThrottleSequenceTests x1000 locally