### PR TITLE
Add fix for AnyAsynchrononsUnitOfWork upstream not being called for some protocol function calls

### DIFF
--- a/Sources/Afluent/Workers/EraseToAnyAsynchronousUnitOfWork.swift
+++ b/Sources/Afluent/Workers/EraseToAnyAsynchronousUnitOfWork.swift
@@ -9,15 +9,52 @@ import Foundation
 
 /// A unit of work that performs type erasure by wrapping another unit of work.
 public struct AnyAsynchronousUnitOfWork<Success: Sendable>: AsynchronousUnitOfWork {
-    public let state = TaskState<Success>()
     let upstream: any AsynchronousUnitOfWork<Success>
 
     public init(_ upstream: any AsynchronousUnitOfWork<Success>) {
         self.upstream = upstream
     }
 
+    // IMPORTANT:
+    // this type must explicitly call the upstream's implementation of all AsynchronousUnitOfWork protocol properties
+    // this is because we cannot assume any given worker will use the default implementation
+
+    public var state: TaskState<Success> {
+        upstream.state
+    }
+    public var result: Result<Success, Error> {
+        get async throws {
+            try await upstream.result
+        }
+    }
+    public func run(priority: TaskPriority?) {
+        upstream.run(priority: priority)
+    }
+    @discardableResult
+    public func execute(priority: TaskPriority?) async throws -> Success {
+        try await upstream.execute(priority: priority)
+    }
+    #if swift(>=6)
+        @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+        public func run(
+            executorPreference taskExecutor: (any TaskExecutor)?, priority: TaskPriority?
+        ) {
+            upstream.run(executorPreference: taskExecutor, priority: priority)
+        }
+        @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+        @discardableResult
+        public func execute(
+            executorPreference taskExecutor: (any TaskExecutor)?, priority: TaskPriority?
+        ) async throws -> Success {
+            try await upstream.execute(executorPreference: taskExecutor, priority: priority)
+        }
+    #endif
+    @Sendable
     public func _operation() async throws -> AsynchronousOperation<Success> {
         try await upstream._operation()
+    }
+    public func cancel() {
+        upstream.cancel()
     }
 }
 

--- a/Tests/AfluentTests/WorkerTests/EraseToAnyAsynchronousUnitOfWorkTests.swift
+++ b/Tests/AfluentTests/WorkerTests/EraseToAnyAsynchronousUnitOfWorkTests.swift
@@ -35,4 +35,102 @@ struct EraseToAnyAsynchronousUnitOfWorkTests {
 
         #expect(val == 0)
     }
+
+    @Test func accomodatesCustomProtocolImplementations() async throws {
+        final class FunctionCallTrackingWorker<Success: Sendable>: AsynchronousUnitOfWork,
+            @unchecked Sendable
+        {
+            init(upstream: any AsynchronousUnitOfWork<Success>) {
+                self.upstream = upstream
+            }
+            let upstream: any AsynchronousUnitOfWork<Success>
+            var functionCalls: [String] = []
+
+            public var state: TaskState<Success> {
+                functionCalls.append(#function)
+                return upstream.state
+            }
+            public var result: Result<Success, Error> {
+                get async throws {
+                    functionCalls.append(#function)
+                    return try await upstream.result
+                }
+            }
+            public func run(priority: TaskPriority?) {
+                functionCalls.append(#function)
+                return upstream.run(priority: priority)
+            }
+            @discardableResult
+            public func execute(priority: TaskPriority?) async throws -> Success {
+                functionCalls.append(#function)
+                return try await upstream.execute(priority: priority)
+            }
+            #if swift(>=6)
+                @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+                public func run(
+                    executorPreference taskExecutor: (any TaskExecutor)?, priority: TaskPriority?
+                ) {
+                    functionCalls.append(#function)
+                    return upstream.run(executorPreference: taskExecutor, priority: priority)
+                }
+                @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+                @discardableResult
+                public func execute(
+                    executorPreference taskExecutor: (any TaskExecutor)?, priority: TaskPriority?
+                ) async throws -> Success {
+                    functionCalls.append(#function)
+                    return try await upstream.execute(
+                        executorPreference: taskExecutor, priority: priority)
+                }
+            #endif
+            @Sendable
+            public func _operation() async throws -> AsynchronousOperation<Success> {
+                functionCalls.append(#function)
+                return try await upstream._operation()
+            }
+            public func cancel() {
+                functionCalls.append(#function)
+                return upstream.cancel()
+            }
+        }
+
+        let worker = FunctionCallTrackingWorker(upstream: DeferredTask { 0 })
+        let erased = worker.eraseToAnyUnitOfWork()
+
+        _ = erased.state
+        #expect(worker.functionCalls == ["state"])
+        worker.functionCalls.removeAll()
+
+        _ = try await erased.result
+        #expect(worker.functionCalls == ["result"])
+        worker.functionCalls.removeAll()
+
+        erased.run(priority: nil)
+        #expect(worker.functionCalls == ["run(priority:)"])
+        worker.functionCalls.removeAll()
+
+        try await erased.execute(priority: nil)
+        #expect(worker.functionCalls == ["execute(priority:)"])
+        worker.functionCalls.removeAll()
+
+        #if swift(>=6)
+            if #available(macOS 15.0, *) {
+                erased.run(executorPreference: nil, priority: nil)
+                #expect(worker.functionCalls == ["run(executorPreference:priority:)"])
+                worker.functionCalls.removeAll()
+
+                try await erased.execute(executorPreference: nil, priority: nil)
+                #expect(worker.functionCalls == ["execute(executorPreference:priority:)"])
+                worker.functionCalls.removeAll()
+            }
+        #endif
+
+        _ = try await erased._operation()
+        #expect(worker.functionCalls == ["_operation()"])
+        worker.functionCalls.removeAll()
+
+        erased.cancel()
+        #expect(worker.functionCalls == ["cancel()"])
+        worker.functionCalls.removeAll()
+    }
 }


### PR DESCRIPTION
## Description

The `AsynchrononsUnitOfWork` protocol has several functions that have default implementations that _can_ be implemented explicitly by workers (e.g. `cancel()`). However, the `AnyAsynchronousUnitOfWork` worker does not properly propagate these calls to the upstream, instead relying upon the default implementations, which results in these explicit implementations not being called.

One concrete example of this is the `Share` worker, which implements its own `cancel()` function. This is not properly being called when this worker is erased as an `AnyAsynchronousUnitOfWork` (see added test, which fails on the current production implementation).

In this PR, I've added all `AsynchronousUnitOfWork` protocol properties and functions explicitly to the `AnyAsynchronousUnitOfWork` type to utilize the upstream's implementation. This both fixes the current issue with the `Share` worker and ensures we avoid any future issues if a worker implements _any_ of the protocol properties or functions itself.