### PR TITLE
[publicize-share] - Remove all SPI protections - TT

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,12 +159,6 @@ Remember, while Afluent and Combine have similarities, they are distinct librari
   **1. How can I contribute to Afluent or report issues?**  
   Afluent is hosted on GitHub. You can fork the repository, make changes, and submit a pull request. For reporting issues, open a new issue on the GitHub repository with a detailed description.
 
-  **2. Why isn't there a `share` operator for sequences?**  
-  Afluent strives to not interfere with ongoing work from Apple. The desire for multicast or share functionality has been strong in the community and the [swift-async-algorithms team is working on a broadcast operator to help](https://github.com/apple/swift-async-algorithms). It's also worth noting that solving this problem is non-trivial, like timing operations. As a consequence, the Afluent team prefers to leave that complexity to Apple to manage.
-
-  **3. If you won't build `share` why did you build `Deferred`?**  
-  It's worth noting that the async algorithms team introduced a `deferred` global function that operates similarly to Afluent's `Deferred` sequence. The reason Afluent implemented this was because of the ease of implementation coupled with the more immediate need. At the time of writing Async Algorithms will not release `deferred` until v1.1 and Afluent can fill the gap easily until that happens. 
-
   **4. Why is it Afluent and not Affluent?**
   Async/Await + Fluent == Afluent
 

--- a/Sources/Afluent/AsyncSequenceCache.swift
+++ b/Sources/Afluent/AsyncSequenceCache.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-@_spi(Experimental) public final class AsyncSequenceCache: @unchecked Sendable {
+public final class AsyncSequenceCache: @unchecked Sendable {
     let lock = NSRecursiveLock()
     var cache = [Int: any AsyncSequence]()
 
@@ -42,7 +42,7 @@ import Foundation
 
 extension AsyncSequenceCache {
     /// `Strategy` represents the available caching strategies for the `AsyncSequenceCache`.
-    @_spi(Experimental) public enum Strategy {
+    public enum Strategy {
         /// With the `.cacheUntilCompletionOrCancellation` strategy, the cache
         /// retains the result until the sequence completes or is canceled.
         case cacheUntilCompletionOrCancellation

--- a/Sources/Afluent/CurrentValueSubject.swift
+++ b/Sources/Afluent/CurrentValueSubject.swift
@@ -8,7 +8,6 @@
 /// A subject that broadcasts its current value and all subsequent values to multiple consumers.
 /// It can also handle completion events, including normal termination and failure with an error.
 /// This is an `AsyncSequence` that allows multiple tasks to asynchronously consume values and mimics Combine's CurrentValueSubject.
-@_spi(Experimental)
 public final class CurrentValueSubject<Element: Sendable>: AsyncSequence, @unchecked Sendable {
     class State: @unchecked Sendable {
         private let lock = Lock.allocate()
@@ -116,7 +115,7 @@ public final class CurrentValueSubject<Element: Sendable>: AsyncSequence, @unche
     }
 }
 
-@_spi(Experimental) extension CurrentValueSubject {
+extension CurrentValueSubject {
     /// Represents the completion event of a subject, which can either succeed or fail with an error.
     public enum Completion<Failure: Error> {
         case finished

--- a/Sources/Afluent/PassthroughSubject.swift
+++ b/Sources/Afluent/PassthroughSubject.swift
@@ -9,7 +9,6 @@
 /// Unlike `CurrentValueSubject`, `PassthroughSubject` does not retain the most recent value.
 /// It only sends values as they are emitted, meaning consumers will only receive values that are sent after they start listening.
 /// This is an `AsyncSequence` that allows multiple tasks to asynchronously consume values and mimics Combine's PassthroughSubject.
-@_spi(Experimental)
 public final class PassthroughSubject<Element: Sendable>: AsyncSequence, @unchecked Sendable {
     private class State: @unchecked Sendable {
         private let lock = Lock.allocate()
@@ -76,7 +75,7 @@ public final class PassthroughSubject<Element: Sendable>: AsyncSequence, @unchec
     }
 }
 
-@_spi(Experimental) extension PassthroughSubject {
+extension PassthroughSubject {
     /// Represents the completion event of a subject, which can either succeed or fail with an error.
     public enum Completion<Failure: Error> {
         case finished

--- a/Sources/Afluent/SequenceOperators/ShareFromCacheSequence.swift
+++ b/Sources/Afluent/SequenceOperators/ShareFromCacheSequence.swift
@@ -46,7 +46,7 @@ extension AsyncSequence where Self: Sendable, Element: Sendable {
     ///   - line: The line number where this function is called. Defaults to `#line`.
     ///   - column: The column where this function is called. Defaults to `#column`.
     /// - Returns: An asynchronous unit of work encapsulating the operation's success or failure.
-    @_spi(Experimental) public func shareFromCache(
+    public func shareFromCache(
         _ cache: AsyncSequenceCache, strategy: AsyncSequenceCache.Strategy,
         fileId: String = #fileID,
         function: String = #function, line: UInt = #line, column: UInt = #column
@@ -64,7 +64,7 @@ extension AsyncSequence where Self: Sendable, Element: Sendable {
     ///   - strategy: The caching strategy to use.
     ///   - keys: One or more hashable keys used to look up the data in the cache.
     /// - Returns: An asynchronous unit of work encapsulating the operation's success or failure.
-    @_spi(Experimental) public func shareFromCache<H0: Hashable>(
+    public func shareFromCache<H0: Hashable>(
         _ cache: AsyncSequenceCache, strategy: AsyncSequenceCache.Strategy, keys k0: H0
     ) -> AsyncBroadcastSequence<AsyncSequences.HandleEvents<Self>> {
         var hasher = Hasher()
@@ -79,7 +79,7 @@ extension AsyncSequence where Self: Sendable, Element: Sendable {
     ///   - strategy: The caching strategy to use.
     ///   - keys: One or more hashable keys used to look up the data in the cache.
     /// - Returns: An asynchronous unit of work encapsulating the operation's success or failure.
-    @_spi(Experimental) public func shareFromCache<H0: Hashable, H1: Hashable>(
+    public func shareFromCache<H0: Hashable, H1: Hashable>(
         _ cache: AsyncSequenceCache, strategy: AsyncSequenceCache.Strategy, keys k0: H0, _ k1: H1
     ) -> AsyncBroadcastSequence<AsyncSequences.HandleEvents<Self>> {
         var hasher = Hasher()
@@ -95,7 +95,7 @@ extension AsyncSequence where Self: Sendable, Element: Sendable {
     ///   - strategy: The caching strategy to use.
     ///   - keys: One or more hashable keys used to look up the data in the cache.
     /// - Returns: An asynchronous unit of work encapsulating the operation's success or failure.
-    @_spi(Experimental) public func shareFromCache<H0: Hashable, H1: Hashable, H2: Hashable>(
+    public func shareFromCache<H0: Hashable, H1: Hashable, H2: Hashable>(
         _ cache: AsyncSequenceCache, strategy: AsyncSequenceCache.Strategy, keys k0: H0, _ k1: H1,
         _ k2: H2
     ) -> AsyncBroadcastSequence<AsyncSequences.HandleEvents<Self>> {
@@ -113,7 +113,6 @@ extension AsyncSequence where Self: Sendable, Element: Sendable {
     ///   - strategy: The caching strategy to use.
     ///   - keys: One or more hashable keys used to look up the data in the cache.
     /// - Returns: An asynchronous unit of work encapsulating the operation's success or failure.
-    @_spi(Experimental)
     public func shareFromCache<H0: Hashable, H1: Hashable, H2: Hashable, H3: Hashable>(
         _ cache: AsyncSequenceCache, strategy: AsyncSequenceCache.Strategy, keys k0: H0, _ k1: H1,
         _ k2: H2, _ k3: H3
@@ -133,7 +132,6 @@ extension AsyncSequence where Self: Sendable, Element: Sendable {
     ///   - strategy: The caching strategy to use.
     ///   - keys: One or more hashable keys used to look up the data in the cache.
     /// - Returns: An asynchronous unit of work encapsulating the operation's success or failure.
-    @_spi(Experimental)
     public func shareFromCache<
         H0: Hashable, H1: Hashable, H2: Hashable, H3: Hashable, H4: Hashable
     >(
@@ -157,7 +155,6 @@ extension AsyncSequence where Self: Sendable, Element: Sendable {
     ///   - strategy: The caching strategy to use.
     ///   - keys: One or more hashable keys used to look up the data in the cache.
     /// - Returns: An asynchronous unit of work encapsulating the operation's success or failure.
-    @_spi(Experimental)
     public func shareFromCache<
         H0: Hashable, H1: Hashable, H2: Hashable, H3: Hashable, H4: Hashable, H5: Hashable
     >(
@@ -182,7 +179,6 @@ extension AsyncSequence where Self: Sendable, Element: Sendable {
     ///   - strategy: The caching strategy to use.
     ///   - keys: One or more hashable keys used to look up the data in the cache.
     /// - Returns: An asynchronous unit of work encapsulating the operation's success or failure.
-    @_spi(Experimental)
     public func shareFromCache<
         H0: Hashable, H1: Hashable, H2: Hashable, H3: Hashable, H4: Hashable, H5: Hashable,
         H6: Hashable
@@ -209,7 +205,6 @@ extension AsyncSequence where Self: Sendable, Element: Sendable {
     ///   - strategy: The caching strategy to use.
     ///   - keys: One or more hashable keys used to look up the data in the cache.
     /// - Returns: An asynchronous unit of work encapsulating the operation's success or failure.
-    @_spi(Experimental)
     public func shareFromCache<
         H0: Hashable, H1: Hashable, H2: Hashable, H3: Hashable, H4: Hashable, H5: Hashable,
         H6: Hashable, H7: Hashable
@@ -237,7 +232,6 @@ extension AsyncSequence where Self: Sendable, Element: Sendable {
     ///   - strategy: The caching strategy to use.
     ///   - keys: One or more hashable keys used to look up the data in the cache.
     /// - Returns: An asynchronous unit of work encapsulating the operation's success or failure.
-    @_spi(Experimental)
     public func shareFromCache<
         H0: Hashable, H1: Hashable, H2: Hashable, H3: Hashable, H4: Hashable, H5: Hashable,
         H6: Hashable, H7: Hashable, H8: Hashable
@@ -266,7 +260,6 @@ extension AsyncSequence where Self: Sendable, Element: Sendable {
     ///   - strategy: The caching strategy to use.
     ///   - keys: One or more hashable keys used to look up the data in the cache.
     /// - Returns: An asynchronous unit of work encapsulating the operation's success or failure.
-    @_spi(Experimental)
     public func shareFromCache<
         H0: Hashable, H1: Hashable, H2: Hashable, H3: Hashable, H4: Hashable, H5: Hashable,
         H6: Hashable, H7: Hashable, H8: Hashable, H9: Hashable

--- a/Sources/Afluent/SequenceOperators/ShareSequence.swift
+++ b/Sources/Afluent/SequenceOperators/ShareSequence.swift
@@ -16,7 +16,7 @@
 //  Modified by Tyler Thompson on 9/29/24.
 //
 
-@_spi(Experimental) extension AsyncSequence where Self: Sendable, Element: Sendable {
+extension AsyncSequence where Self: Sendable, Element: Sendable {
     public func broadcast() -> AsyncBroadcastSequence<Self> {
         AsyncBroadcastSequence(self)
     }
@@ -26,7 +26,7 @@
     }
 }
 
-@_spi(Experimental) public struct AsyncBroadcastSequence<Base: AsyncSequence>: Sendable
+public struct AsyncBroadcastSequence<Base: AsyncSequence>: Sendable
 where Base: Sendable, Base.Element: Sendable {
     struct State: Sendable {
         enum Terminal {
@@ -201,7 +201,7 @@ where Base: Sendable, Base.Element: Sendable {
     }
 }
 
-@_spi(Experimental) extension AsyncBroadcastSequence: AsyncSequence {
+extension AsyncBroadcastSequence: AsyncSequence {
     public typealias Element = Base.Element
 
     public struct Iterator: AsyncIteratorProtocol {
@@ -259,4 +259,4 @@ where Base: Sendable, Base.Element: Sendable {
 }
 
 @available(*, unavailable)
-@_spi(Experimental) extension AsyncBroadcastSequence.Iterator: Sendable {}
+extension AsyncBroadcastSequence.Iterator: Sendable {}

--- a/Tests/AfluentTests/CurrentValueSubjectTests.swift
+++ b/Tests/AfluentTests/CurrentValueSubjectTests.swift
@@ -5,7 +5,7 @@
 //  Created by Tyler Thompson on 10/12/24.
 //
 
-@_spi(Experimental) import Afluent
+import Afluent
 import Testing
 
 struct CurrentValueSubjectTests {

--- a/Tests/AfluentTests/PassthroughSubjectTests.swift
+++ b/Tests/AfluentTests/PassthroughSubjectTests.swift
@@ -5,7 +5,7 @@
 //  Created by Tyler Thompson on 10/12/24.
 //
 
-@_spi(Experimental) import Afluent
+import Afluent
 import Testing
 
 struct PassthroughSubjectTests {

--- a/Tests/AfluentTests/SequenceTests/ShareFromCacheSequenceTests.swift
+++ b/Tests/AfluentTests/SequenceTests/ShareFromCacheSequenceTests.swift
@@ -5,7 +5,7 @@
 //  Created by Tyler Thompson on 10/19/24.
 //
 
-@_spi(Experimental) @testable import Afluent
+@testable import Afluent
 import Clocks
 import ConcurrencyExtras
 import Foundation

--- a/Tests/AfluentTests/SequenceTests/ShareSequenceTests.swift
+++ b/Tests/AfluentTests/SequenceTests/ShareSequenceTests.swift
@@ -16,7 +16,7 @@
 //  Modified by Tyler Thompson on 9/29/24.
 //
 
-@_spi(Experimental) import Afluent
+import Afluent
 import Testing
 
 @Suite struct ShareSequenceTests {

--- a/Tests/AfluentTests/SequenceTests/TimerSequenceTests.swift
+++ b/Tests/AfluentTests/SequenceTests/TimerSequenceTests.swift
@@ -5,7 +5,7 @@
 //  Created by Annalise Mariottini on 11/9/24.
 //
 
-@_spi(Experimental) import Afluent
+import Afluent
 import AfluentTesting
 import Atomics
 import Clocks


### PR DESCRIPTION
Previously the `share` operator on `AsyncSequence` was behind `@_spi(Experimental)` because it'd been taken from swift-async-algorithms. This also prevented `shareFromCache`, `CurrentValueSubject`, and `PassthroughSubject` from being exposed without the SPI. Now that we've had some users in production with it I think it's about time to get rid of the SPI protections. They've honestly been more irritating than helpful.