### PR TITLE
Enable URLSession additions on other OS's in swift 6

### DIFF
--- a/Sources/Afluent/Additions/URLSessionAdditions.swift
+++ b/Sources/Afluent/Additions/URLSessionAdditions.swift
@@ -1,4 +1,4 @@
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(visionOS) || swift(>=6.0)
     //
     //  URLSessionAdditions.swift
     //
@@ -7,6 +7,9 @@
     //
 
     import Foundation
+    #if canImport(FoundationNetworking)
+        import FoundationNetworking
+    #endif
 
     extension URLSession {
         /// Returns a deferred data task that wraps a URL session data task for a given URL.


### PR DESCRIPTION
With [this PR](https://github.com/swiftlang/swift-corelibs-foundation/pull/4970), the async/await URLSession functions are now available on other OS's, but only in swift 6.

Updates `URLSessionAdditions.swift` to also check for swift 6, and enable these urlsession -> afluent bridge functions when possible.