### PR TITLE
Implement output in

### DIFF
--- a/Sources/Afluent/SequenceOperators/OutputSequence.swift
+++ b/Sources/Afluent/SequenceOperators/OutputSequence.swift
@@ -80,7 +80,7 @@ extension AsyncSequence where Self: Sendable {
     /// Returns an async sequence that contains, in order, the elements of the base sequence specified by the range.
     ///
     /// ### Discussion:
-    /// Optimized to be used with built-in range types. Completes normally after returning all elements.
+    /// Completes normally after range is exhausted.
     /// 
     /// ### Example:
     /// ```swift

--- a/Tests/AfluentTests/SequenceTests/OutputSequenceTests.swift
+++ b/Tests/AfluentTests/SequenceTests/OutputSequenceTests.swift
@@ -123,25 +123,4 @@ struct OutputSequenceTests {
         #expect(result == nil)
     }
     
-    @Test func testOutputAnyIntRange() {
-        let range = 0..<2
-        var sut = AsyncSequences.OutputAnyIntRange.make(range)
-        #expect(sut.contains(1))
-        #expect(sut.exceeds(2))
-        
-        let closedRange = 0...1
-        sut = AsyncSequences.OutputAnyIntRange.make(closedRange)
-        #expect(sut.contains(1))
-        #expect(sut.exceeds(2))
-        
-        let partialRangeUpTo = ..<2
-        sut = AsyncSequences.OutputAnyIntRange.make(partialRangeUpTo)
-        #expect(sut.contains(1))
-        #expect(sut.exceeds(2))
-        
-        let partialRangeThroug = ...1
-        sut = AsyncSequences.OutputAnyIntRange.make(partialRangeThroug)
-        #expect(sut.contains(1))
-        #expect(sut.exceeds(2))
-    }
 }

--- a/Tests/AfluentTests/SequenceTests/OutputSequenceTests.swift
+++ b/Tests/AfluentTests/SequenceTests/OutputSequenceTests.swift
@@ -5,7 +5,7 @@
 //  Created by Roman Temchenko on 2025-03-07.
 //
 
-import Afluent
+@testable import Afluent
 import Foundation
 import Testing
 import ConcurrencyExtras
@@ -13,9 +13,9 @@ import ConcurrencyExtras
 struct OutputSequenceTests {
     
     @Test func testOutputAt() async throws {
-        let emptySequence = [0, 3, 5].async
-        let result = try await emptySequence.output(at: 1).first()
-        #expect(result == 3)
+        let originalSequence = [0, 3, 5].async
+        let result = try await originalSequence.output(at: 1).collect().first()
+        #expect(result == [3])
     }
     
     @Test func testOutputAtWithEmptySequence() async throws {
@@ -25,8 +25,8 @@ struct OutputSequenceTests {
     }
     
     @Test func testOutputAtOutOfBounds() async throws {
-        let emptySequence = [0, 3, 5].async
-        let result = try await emptySequence.output(at: 5).first()
+        let originalSequence = [0, 3, 5].async
+        let result = try await originalSequence.output(at: 5).first()
         #expect(result == nil)
     }
     
@@ -60,4 +60,88 @@ struct OutputSequenceTests {
         #expect(result == nil)
     }
     
+    @Test func testOutputIn() async throws {
+        let originalSequence = [0, 3, 5, 7, 9].async
+        let result = try await originalSequence.output(in: 1..<4).collect().first()
+        #expect(result == [3, 5, 7])
+    }
+    
+    @Test func testOutputInClosedRange() async throws {
+        let originalSequence = [0, 3, 5, 7, 9].async
+        let result = try await originalSequence.output(in: 1...3).collect().first()
+        #expect(result == [3, 5, 7])
+    }
+    
+    @Test func testOutputInPartialRangeUpTo() async throws {
+        let originalSequence = [0, 3, 5, 7, 9].async
+        let result = try await originalSequence.output(in: ..<3).collect().first()
+        #expect(result == [0, 3, 5])
+    }
+    
+    @Test func testOutputInPartialRangeThrough() async throws {
+        let originalSequence = [0, 3, 5, 7, 9].async
+        let result = try await originalSequence.output(in: ...3).collect().first()
+        #expect(result == [0, 3, 5, 7])
+    }
+    
+    @Test func testOutputInPartialRangeFrom() async throws {
+        let originalSequence = [0, 3, 5, 7, 9].async
+        let result = try await originalSequence.output(in: 2...).collect().first()
+        #expect(result == [5, 7, 9])
+    }
+    
+    @Test func testOutputInWithEmptySequence() async throws {
+        let emptySequence = [Int]().async
+        let result = try await emptySequence.output(in: 0...).first()
+        try #require(result == nil)
+    }
+    
+    @Test func testOutputInOutOfBounds() async throws {
+        let originalSequence = [0, 3, 5].async
+        let result = try await originalSequence.output(in: 5...).first()
+        #expect(result == nil)
+    }
+    
+    @Test func testOutputInCancellation() async throws {
+        let (stream, continuation) = AsyncThrowingStream.makeStream(of: Int.self)
+        
+        let task = Task {
+            let result = try await stream.output(in: 5...).first()
+            #expect(result == nil)
+            return result
+        }
+        
+        continuation.yield(0)
+        task.cancel()
+        
+        // Give task cancellation time to propagate.
+        await Task.megaYield()
+        
+        continuation.finish(throwing: GeneralError.e1)
+        
+        let result = try await task.value
+        #expect(result == nil)
+    }
+    
+    @Test func testOutputAnyIntRange() {
+        let range = 0..<2
+        var sut = AsyncSequences.OutputAnyIntRange.make(range)
+        #expect(sut.contains(1))
+        #expect(sut.exceeds(2))
+        
+        let closedRange = 0...1
+        sut = AsyncSequences.OutputAnyIntRange.make(closedRange)
+        #expect(sut.contains(1))
+        #expect(sut.exceeds(2))
+        
+        let partialRangeUpTo = ..<2
+        sut = AsyncSequences.OutputAnyIntRange.make(partialRangeUpTo)
+        #expect(sut.contains(1))
+        #expect(sut.exceeds(2))
+        
+        let partialRangeThroug = ...1
+        sut = AsyncSequences.OutputAnyIntRange.make(partialRangeThroug)
+        #expect(sut.contains(1))
+        #expect(sut.exceeds(2))
+    }
 }


### PR DESCRIPTION
Implement `output(in:)` similar to Combine - https://developer.apple.com/documentation/combine/publisher/output(in:)
Incoming ranges are reduced to `Range<Int>` same way as Apple does it in Combine.