### PR TITLE
[scan-operator] - Added a scan operator - TT

### DIFF
--- a/.github/workflows/MERGE_QUEUE.yml
+++ b/.github/workflows/MERGE_QUEUE.yml
@@ -43,7 +43,7 @@ jobs:
         - "platform=iOS Simulator,name=iPad mini (A17 Pro),OS=18.2"
         - "platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=18.1"
         - "platform=visionOS Simulator,name=Apple Vision Pro,OS=2.0"
-        - "platform=watchOS Simulator,name=Apple Watch Ultra 2 (49mm),OS=10.5"
+        - "platform=watchOS Simulator,name=Apple Watch Ultra 2 (49mm),OS=11.5"
     steps:
       - uses: actions/checkout@v4
       - name: Build and Test for ${{ matrix.destination }}

--- a/.github/workflows/MERGE_QUEUE.yml
+++ b/.github/workflows/MERGE_QUEUE.yml
@@ -39,7 +39,7 @@ jobs:
         destination:
         - "platform=macOS,arch=arm64"
         - "platform=macOS,arch=arm64,variant=Mac Catalyst"
-        - "platform=iOS Simulator,name=iPhone 15 Pro,OS=17.5"
+        - "platform=iOS Simulator,name=iPhone 16 Pro,OS=18.5"
         - "platform=iOS Simulator,name=iPad mini (A17 Pro),OS=18.2"
         - "platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=18.1"
         - "platform=visionOS Simulator,name=Apple Vision Pro,OS=2.0"

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -2,11 +2,11 @@ version: 0.1
 merge: 
   required_statuses:
     - apple-platform-regression-tests (platform=iOS Simulator,name=iPad mini (A17 Pro),OS=18.2)
-    - apple-platform-regression-tests (platform=iOS Simulator,name=iPhone 15 Pro,OS=17.5)
+    - apple-platform-regression-tests (platform=iOS Simulator,name=iPhone 16 Pro,OS=18.5)
     - apple-platform-regression-tests (platform=macOS,arch=arm64,variant=Mac Catalyst)
     - apple-platform-regression-tests (platform=macOS,arch=arm64)
     - apple-platform-regression-tests (platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=18.1)
     - apple-platform-regression-tests (platform=visionOS Simulator,name=Apple Vision Pro,OS=2.0)
-    - apple-platform-regression-tests (platform=watchOS Simulator,name=Apple Watch Ultra 2 (49mm),OS=10.5)
+    - apple-platform-regression-tests (platform=watchOS Simulator,name=Apple Watch Ultra 2 (49mm),OS=11.5)
     - swift-regression-tests (5.10)
     - swift-regression-tests (5.9)

--- a/Sources/Afluent/SequenceOperators/ScanSequence.swift
+++ b/Sources/Afluent/SequenceOperators/ScanSequence.swift
@@ -1,0 +1,58 @@
+//
+//  ScanSequence.swift
+//  Afluent
+//
+//  Created by Tyler Thompson on 6/14/25.
+//
+
+import Foundation
+
+extension AsyncSequences {
+    public struct Scan<Upstream: AsyncSequence & Sendable, Output: Sendable>: AsyncSequence, Sendable
+    where Upstream.Element: Sendable {
+        public typealias Element = Output
+
+        let upstream: Upstream
+        let initialResult: Output
+        let nextPartialResult: @Sendable (Output, Upstream.Element) async throws -> Output
+
+        public struct AsyncIterator: AsyncIteratorProtocol {
+            var upstream: Upstream.AsyncIterator
+            let nextPartialResult: @Sendable (Output, Upstream.Element) async throws -> Output
+            private var nextResult: Output
+
+            init(upstream: Upstream.AsyncIterator, initialResult: Output, nextPartialResult: @Sendable @escaping (Output, Upstream.Element) async throws -> Output) {
+                self.upstream = upstream
+                self.nextResult = initialResult
+                self.nextPartialResult = nextPartialResult
+            }
+            
+            public mutating func next() async throws -> Element? {
+                try Task.checkCancellation()
+                guard let upstreamNext = try await upstream.next() else { return nil }
+                nextResult = try await nextPartialResult(nextResult, upstreamNext)
+                return nextResult
+            }
+        }
+
+        public func makeAsyncIterator() -> AsyncIterator {
+            AsyncIterator(upstream: upstream.makeAsyncIterator(), initialResult: initialResult, nextPartialResult: nextPartialResult)
+        }
+    }
+}
+
+extension AsyncSequence where Self: Sendable {
+    /// Transforms elements from the upstream sequence by providing the current
+    /// element to a closure along with the last value returned by the closure.
+    ///
+    /// Use ``AsyncSequence/scan(_:_:)`` to accumulate all previously-published values into a single
+    /// value, which you then combine with each newly-published value.
+    ///
+    /// - Parameters:
+    ///   - initialResult: The previous result returned by the `nextPartialResult` closure.
+    ///   - nextPartialResult: A closure that takes as its arguments the previous value returned by the closure and the next element emitted from the upstream sequence.
+    /// - Returns: A sequence that transforms elements by applying a closure that receives its previous return value and the next element from the upstream sequence.
+    public func scan<T>(_ initialResult: T, _ nextPartialResult: @Sendable @escaping (T, Self.Element) async throws -> T) -> AsyncSequences.Scan<Self, T> {
+        .init(upstream: self, initialResult: initialResult, nextPartialResult: nextPartialResult)
+    }
+}

--- a/Tests/AfluentTests/SequenceTests/ScanSequenceTests.swift
+++ b/Tests/AfluentTests/SequenceTests/ScanSequenceTests.swift
@@ -1,0 +1,86 @@
+//
+//  ScanSequenceTests.swift
+//  Afluent
+//
+//  Created by Tyler Thompson on 6/14/25.
+//
+
+import Afluent
+import Foundation
+import Testing
+
+struct ScanSequenceTests {
+    @Test func scanAccumulatesValuesCorrectly() async throws {
+        let input = [1, 2, 3, 4, 5].async
+        let result = try await input
+            .scan(0) { $0 + $1 }
+            .collect()
+            .first()
+        
+        try #expect(#require(result) == [1, 3, 6, 10, 15])
+    }
+
+    @Test func scanEmitsNoValuesOnEmptyUpstream() async throws {
+        let input = [Int]().async
+        let result = try await input
+            .scan(100) { $0 + $1 }
+            .collect()
+            .first()
+
+        try #expect(#require(result).isEmpty)
+    }
+
+    @Test func scanHandlesSingleElement() async throws {
+        let input = [42].async
+        let result = try await input
+            .scan(10) { $0 * $1 }
+            .collect()
+            .first()
+
+        try #expect(#require(result) == [420])
+    }
+
+    @Test func scanPropagatesErrors() async throws {
+        enum TestError: Error { case boom }
+
+        let stream = AsyncThrowingStream<Int, Error> { continuation in
+            continuation.yield(1)
+            continuation.yield(2)
+            continuation.finish(throwing: TestError.boom)
+        }
+
+        let task = Task {
+            try await stream
+                .scan(0) { $0 + $1 }
+                .collect()
+                .first()
+        }
+
+        let result = await task.result
+        #expect(throws: TestError.boom) { try result.get() }
+    }
+
+    @Test func scanSupportsCancellation() async throws {
+        let stream = AsyncThrowingStream<Int, Error> { continuation in
+            continuation.yield(1)
+            continuation.yield(2)
+            continuation.yield(3)
+            // Delay finish to allow cancellation
+            Task {
+                try? await Task.sleep(nanoseconds: 1_000_000)
+                continuation.finish()
+            }
+        }
+
+        let task = Task {
+            try await stream
+                .scan(0) { $0 + $1 }
+                .collect()
+                .first()
+        }
+
+        task.cancel()
+        let result = await task.result
+        #expect(throws: CancellationError.self) { try result.get() }
+    }
+}


### PR DESCRIPTION
[Scan](https://developer.apple.com/documentation/combine/publisher/scan(_:_:)) is an operator provided by Combine that's handy for creating streams that know how to operate over previous values. For example, you can use a trick like this to look at the previous and current value in a sequence:
```swift
scan(Optional<(Output?, Output)>.none) { ($0?.1, $1) }
    .compactMap { $0 }
```

This would allow you to build up sequences that only emit when the upstream changes its value. 

The addition to Afluent furthers the parity between Afluent and Combine.