### PR TITLE
Added examples to documentation for all operators

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+early_access: false
+reviews:
+  profile: "assertive"
+  request_changes_workflow: true
+  high_level_summary: true
+  poem: false
+  review_status: true
+  collapse_walkthrough: true
+  changed_files_summary: true
+  suggested_reviewers: false
+chat:
+  auto_reply: true

--- a/Sources/Afluent/AUOWCacheStrategies/AUOWCache+CacheUntilCompletionOrCancellation.swift
+++ b/Sources/Afluent/AUOWCacheStrategies/AUOWCache+CacheUntilCompletionOrCancellation.swift
@@ -8,6 +8,39 @@
 import Foundation
 
 extension AUOWCache {
+    /// A caching strategy that retains a unit of work in the cache until it completes, fails, or is cancelled.
+    ///
+    /// This strategy is useful when you want to deduplicate concurrent requests for the same unit of work, ensuring that
+    /// all consumers receive the same result, and the cached value is automatically cleared after completion or cancellation.
+    ///
+    /// The cached entry is cleared on:
+    /// - successful completion (output received)
+    /// - error thrown
+    /// - cancellation
+    ///
+    /// ## Example
+    ///
+    /// ```swift
+    /// let cache = AUOWCache()
+    ///
+    /// // A unit of work that produces a String after a delay
+    /// @Sendable func unitOfWork() -> some AsynchronousUnitOfWork<String> {
+    ///     DeferredTask {
+    ///         // ... expensive computation or network call ...
+    ///         return "result"
+    ///     }
+    ///     .shareFromCache(cache, strategy: .cacheUntilCompletionOrCancellation)
+    /// }
+    ///
+    /// // First execution stores the value in the cache
+    /// let task1 = unitOfWork().execute()
+    /// // Second execution (if started before completion) shares the cached value
+    /// let task2 = unitOfWork().execute()
+    ///
+    /// // When task1 completes, the cache entry is cleared
+    /// ```
+    ///
+    /// See also: ``AUOWCacheStrategy/cacheUntilCompletionOrCancellation``
     public struct CacheUntilCompletionOrCancellation: AUOWCacheStrategy {
         public func handle<A: AsynchronousUnitOfWork>(
             unitOfWork: A, keyedBy key: Int, storedIn cache: AUOWCache
@@ -31,8 +64,11 @@ extension AUOWCache {
 }
 
 extension AUOWCacheStrategy where Self == AUOWCache.CacheUntilCompletionOrCancellation {
-    /// With the `.cacheUntilCompletionOrCancellation` strategy, the cache
-    /// retains the result until the unit of work completes or is cancelled.
+    /// Returns the `.cacheUntilCompletionOrCancellation` strategy.
+    ///
+    /// Use this to cache a unit of work until it completes or is cancelled.
+    ///
+    /// See ``AUOWCache.CacheUntilCompletionOrCancellation`` for usage examples.
     public static var cacheUntilCompletionOrCancellation: Self {
         AUOWCache.CacheUntilCompletionOrCancellation()
     }

--- a/Sources/Afluent/AUOWCacheStrategies/AUOWCache+CancelAndRetry.swift
+++ b/Sources/Afluent/AUOWCacheStrategies/AUOWCache+CancelAndRetry.swift
@@ -8,7 +8,51 @@
 import Foundation
 
 extension AUOWCache {
+    /// A caching strategy that cancels any existing in-flight unit of work for a key, then starts the new one.
+    ///
+    /// This strategy is useful when you want to ensure only the latest requested unit of work for a given key is running, and any prior work is cancelled.
+    ///
+    /// The cached entry is cleared on:
+    /// - successful completion (output received)
+    /// - error thrown
+    /// - cancellation
+    ///
+    /// ## Example
+    ///
+    /// ```swift
+    /// let cache = AUOWCache()
+    /// let clock = TestClock()
+    ///
+    /// // A unit of work that produces a String after a delay
+    /// @Sendable func unitOfWork() -> some AsynchronousUnitOfWork<String> {
+    ///     DeferredTask {
+    ///         UUID().uuidString
+    ///     }
+    ///     .delay(for: .milliseconds(10), clock: clock)
+    ///     .shareFromCache(cache, strategy: .cancelAndRestart)
+    /// }
+    ///
+    /// // First execution starts the work
+    /// async let r1 = Result { try await unitOfWork().execute() }
+    /// // Second execution before the first completes cancels the previous one
+    /// async let r2 = Result { try await unitOfWork().execute() }
+    ///
+    /// await clock.advance(by: .milliseconds(11))
+    /// let result1 = await r1
+    /// let result2 = await r2
+    ///
+    /// // result1 should throw CancellationError, result2 completes successfully
+    /// ```
+    ///
+    /// See also: ``AUOWCacheStrategy/cancelAndRestart``
     public struct CancelAndRetry: AUOWCacheStrategy {
+        /// Handles the unit of work for this strategy, cancelling any in-flight work with the same key and starting the new one.
+        ///
+        /// - Parameters:
+        ///   - unitOfWork: The unit of work to perform.
+        ///   - key: The cache key associated with the unit of work.
+        ///   - cache: The cache to use for sharing or cancelling work.
+        /// - Returns: An asynchronous unit of work that will clear its cache entry after completion, error, or cancellation.
         public func handle<A: AsynchronousUnitOfWork>(
             unitOfWork: A, keyedBy key: Int, storedIn cache: AUOWCache
         ) -> AnyAsynchronousUnitOfWork<A.Success> {
@@ -34,6 +78,8 @@ extension AUOWCache {
 }
 
 extension AUOWCacheStrategy where Self == AUOWCache.CancelAndRetry {
-    /// This strategy indicates that any existing work should be cancelled before restarting the upstream work again.
+    /// Returns the `.cancelAndRestart` strategy.
+    ///
+    /// Use this to cancel any in-flight unit of work for a given key before starting the new one. See ``AUOWCache.CancelAndRetry`` for a usage example.
     public static var cancelAndRestart: Self { AUOWCache.CancelAndRetry() }
 }

--- a/Sources/Afluent/AUOWCacheStrategies/AUOWCacheStrategy.swift
+++ b/Sources/Afluent/AUOWCacheStrategies/AUOWCacheStrategy.swift
@@ -7,10 +7,39 @@
 
 import Foundation
 
-/// ``AUOWCacheStrategy`` represents the available caching strategies for the ``AUOWCache``.
+/// Represents a cache strategy for use with ``AUOWCache``.
+///
+/// Conforming types determine how units of work are stored, reused, or cancelled within the cache.
+///
+/// > Tip: Use or extend built-in strategies like ``AUOWCache.CancelAndRetry`` or ``AUOWCache.CacheUntilCompletionOrCancellation`` for common needs, or create a custom strategy for specialized scenarios.
+///
+/// ## Example
+///
+/// ```swift
+/// struct NeverCacheStrategy: AUOWCacheStrategy {
+///     func handle<A: AsynchronousUnitOfWork>(unitOfWork: A, keyedBy key: Int, storedIn cache: AUOWCache) -> AnyAsynchronousUnitOfWork<A.Success> {
+///         unitOfWork.eraseToAnyUnitOfWork()
+///     }
+/// }
+///
+/// let cache = AUOWCache()
+/// let myStrategy = NeverCacheStrategy()
+/// let task = DeferredTask { "value" }
+///     .shareFromCache(cache, strategy: myStrategy)
+///
+/// // Alternatively, use built-in strategies like:
+/// // .shareFromCache(cache, strategy: .cancelAndRestart)
+/// ```
 public protocol AUOWCacheStrategy {
-    /// A caching strategy implementation that handles some work, keyed by some hashed key, which may be stored in or retrieved from the passed cache.
+    /// Performs strategy-specific logic to store or retrieve an asynchronous unit of work in the cache.
+    ///
+    /// - Parameters:
+    ///   - unitOfWork: The unit of work being evaluated or started.
+    ///   - key: The hashed cache key for the unit of work.
+    ///   - cache: The cache instance in which to store or from which to retrieve work.
+    /// - Returns: An erased asynchronous unit of work. The specifics depend on the strategy implementation.
     func handle<A: AsynchronousUnitOfWork>(
         unitOfWork: A, keyedBy key: Int, storedIn cache: AUOWCache
     ) -> AnyAsynchronousUnitOfWork<A.Success>
 }
+

--- a/Sources/Afluent/AsynchronousUnitOfWorkCache.swift
+++ b/Sources/Afluent/AsynchronousUnitOfWorkCache.swift
@@ -10,15 +10,28 @@ import Foundation
 public typealias AUOWCache = AsynchronousUnitOfWorkCache
 public typealias AnySendableReference = AnyObject & Sendable
 
-/// A cache for asynchronous unit of work types.
-/// A stored unit of work should be both `Sendable` and a reference type (e.g. a unit of work shared via the ``AsynchronousUnitOfWork/share()`` operator).
+/// A thread-safe cache for storing and sharing asynchronous units of work.
+///
+/// Store and retrieve reference-type, sendable units of work keyed by an integer. This cache is typically used by the ``shareFromCache(_:strategy:keys:)`` operator to deduplicate and share underlying work across consumers.
+///
+/// Use this cache to avoid redundant execution of identical units of work, especially those that are expensive or should only be performed once for a given key.
+/// ## Example
+/// ```
+/// let cache = AUOWCache()
+/// let work = DeferredTask { await fetchUser() }
+///     .shareFromCache(cache, strategy: .cacheUntilCompletionOrCancellation, keys: "user42")
+/// let _ = try await work.execute()
+/// ```
 public final class AsynchronousUnitOfWorkCache: @unchecked Sendable {
     let lock = NSRecursiveLock()
     var cache = [Int: any AsynchronousUnitOfWork & AnySendableReference]()
 
     public init() {}
 
-    /// Returns a stored unit of work for the given key, if it exists in the cache.
+    /// Retrieves a stored unit of work for the given key, if it exists in the cache.
+    ///
+    /// - Parameter key: The integer cache key associated with the unit of work.
+    /// - Returns: The stored unit of work if present, or `nil` if none is cached.
     public func retrieve(
         keyedBy key: Int
     ) -> (any AsynchronousUnitOfWork & AnySendableReference)? {
@@ -28,7 +41,14 @@ public final class AsynchronousUnitOfWorkCache: @unchecked Sendable {
         return fromCache
     }
 
-    /// Creates a new cached unit of work for the given key.
+    /// Stores a unit of work in the cache for the given key.
+    ///
+    /// If a unit of work already exists for the key, it is replaced with the provided one.
+    ///
+    /// - Parameters:
+    ///   - unitOfWork: The unit of work to cache. Must be reference-type and sendable.
+    ///   - key: The integer cache key to associate with the unit of work.
+    /// - Returns: The cached unit of work (the same instance passed in).
     public func create<A: AsynchronousUnitOfWork & AnySendableReference>(
         unitOfWork: A, keyedBy key: Int
     ) -> A {
@@ -38,7 +58,14 @@ public final class AsynchronousUnitOfWorkCache: @unchecked Sendable {
         return unitOfWork
     }
 
-    /// Either retrieves a stored unit of work for the given key, or creates a new one if no current one exists.
+    /// Retrieves the unit of work for the given key if present; otherwise, stores the provided unit of work and returns it.
+    ///
+    /// This is typically used to deduplicate work by sharing a single instance for the same key.
+    ///
+    /// - Parameters:
+    ///   - unitOfWork: The unit of work to cache if a value does not yet exist for the key.
+    ///   - key: The integer cache key to lookup or store under.
+    /// - Returns: The cached or newly created unit of work.
     public func retrieveOrCreate<A: AsynchronousUnitOfWork & AnySendableReference>(
         unitOfWork: A, keyedBy key: Int
     ) -> A {
@@ -53,12 +80,20 @@ public final class AsynchronousUnitOfWorkCache: @unchecked Sendable {
         return unitOfWork
     }
 
+    /// Removes the cached unit of work for the given key, if present.
+    ///
+    /// This is used internally by cache strategies to clear results when a unit of work completes, fails, or is cancelled.
+    ///
+    /// - Parameter key: The integer cache key to clear.
     public func clearAsynchronousUnitOfWork(withKey key: Int) {
         lock.lock()
         defer { lock.unlock() }
         cache.removeValue(forKey: key)
     }
 
+    /// Cancels all cached units of work and removes them from the cache upon deinitialization.
+    ///
+    /// This ensures no hanging work remains in memory if the cache is released.
     deinit {
         lock.lock()
         defer { lock.unlock() }
@@ -66,3 +101,4 @@ public final class AsynchronousUnitOfWorkCache: @unchecked Sendable {
         cache.removeAll()
     }
 }
+

--- a/Sources/Afluent/DeferredTask.swift
+++ b/Sources/Afluent/DeferredTask.swift
@@ -7,21 +7,85 @@
 
 import Foundation
 
-/// A structure representing a deferred asynchronous unit of work.
+/// A deferred unit of asynchronous work that produces a result of type `Success`.
 ///
-/// `DeferredTask` conforms to the `AsynchronousUnitOfWork` protocol and allows you to encapsulate an asynchronous operation
-/// that produces a result of type `Success`. The operation will be executed in a deferred manner, i.e., it won't start
-/// until explicitly awaited.
+/// `DeferredTask` represents an asynchronous operation that is defined but does not start executing until it is explicitly started.
+/// This allows precise control over when the asynchronous work begins, supporting scenarios where you want to set up an async operation ahead of time and
+/// trigger its execution at a chosen moment.
 ///
-/// - Note: The `Success` type must conform to the `Sendable` protocol.
+/// This type conforms to the `AsynchronousUnitOfWork` protocol and is useful for wrapping async computations, network requests, or any other asynchronous operation
+/// that may throw an error and returns a value.
+///
+/// ## Example
+///
+/// Basic usage with `execute()` to start and await the operation:
+/// ```
+/// let deferred = DeferredTask<Int> {
+///     try await Task.sleep(nanoseconds: 1_000_000_000)
+///     return 42
+/// }
+/// let result = try await deferred.execute()
+/// print("Result is \(result)")
+/// ```
+///
+/// Accessing the result via the `result` property (an async property that awaits completion):
+/// ```
+/// let deferred = DeferredTask<Int> {
+///     10 * 5
+/// }
+/// let value = await deferred.result
+/// print("Value is \(value)")
+/// ```
+///
+/// Running the operation without awaiting its result immediately, via `run()`:
+/// ```
+/// let deferred = DeferredTask<Int> {
+///     7 + 3
+/// }
+/// deferred.run()
+/// // Later, you may await the result property or handle completion otherwise
+/// ```
+///
+/// Subscribing to the task's events using `subscribe()`:
+/// ```
+/// let deferred = DeferredTask<String> {
+///     "Hello, World!"
+/// }
+/// let cancellable = deferred.subscribe { event in
+///     switch event {
+///     case .success(let value):
+///         print("Completed with value: \(value)")
+///     case .failure(let error):
+///         print("Failed with error: \(error)")
+///     }
+/// }
+/// ```
+///
+/// Storing the subscription in a collection for lifecycle management:
+/// ```
+/// var cancellables = Set<AnyCancellable>()
+/// let deferred = DeferredTask<Void> {
+///     print("Task executed")
+/// }
+/// deferred.subscribe().store(in: &cancellables)
+/// ```
+///
+/// Chaining with operators:
+/// ```
+/// let result = try await DeferredTask { 21 }
+///     .map { $0 * 2 }
+///     .execute() // result is 42
+/// ```
 public actor DeferredTask<Success: Sendable>: AsynchronousUnitOfWork {
+    /// The internal state of the task, tracking its lifecycle and result.
     public let state = TaskState<Success>()
+    
+    /// The asynchronous operation to be executed when awaited.
     let operation: @Sendable () async throws -> Success
 
-    /// Initializes a new instance of `DeferredTask`.
+    /// Initializes a new `DeferredTask` with the provided asynchronous operation.
     ///
-    /// - Parameters:
-    ///   - operation: The asynchronous operation that this task will execute. The operation should be a throwing, async closure that returns a value of type `Success`.
+    /// - Parameter operation: An async closure representing the work to be performed. The closure can throw errors and must return a value of type `Success`.
     public init(
         @_inheritActorContext @_implicitSelfCapture operation: @Sendable @escaping () async throws
             -> Success
@@ -29,6 +93,10 @@ public actor DeferredTask<Success: Sendable>: AsynchronousUnitOfWork {
         self.operation = operation
     }
 
+    /// Executes the deferred asynchronous operation, returning an `AsynchronousOperation` that can be awaited.
+    ///
+    /// - Throws: Errors thrown by the underlying operation or a `CancellationError` if the task is no longer available.
+    /// - Returns: An `AsynchronousOperation` wrapping the result of type `Success`.
     public func _operation() async throws -> AsynchronousOperation<Success> {
         AsynchronousOperation { [weak self] in
             guard let self else { throw CancellationError() }
@@ -36,3 +104,4 @@ public actor DeferredTask<Success: Sendable>: AsynchronousUnitOfWork {
         }
     }
 }
+

--- a/Sources/Afluent/Errors/TimeoutError.swift
+++ b/Sources/Afluent/Errors/TimeoutError.swift
@@ -7,19 +7,37 @@
 
 import Foundation
 
-/// An error indicating a timeout has occurred.
+/// An error indicating a timeout has occurred during asynchronous work.
 ///
-/// Potentially thrown by ``AsynchronousUnitOfWork/timeout(_:customError:)`` and ``AsynchronousUnitOfWork/timeout(_:clock:tolerance:customError:)``.
+/// This error can be thrown from operations that support timeouts, such as ``AsynchronousUnitOfWork/timeout(_:customError:)`` and ``AsynchronousUnitOfWork/timeout(_:clock:tolerance:customError:)``.
+///
+/// You can compare two `TimeoutError` values for equality, but the associated `duration` is not considered—only the fact that a timeout occurred.
+///
+/// ## Example
+///
+/// ```swift
+/// let work = DeferredTask {
+///     try await Task.sleep(for: .seconds(2))
+/// }
+/// .timeout(.seconds(1), customError: TimeoutError.timedOut)
+///
+/// do {
+///     try await work.execute()
+/// } catch is TimeoutError {
+///     print("Operation timed out")
+/// }
+/// ```
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 public enum TimeoutError: Swift.Error, LocalizedError {
-    /// A timeout occurred, with the duration timeout.
+    /// A timeout occurred, with the given duration.
     ///
-    /// Checking two `timedOut` cases for equality does not consider the `duration`.
+    /// - Parameter duration: The maximum allowed duration before timing out.
+    /// - Note: Equality checks ignore the duration value.
     case timedOut(duration: any DurationProtocol)
 
-    /// A timeout occurred, with no specific duration.
+    /// A convenient static value representing a timeout, with no specific duration.
     ///
-    /// Can be used to easily check if some existential error is a ``TimeoutError/timedOut(duration:)`` error.
+    /// Useful for pattern-matching or as a default error for custom timeouts.
     public static var timedOut: Self { .timedOut(duration: Duration.zero) }
 
     public var errorDescription: String? {
@@ -29,6 +47,9 @@ public enum TimeoutError: Swift.Error, LocalizedError {
     }
 }
 
+/// `TimeoutError` conforms to `Equatable`.
+///
+/// Two `TimeoutError` values are considered equal if both are `.timedOut`, regardless of their `duration` values.
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension TimeoutError: Equatable {
     public static func == (lhs: Self, rhs: Self) -> Bool {

--- a/Sources/Afluent/Extensions/AsyncSequenceExtensions.swift
+++ b/Sources/Afluent/Extensions/AsyncSequenceExtensions.swift
@@ -8,7 +8,25 @@
 import Foundation
 
 extension AsyncSequence where Element: Sendable {
-    /// Returns the first element of the sequence
+    /// Returns the first element of the sequence, or `nil` if the sequence is empty.
+    ///
+    /// This method is a convenience overload for async sequences, returning the first element encountered, or `nil` if none is produced.
+    ///
+    /// If the sequence throws before yielding a value, the error is rethrown.
+    ///
+    /// ## Example
+    ///
+    /// ```swift
+    /// let stream = AsyncStream<Int> { continuation in
+    ///     continuation.yield(42)
+    ///     continuation.yield(100)
+    ///     continuation.finish()
+    /// }
+    ///
+    /// if let first = try await stream.first() {
+    ///     print("First: \(first)") // Prints: First: 42
+    /// }
+    /// ```
     @_disfavoredOverload public func first() async rethrows -> Self.Element? {
         try await first { _ in true }
     }

--- a/Sources/Afluent/PassthroughSubject.swift
+++ b/Sources/Afluent/PassthroughSubject.swift
@@ -9,6 +9,21 @@
 /// Unlike `CurrentValueSubject`, `PassthroughSubject` does not retain the most recent value.
 /// It only sends values as they are emitted, meaning consumers will only receive values that are sent after they start listening.
 /// This is an `AsyncSequence` that allows multiple tasks to asynchronously consume values and mimics Combine's PassthroughSubject.
+///
+/// ## Example
+/// ```
+/// let subject = PassthroughSubject<Int>()
+///
+/// Task {
+///     for try await value in subject {
+///         print("Received value: \(value)")
+///     }
+/// }
+///
+/// subject.send(1)
+/// subject.send(2)
+/// subject.send(completion: .finished)
+/// ```
 public final class PassthroughSubject<Element: Sendable>: AsyncSequence, @unchecked Sendable {
     private class State: @unchecked Sendable {
         private let lock = Lock.allocate()

--- a/Sources/Afluent/RetryStrategies/RetryByCountStrategy.swift
+++ b/Sources/Afluent/RetryStrategies/RetryByCountStrategy.swift
@@ -8,10 +8,14 @@
 extension RetryStrategy where Self == RetryByCountStrategy {
     /// Creates a retry strategy that retries the operation up to a specified number of times.
     ///
-    /// - Parameter count: The maximum number of retries allowed.
-    /// - Returns: A `RetryByCountStrategy` configured to retry up to the specified count.
+    /// Use this strategy with operators like `.retry(strategy:)` to control how many times an operation will be retried.
     ///
-    /// - Note: The retry count will be decremented after each retry attempt, stopping when it reaches zero.
+    /// ## Example
+    /// ```
+    /// try await DeferredTask { /* some fallible work */ }
+    ///     .retry(strategy: .byCount(3))
+    ///     .execute()
+    /// ```
     public static func byCount(_ count: UInt) -> RetryByCountStrategy {
         return RetryByCountStrategy(retryCount: count)
     }
@@ -21,7 +25,12 @@ extension RetryStrategy where Self == RetryByCountStrategy {
 ///
 /// This strategy retries an operation a specified number of times before giving up.
 ///
-/// - Important: Once the retry count reaches zero, no further retries will be attempted.
+/// ## Example
+/// ```
+/// try await DeferredTask { /* some fallible work */ }
+///     .retry(strategy: .byCount(3))
+///     .execute()
+/// ```
 public actor RetryByCountStrategy: RetryStrategy {
     /// The number of retries remaining.
     var retryCount: UInt
@@ -50,3 +59,4 @@ public actor RetryByCountStrategy: RetryStrategy {
         retryCount -= 1
     }
 }
+

--- a/Sources/Afluent/RetryStrategies/RetryStrategy.swift
+++ b/Sources/Afluent/RetryStrategies/RetryStrategy.swift
@@ -9,6 +9,21 @@
 ///
 /// Conforming types must implement logic to determine if an operation should be retried after an error occurs.
 /// This protocol also allows executing any pre-retry logic, such as logging or cleanup, before attempting a retry.
+///
+/// ## Example
+/// ```
+/// actor AlwaysRetryOnce: RetryStrategy {
+///     private var hasRetried = false
+///     func handle(error: Error, beforeRetry: @Sendable (Error) async throws -> Void) async throws -> Bool {
+///         defer { hasRetried = true }
+///         return !hasRetried
+///     }
+/// }
+///
+/// try await DeferredTask { /* some fallible work */ }
+///     .retry(strategy: AlwaysRetryOnce())
+///     .execute()
+/// ```
 public protocol RetryStrategy: Sendable {
 
     /// Determines whether an operation should be retried after encountering an error.
@@ -39,3 +54,4 @@ extension RetryStrategy {
         try await handle(error: err, beforeRetry: { _ in })
     }
 }
+

--- a/Sources/Afluent/SequenceOperators/AnyAsyncSequence.swift
+++ b/Sources/Afluent/SequenceOperators/AnyAsyncSequence.swift
@@ -7,8 +7,14 @@
 
 import Foundation
 
+/// A type-erased async sequence.
+///
+/// Used as the backing implementation for ``AsyncSequence/eraseToAnyAsyncSequence()``
 public typealias AnyAsyncSequence = AsyncSequences.AnyAsyncSequence
 extension AsyncSequences {
+    /// A type-erased async sequence.
+    ///
+    /// Used as the backing implementation for ``AsyncSequence/eraseToAnyAsyncSequence()``
     public struct AnyAsyncSequence<Element: Sendable>: AsyncSequence, Sendable {
         let makeIterator: @Sendable () -> AnyAsyncIterator<Element>
 
@@ -59,7 +65,22 @@ extension AsyncSequences {
 }
 
 extension AsyncSequence where Self: Sendable, Element: Sendable {
-    /// Type erases the current sequence, useful when you need a concrete type that's easy to predict.
+    /// Returns a type-erased async sequence.
+    ///
+    /// Use this to hide the underlying concrete type of an async sequence when you need to pass it generically.
+    ///
+    /// ## Example
+    /// ```
+    /// let stream = AsyncStream<Int> { continuation in
+    ///     continuation.yield(1)
+    ///     continuation.yield(2)
+    ///     continuation.finish()
+    /// }
+    /// let erased = stream.eraseToAnyAsyncSequence()
+    /// for await value in erased {
+    ///     print(value)
+    /// }
+    /// ```
     public func eraseToAnyAsyncSequence() -> AsyncSequences.AnyAsyncSequence<Element> {
         AsyncSequences.AnyAsyncSequence(erasing: self)
     }

--- a/Sources/Afluent/SequenceOperators/AssertNoFailureSequence.swift
+++ b/Sources/Afluent/SequenceOperators/AssertNoFailureSequence.swift
@@ -8,6 +8,9 @@
 import Foundation
 
 extension AsyncSequences {
+    /// An async sequence that raises a fatal error if its upstream sequence throws.
+    ///
+    /// Used as the implementation detail for ``AsyncSequence/assertNoFailure()``.
     public struct AssertNoFailure<Upstream: AsyncSequence & Sendable>: AsyncSequence, Sendable {
         public typealias Element = Upstream.Element
         let upstream: Upstream
@@ -34,7 +37,21 @@ extension AsyncSequences {
 }
 
 extension AsyncSequence where Self: Sendable {
-    /// Raises a fatal error when its upstream sequence fails, and otherwise republishes all received input.
+    /// Raises a fatal error if the upstream async sequence throws (other than cancellation), otherwise republishes all received values.
+    ///
+    /// Use this to assert that a sequence is infallible, propagating values and terminating with a fatal error if any error occurs.
+    ///
+    /// ## Example
+    /// ```
+    /// let numbers = AsyncStream<Int> { continuation in
+    ///     continuation.yield(1)
+    ///     continuation.yield(2)
+    ///     continuation.finish()
+    /// }
+    /// for try await value in numbers.assertNoFailure() {
+    ///     print(value)
+    /// }
+    /// ```
     public func assertNoFailure() -> AsyncSequences.AssertNoFailure<Self> {
         AsyncSequences.AssertNoFailure(upstream: self)
     }

--- a/Sources/Afluent/SequenceOperators/CatchSequence.swift
+++ b/Sources/Afluent/SequenceOperators/CatchSequence.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 extension AsyncSequences {
+    /// Used as the implementation detail for the catch/tryCatch sequence operators.
     public struct Catch<Upstream: AsyncSequence & Sendable, Downstream: AsyncSequence & Sendable>:
         AsyncSequence, Sendable
     where Upstream.Element == Downstream.Element {
@@ -56,10 +57,12 @@ extension AsyncSequences {
 extension AsyncSequence where Self: Sendable {
     /// Catches any errors emitted by the upstream `AsyncSequence` and handles them using the provided closure.
     ///
-    /// - Parameters:
-    ///   - handler: A closure that takes an `Error` and returns an `AsyncSequence`.
-    ///
-    /// - Returns: An `AsyncSequence` that will catch and handle any errors emitted by the upstream sequence.
+    /// ## Example
+    /// ```
+    /// for try await value in Just(1).catch { _ in Just(0) } {
+    ///     print(value)
+    /// }
+    /// ```
     public func `catch`<D: AsyncSequence>(
         @_inheritActorContext @_implicitSelfCapture _ handler: @Sendable @escaping (Error) async ->
             D
@@ -69,11 +72,12 @@ extension AsyncSequence where Self: Sendable {
 
     /// Catches a specific type of error emitted by the upstream `AsyncSequence` and handles them using the provided closure.
     ///
-    /// - Parameters:
-    ///   - error: The specific error type to catch.
-    ///   - handler: A closure that takes an `Error` and returns an `AsyncSequence`.
-    ///
-    /// - Returns: An `AsyncSequence` that will catch and handle the specific error.
+    /// ## Example
+    /// ```
+    /// for try await value in Just(1).catch(MyError()) { _ in Just(0) } {
+    ///     print(value)
+    /// }
+    /// ```
     public func `catch`<D: AsyncSequence, E: Error & Equatable>(
         _ error: E,
         @_inheritActorContext @_implicitSelfCapture _ handler: @Sendable @escaping (E) async -> D
@@ -88,10 +92,12 @@ extension AsyncSequence where Self: Sendable {
 
     /// Tries to catch any errors emitted by the upstream `AsyncSequence` and handles them using the provided throwing closure.
     ///
-    /// - Parameters:
-    ///   - handler: A closure that takes an `Error` and returns an `AsyncSequence`, potentially throwing an error.
-    ///
-    /// - Returns: An `AsyncSequence` that will try to catch and handle any errors emitted by the upstream sequence.
+    /// ## Example
+    /// ```
+    /// for try await value in Just(1).tryCatch { _ in Just(0) } {
+    ///     print(value)
+    /// }
+    /// ```
     public func tryCatch<D: AsyncSequence>(
         @_inheritActorContext @_implicitSelfCapture _ handler: @Sendable @escaping (Error)
             async throws -> D
@@ -101,11 +107,12 @@ extension AsyncSequence where Self: Sendable {
 
     /// Tries to catch a specific type of error emitted by the upstream `AsyncSequence` and handles them using the provided throwing closure.
     ///
-    /// - Parameters:
-    ///   - error: The specific error type to catch.
-    ///   - handler: A closure that takes an `Error` and returns an `AsyncSequence`, potentially throwing an error.
-    ///
-    /// - Returns: An `AsyncSequence` that will try to catch and handle the specific error.
+    /// ## Example
+    /// ```
+    /// for try await value in Just(1).tryCatch(MyError()) { _ in Just(0) } {
+    ///     print(value)
+    /// }
+    /// ```
     public func tryCatch<D: AsyncSequence, E: Error & Equatable>(
         _ error: E,
         @_inheritActorContext @_implicitSelfCapture _ handler: @Sendable @escaping (E) async throws

--- a/Sources/Afluent/SequenceOperators/CollectSequence.swift
+++ b/Sources/Afluent/SequenceOperators/CollectSequence.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 extension AsyncSequences {
+    /// Used as the implementation detail for the ``AsyncSequence/collect()`` operator.
     public struct Collect<Upstream: AsyncSequence & Sendable>: AsyncSequence, Sendable {
         public typealias Element = [Upstream.Element]
         let upstream: Upstream
@@ -36,11 +37,19 @@ extension AsyncSequences {
 }
 
 extension AsyncSequence where Self: Sendable {
-    /// Collects all received elements, and emits a single array of the collection when the upstream sequence finishes.
-    /// ### Discussion:
-    /// Use `collect()` to gather elements into an array that the operator emits after the upstream sequence finishes.
-    /// If the upstream sequence fails with an error, this sequence forwards the error to the downstream receiver instead of sending its output.
-    /// - Important: Be cautious when using `collect` on sequences that can emit a large number of elements or do not complete, as it can lead to high memory usage or even memory exhaustion.
+    /// Collects all received elements and emits a single array when the upstream sequence finishes.
+    ///
+    /// Use `collect()` to gather elements into an array and emit the result as a single value.
+    /// If the upstream sequence fails with an error, the error is forwarded and no array is emitted.
+    ///
+    /// - Important: Be cautious using `collect()` on sequences that emit a large number of elements or never complete, as this can lead to high memory usage.
+    ///
+    /// ## Example
+    /// ```
+    /// for try await values in Just(1).collect() {
+    ///     print(values) // Prints: [1]
+    /// }
+    /// ```
     public func collect() -> AsyncSequences.Collect<Self> {
         AsyncSequences.Collect(upstream: self)
     }

--- a/Sources/Afluent/SequenceOperators/DecodeSequence.swift
+++ b/Sources/Afluent/SequenceOperators/DecodeSequence.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 extension AsyncSequences {
+    /// Used as the implementation detail for the ``AsyncSequence/decode(type:decoder:)`` operator.
     public struct Decode<
         Upstream: AsyncSequence & Sendable, Decoder: TopLevelDecoder,
         DecodedType: Decodable & Sendable
@@ -58,9 +59,21 @@ extension AsyncSequences {
 
 extension AsyncSequence where Self: Sendable {
     /// Decodes the output from the upstream using a specified decoder.
+    ///
+    /// Use this to decode values from upstream elements (such as encoded JSON) to a concrete type.
+    ///
+    /// ## Example
+    /// ```
+    /// struct Person: Decodable { let name: String }
+    /// let json = try JSONEncoder().encode(Person(name: "Alice"))
+    /// for try await person in Just(json).decode(type: Person.self, decoder: JSONDecoder()) {
+    ///     print(person.name) // Prints: Alice
+    /// }
+    /// ```
     public func decode<T: Decodable, D: TopLevelDecoder>(type _: T.Type, decoder: D)
         -> AsyncSequences.Decode<Self, D, T> where Element == D.Input
     {
         AsyncSequences.Decode(upstream: self, decoder: decoder)
     }
 }
+

--- a/Sources/Afluent/SequenceOperators/DelaySequence.swift
+++ b/Sources/Afluent/SequenceOperators/DelaySequence.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 extension AsyncSequences {
+    /// Used as the implementation detail for the ``AsyncSequence/delay(for:tolerance:)`` operator.
     @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
     public struct Delay<Upstream: AsyncSequence & Sendable, C: Clock>: AsyncSequence, Sendable
     where Upstream.Element: Sendable {
@@ -64,8 +65,22 @@ extension AsyncSequences {
 }
 
 extension AsyncSequence where Self: Sendable, Element: Sendable {
-    /// Delays delivery of all output to the downstream receiver by a specified amount of time
-    /// - Parameter interval: The amount of time to delay.
+    /// Delays delivery of all output by the specified amount of time, using a default clock.
+    ///
+    /// Use this to delay events from a sequence before they are delivered to the downstream consumer.
+    ///
+    /// - Parameters:
+    ///   - interval: The duration to delay.
+    ///   - tolerance: The allowed tolerance for the delay.
+    ///
+    /// The default clock is `SuspendingClock`.
+    ///
+    /// ## Example
+    /// ```
+    /// for try await value in Just(1).delay(for: .seconds(1), tolerance: .milliseconds(100)) {
+    ///     print(value)
+    /// }
+    /// ```
     @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
     public func delay(for interval: Duration, tolerance: Duration)
         -> AsyncSequences.Delay<Self, SuspendingClock>
@@ -73,8 +88,19 @@ extension AsyncSequence where Self: Sendable, Element: Sendable {
         delay(for: interval, tolerance: tolerance, clock: SuspendingClock())
     }
 
-    /// Delays delivery of all output to the downstream receiver by a specified amount of time
-    /// - Parameter interval: The amount of time to delay.
+    /// Delays delivery of all output by the specified amount of time, using the provided clock.
+    ///
+    /// - Parameters:
+    ///   - interval: The duration to delay.
+    ///   - tolerance: The allowed tolerance for the delay. Default is `nil`.
+    ///   - clock: The clock to use for timing the delay.
+    ///
+    /// ## Example
+    /// ```
+    /// for try await value in Just(1).delay(for: .seconds(1), clock: ContinuousClock()) {
+    ///     print(value)
+    /// }
+    /// ```
     @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
     public func delay<C: Clock>(for interval: C.Duration, tolerance: C.Duration? = nil, clock: C)
         -> AsyncSequences.Delay<Self, C>

--- a/Sources/Afluent/SequenceOperators/DematerializeSequence.swift
+++ b/Sources/Afluent/SequenceOperators/DematerializeSequence.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 extension AsyncSequences {
+    /// Used as the implementation detail for the ``AsyncSequence/dematerialize()`` operator.
     public struct Dematerialize<Upstream: AsyncSequence & Sendable, Element: Sendable>:
         AsyncSequence, Sendable
     where Upstream.Element == AsyncSequences.Event<Element> {
@@ -37,14 +38,16 @@ extension AsyncSequences {
 }
 
 extension AsyncSequence where Self: Sendable {
-    /// Transforms a sequence of `Event` values back into their original form in an `AsyncSequence`.
+    /// Transforms a sequence of `Event` values back into a sequence of their original elements, rethrowing errors.
     ///
-    /// This method is the inverse of `materialize`. It takes an `AsyncSequence` of `Event` values and transforms it back into an `AsyncSequence` of the original elements, propagating errors as thrown exceptions.
+    /// This is the inverse of `materialize()`. Use it to recover values and errors from a sequence of events.
     ///
-    /// - Note: The sequence must be of type `AsyncSequences.Event<T>`. The `dematerialize` method will extract the original elements and errors from these events.
-    ///
-    /// - Returns: An `AsyncSequences.Dematerialize` instance that represents the original `AsyncSequence` with its elements and errors.
-    /// - Throws: Re-throws any errors that were encapsulated in the `Event.failure` cases.
+    /// ## Example
+    /// ```
+    /// for try await value in Just(1).materialize().dematerialize() {
+    ///     print(value) // Prints: 1
+    /// }
+    /// ```
     public func dematerialize<T>() -> AsyncSequences.Dematerialize<Self, T>
     where Element == AsyncSequences.Event<T> {
         AsyncSequences.Dematerialize(upstream: self)

--- a/Sources/Afluent/SequenceOperators/DiscardOutputSequence.swift
+++ b/Sources/Afluent/SequenceOperators/DiscardOutputSequence.swift
@@ -8,9 +8,16 @@
 import Foundation
 
 extension AsyncSequence where Self: Sendable {
-    /// Discards the output values from the upstream `AsyncSequence`.
+    /// Transforms each output value from the upstream sequence into `Void`.
     ///
-    /// - Returns: An `AsyncSequence` of type `Void` that emits a completion event when the upstream completes.
+    /// Use this to ignore the payload of each element, but still receive an event for every value.
+    ///
+    /// ## Example
+    /// ```
+    /// for await _ in Just(1).discardOutput() {
+    ///     // Loop runs once for each element, but value is always Void
+    /// }
+    /// ```
     public func discardOutput() -> AsyncMapSequence<Self, Void> {
         map { _ in }
     }

--- a/Sources/Afluent/SequenceOperators/EncodeSequence.swift
+++ b/Sources/Afluent/SequenceOperators/EncodeSequence.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 extension AsyncSequences {
+    /// Used as the implementation detail for the ``AsyncSequence/encode(encoder:)`` operator.
     public struct Encode<Upstream: AsyncSequence & Sendable, Encoder: TopLevelEncoder>:
         AsyncSequence, Sendable
     where Upstream.Element: Encodable {
@@ -56,7 +57,17 @@ extension AsyncSequences {
 }
 
 extension AsyncSequence where Self: Sendable {
-    /// Encodes the output from upstream using a specified encoder.
+    /// Encodes the output from upstream using the specified encoder.
+    ///
+    /// Use this to encode values into a data format (such as JSON) before further processing or output.
+    ///
+    /// ## Example
+    /// ```
+    /// struct Person: Encodable { let name: String }
+    /// for try await data in Just(Person(name: "Alice")).encode(encoder: JSONEncoder()) {
+    ///     print(data) // Encoded JSON data
+    /// }
+    /// ```
     public func encode<E: TopLevelEncoder>(encoder: E) -> AsyncSequences.Encode<Self, E>
     where Element: Encodable {
         AsyncSequences.Encode(upstream: self, encoder: encoder)

--- a/Sources/Afluent/SequenceOperators/FlatMapSequence.swift
+++ b/Sources/Afluent/SequenceOperators/FlatMapSequence.swift
@@ -9,6 +9,7 @@ import Atomics
 import Foundation
 
 extension AsyncSequences {
+    /// Used as the implementation detail for the ``AsyncSequence/flatMap(maxSubscriptions:_:)`` operator.
     public struct FlatMap<
         Upstream: AsyncSequence & Sendable, SegmentOfResult: AsyncSequence & Sendable
     >: AsyncSequence, Sendable where Upstream.Element: Sendable, SegmentOfResult.Element: Sendable {
@@ -69,6 +70,20 @@ extension AsyncSequences {
 }
 
 extension AsyncSequence {
+    /// Merges the results of mapping each element to an `AsyncSequence`, with control over subscription demand.
+    ///
+    /// Unlike the standard library's `flatMap`, this operator allows you to control how many inner sequences may be subscribed to concurrently.
+    ///
+    /// - Parameters:
+    ///   - maxSubscriptions: The maximum number of concurrent inner subscriptions. Use `.unlimited` for no limit.
+    ///   - transform: Transforms each element into an `AsyncSequence`.
+    ///
+    /// ## Example
+    /// ```
+    /// for try await value in Just(1).flatMap(maxSubscriptions: .unlimited) { i in Just(i * 2) } {
+    ///     print(value) // Prints: 2
+    /// }
+    /// ```
     public func flatMap<SegmentOfResult: AsyncSequence>(
         maxSubscriptions: SubscriptionDemand,
         _ transform: @Sendable @escaping (Self.Element) async throws -> SegmentOfResult
@@ -78,6 +93,10 @@ extension AsyncSequence {
     }
 }
 
+/// Specifies the number of concurrent inner subscriptions for operators like ``AsyncSequence/flatMap(maxSubscriptions:_:)``.
+///
+/// Use `.unlimited` to allow unlimited concurrency.
 public enum SubscriptionDemand: Sendable {
+    /// Allows unlimited concurrent inner subscriptions.
     case unlimited
 }

--- a/Sources/Afluent/SequenceOperators/GroupBySequence.swift
+++ b/Sources/Afluent/SequenceOperators/GroupBySequence.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 extension AsyncSequences {
+    /// Used as the implementation detail for the ``AsyncSequence/groupBy(keySelector:)`` operator.
     public struct GroupBy<Upstream: AsyncSequence & Sendable, Key: Hashable>: AsyncSequence,
         Sendable
     where Upstream.Element: Sendable {
@@ -64,6 +65,21 @@ extension AsyncSequences {
 }
 
 extension AsyncSequence where Self: Sendable, Element: Sendable {
+    /// Groups the elements of the sequence into substreams based on a key.
+    ///
+    /// Use this to partition values by a computed key, yielding an async sequence for each group.
+    ///
+    /// - Warning: This operator stores each group in a dictionary. If the number of unique keys is very large or unbounded, memory usage may increase significantly.
+    ///
+    /// ## Example
+    /// ```
+    /// for await (key, group) in Just(1).groupBy { $0 % 2 } {
+    ///     print("Key: \(key)")
+    ///     for try await value in group {
+    ///         print("Value: \(value)")
+    ///     }
+    /// }
+    /// ```
     public func groupBy<Key: Hashable>(keySelector: @Sendable @escaping (Element) async -> Key)
         -> AsyncSequences.GroupBy<Self, Key>
     {

--- a/Sources/Afluent/SequenceOperators/HandleEventsSequence.swift
+++ b/Sources/Afluent/SequenceOperators/HandleEventsSequence.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 extension AsyncSequences {
+    /// Used as the implementation detail for the ``AsyncSequence/handleEvents(receiveMakeIterator:receiveNext:receiveOutput:receiveError:receiveComplete:receiveCancel:)`` operator.
     public struct HandleEvents<Upstream: AsyncSequence & Sendable>: AsyncSequence, Sendable {
         public typealias Element = Upstream.Element
         let upstream: Upstream
@@ -62,18 +63,28 @@ extension AsyncSequences {
 }
 
 extension AsyncSequence where Self: Sendable {
-    /// Adds side-effects to the receiving events of the upstream `AsyncSequence`.
+    /// Adds side-effects to the lifetime events of the sequence.
+    ///
+    /// Use this to observe or act on events like output, error, completion, or cancellation.
+    ///
+    /// ## Example
+    /// ```
+    /// for try await value in Just(1).handleEvents(receiveOutput: { print("Saw value: \($0)") }) {
+    ///     print("Received: \(value)")
+    /// }
+    /// ```
     ///
     /// - Parameters:
-    ///   - receiveMakeIterator: A closure that is invoked when the an iterator is requested from this sequence.
+    ///   - receiveMakeIterator: A closure that is invoked when an iterator is requested from this sequence.
     ///   - receiveNext: A closure that is invoked when the next element is requested from this sequence. The closure can throw errors.
     ///   - receiveOutput: A closure that is invoked when the upstream emits a successful output. The closure can throw errors.
     ///   - receiveError: A closure that is invoked when the upstream emits an error. The closure can throw errors.
-    ///   - receiveCancel: A closure that is invoked when the unit of work is cancelled. The closure can throw errors.
+    ///   - receiveComplete: A closure that is invoked when the upstream completes. The closure can throw errors.
+    ///   - receiveCancel: A closure that is invoked when the sequence is cancelled. The closure can throw errors.
     ///
-    /// - Returns: An `AsynchronousUnitOfWork` that performs the side-effects for the specified receiving events.
+    /// - Returns: An async sequence that performs the side-effects for the specified events.
     ///
-    /// - Note: The returned `AsynchronousUnitOfWork` forwards all receiving events from the upstream unit of work.
+    /// - Note: The returned sequence forwards all events from the upstream.
     public func handleEvents(
         @_implicitSelfCapture receiveMakeIterator: (@Sendable () -> Void)? = nil,
         @_inheritActorContext @_implicitSelfCapture receiveNext: (
@@ -98,3 +109,4 @@ extension AsyncSequence where Self: Sendable {
             receiveComplete: receiveComplete, receiveCancel: receiveCancel)
     }
 }
+

--- a/Sources/Afluent/SequenceOperators/JustSequence.swift
+++ b/Sources/Afluent/SequenceOperators/JustSequence.swift
@@ -8,11 +8,18 @@
 import Foundation
 
 extension AsyncSequences {
-    /// An `AsyncSequence` that emits a single specified element and then completes.
+    /// An async sequence that emits a single specified element and then completes.
     ///
-    /// `Just` is a simple `AsyncSequence` that emits only one element and then finishes. It's useful for creating sequences with a single, known value, often for testing or combining with other asynchronous sequences.
+    /// Use `Just` to create a sequence that yields one value and then finishes, often for testing, composition, or as a source of a single known value.
     ///
-    /// - Parameter value: The single element that this sequence will emit.
+    /// ## Example
+    /// ```
+    /// for await value in Just(1) {
+    ///     print(value) // Prints: 1
+    /// }
+    /// ```
+    ///
+    /// - Note: If you want to emit a single asynchronous value (not a sequence), consider using `DeferredTask` instead.
     public struct Just<Element: Sendable>: AsyncSequence, Sendable {
         let val: Element
 
@@ -44,3 +51,4 @@ extension AsyncSequences {
 }
 
 public typealias Just = AsyncSequences.Just
+

--- a/Sources/Afluent/SequenceOperators/MaterializeSequence.swift
+++ b/Sources/Afluent/SequenceOperators/MaterializeSequence.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 extension AsyncSequences {
-    /// Represents the different kinds of events that can be emitted by `Materialize`.
+    /// Represents an event (element, error, or completion) from a materialized async sequence.
     public enum Event<Element: Sendable>: Sendable {
         /// An element from the upstream sequence.
         case element(Element)
@@ -18,6 +18,7 @@ extension AsyncSequences {
         case complete
     }
 
+    /// Used as the implementation detail for the ``AsyncSequence/materialize()`` operator.
     public struct Materialize<Upstream: AsyncSequence & Sendable>: AsyncSequence, Sendable
     where Upstream.Element: Sendable {
         public typealias Element = Event<Upstream.Element>
@@ -52,12 +53,22 @@ extension AsyncSequences {
 }
 
 extension AsyncSequence where Self: Sendable {
-    /// Transforms the elements, completion, and errors of the current `AsyncSequence` into `Event` values.
+    /// Transforms all elements, errors, and completion of the sequence into `Event` values.
     ///
-    /// This method wraps the `AsyncSequence` and emits each of its elements, errors, and completion as distinct `Event` cases. It's useful for uniformly handling all aspects of the sequence's lifecycle.
+    /// Use this to handle elements, errors, and completion uniformly as events.
     ///
-    /// - Returns: An `AsyncSequences.Materialize` instance that represents the transformed sequence.
+    /// ## Example
+    /// ```
+    /// for await event in Just(1).materialize() {
+    ///     switch event {
+    ///     case .element(let value): print("Element: \(value)")
+    ///     case .failure(let error): print("Failure: \(error)")
+    ///     case .complete: print("Complete")
+    ///     }
+    /// }
+    /// ```
     public func materialize() -> AsyncSequences.Materialize<Self> where Element: Sendable {
         AsyncSequences.Materialize(upstream: self)
     }
 }
+

--- a/Sources/Afluent/SequenceOperators/PrintSequence.swift
+++ b/Sources/Afluent/SequenceOperators/PrintSequence.swift
@@ -8,12 +8,18 @@
 import Foundation
 
 extension AsyncSequence where Self: Sendable {
-    /// Logs events from the upstream `AsyncSequence` to the console.
+    /// Logs events from the sequence to the console, optionally with a prefix.
     ///
-    /// - Parameters:
-    ///   - prefix: A string to prefix each log message with. Default is an empty string.
+    /// Use this for debugging or observing the lifecycle of a sequence.
     ///
-    /// - Returns: An `AsyncSequence` that behaves identically to the upstream but logs events.
+    /// - Parameter prefix: A string to prefix each log message with. Default is an empty string.
+    ///
+    /// ## Example
+    /// ```
+    /// for try await value in Just(1).print("MyPrefix") {
+    ///     // Prints lifecycle events and value to the console with prefix "MyPrefix"
+    /// }
+    /// ```
     public func print(_ prefix: String = "") -> AsyncSequences.HandleEvents<Self> {
         handleEvents {
             Swift.print("\(prefix) received make iterator")

--- a/Sources/Afluent/SequenceOperators/ReplaceErrorSequence.swift
+++ b/Sources/Afluent/SequenceOperators/ReplaceErrorSequence.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 extension AsyncSequences {
+    /// Used as the implementation detail for the ``AsyncSequence/replaceError(with:)`` operator.
     public struct ReplaceError<Upstream: AsyncSequence & Sendable, Output: Sendable>: AsyncSequence,
         Sendable
     where Upstream.Element == Output {
@@ -39,11 +40,17 @@ extension AsyncSequences {
 }
 
 extension AsyncSequence where Self: Sendable {
-    /// Replaces any errors from the upstream `AsyncSequence` with the provided value.
+    /// Replaces any error from the sequence with the provided value.
     ///
-    /// - Parameter value: The value to emit upon encountering an error.
+    /// Use this to emit a fallback value instead of propagating an error downstream.
     ///
-    /// - Returns: An `AsyncSequence` that emits the specified value instead of failing when the upstream fails.
+    /// ## Example
+    /// ```
+    /// let stream = Just(1).map { _ in throw MyError() }
+    /// for await value in stream.replaceError(with: 42) {
+    ///     print(value) // Prints: 42
+    /// }
+    /// ```
     public func replaceError(with value: Element) -> AsyncSequences.ReplaceError<Self, Element>
     where Element: Sendable {
         AsyncSequences.ReplaceError(upstream: self, newOutput: value)

--- a/Sources/Afluent/SequenceOperators/ReplaceNilSequence.swift
+++ b/Sources/Afluent/SequenceOperators/ReplaceNilSequence.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 extension AsyncSequences {
+    /// Used as the implementation detail for the ``AsyncSequence/replaceNil(with:)`` operator.
     public struct ReplaceNil<Upstream: AsyncSequence & Sendable, Output: Sendable>: AsyncSequence,
         Sendable
     where Upstream.Element == Output? {
@@ -38,13 +39,25 @@ extension AsyncSequences {
 }
 
 extension AsyncSequence where Self: Sendable {
-    /// Replaces any `nil` values from the upstream `AsyncSequence` with the provided non-nil value.
+    /// Replaces any `nil` values from the sequence with the provided non-nil value.
     ///
-    /// - Parameter value: The value to emit when the upstream emits `nil`.
+    /// Use this to emit a fallback value whenever the upstream emits `nil`.
     ///
-    /// - Returns: An `AsyncSequence` that emits the specified value instead of `nil` when the upstream emits `nil`.
+    /// ## Example
+    /// ```
+    /// let stream = AsyncStream<Int?> { continuation in
+    ///     continuation.yield(1)
+    ///     continuation.yield(nil)
+    ///     continuation.yield(3)
+    ///     continuation.finish()
+    /// }
+    /// for await value in stream.replaceNil(with: 42) {
+    ///     print(value) // Prints: 1, 42, 3
+    /// }
+    /// ```
     public func replaceNil<E>(with value: E) -> AsyncSequences.ReplaceNil<Self, E>
     where Element == E? {
         AsyncSequences.ReplaceNil(upstream: self, newOutput: value)
     }
 }
+

--- a/Sources/Afluent/SequenceOperators/RetryAfterFlatMappingSequence.swift
+++ b/Sources/Afluent/SequenceOperators/RetryAfterFlatMappingSequence.swift
@@ -282,13 +282,36 @@ extension AsyncSequences {
 }
 
 extension AsyncSequence where Self: Sendable {
-    /// Retries the upstream `AsyncSequence` up to a specified number of times while applying a transformation on error.
+    /// Retries the upstream `AsyncSequence` using the provided retry strategy.
+    ///
+    /// The provided transformation closure is executed *before* each retry, allowing for side effects such as refreshing tokens or resetting state.
+    /// The closure's returned `AsyncSequence` is always fully consumed before the retry occurs, but its elements are ignored.
+    /// The element type of the returned sequence does not need to match the upstream's element type.
+    ///
+    /// This is useful for performing asynchronous side effects like credential refresh before retrying the main sequence.
+    ///
+    /// ## Example: Refreshing an access token on a 401 HTTP error before retrying the main request
+    ///
+    /// ```
+    /// let mainRequest = URLSession.shared.dataTaskAsyncSequence(for: URLRequest(url: URL(string: "https://api.example.com/data")!))
+    ///
+    /// let retriedSequence = mainRequest.retry(.byCount(3)) { error in
+    ///     // If error is 401 Unauthorized, refresh token before retrying
+    ///     DeferredTask {
+    ///         if let urlError = error as? URLError, urlError.code == .userAuthenticationRequired {
+    ///             try await refreshAccessToken()
+    ///         }
+    ///     }
+    ///     .toAsyncSequence() // This sequence is fully consumed before retrying, ignoring its elements
+    /// }
+    /// ```
     ///
     /// - Parameters:
-    ///   - retries: The maximum number of times to retry the upstream, defaulting to 1.
-    ///   - transform: An async closure that takes the error from the upstream and returns a new `AsyncSequence`.
+    ///   - strategy: The retry strategy to use.
+    ///   - transform: An async closure that takes the error from the upstream and returns a new `AsyncSequence` to be fully consumed for side effects before retrying.
     ///
-    /// - Returns: An `AsyncSequence` that emits the same output as the upstream but retries on failure up to the specified number of times, with the applied transformation.
+    /// - Returns: An `AsyncSequence` that emits the same elements as the upstream but retries on failure using the given strategy,
+    ///            performing the transformation before each retry.
     public func retry<D: AsyncSequence, S: RetryStrategy>(
         _ strategy: S, _ transform: @Sendable @escaping (Error) async throws -> D
     ) -> AsyncSequences.RetryAfterFlatMapping<Self, D, S> {
@@ -296,13 +319,31 @@ extension AsyncSequence where Self: Sendable {
             upstream: self, strategy: strategy, transform: transform)
     }
 
-    /// Retries the upstream `AsyncSequence` up to a specified number of times while applying a transformation on error.
+    /// Retries the upstream `AsyncSequence` up to a specified number of times.
+    ///
+    /// The transformation closure runs *before* each retry and can be used to perform side effects like refreshing credentials.
+    /// The returned sequence is always fully consumed before retrying, and its element type does not need to match the upstream.
+    ///
+    /// This is useful for operations such as token refresh or cache reset prior to retrying the upstream sequence.
+    ///
+    /// ## Example: Refreshing tokens before retrying a network call
+    ///
+    /// ```
+    /// let retriedSequence = myAsyncSequence.retry(3) { error in
+    ///     DeferredTask {
+    ///         if let authError = error as? MyAuthError {
+    ///             try await refreshTokens()
+    ///         }
+    ///     }
+    ///     .toAsyncSequence() // Fully consumed before retry
+    /// }
+    /// ```
     ///
     /// - Parameters:
-    ///   - retries: The maximum number of times to retry the upstream, defaulting to 1.
-    ///   - transform: An async closure that takes the error from the upstream and returns a new `AsyncSequence`.
+    ///   - retries: The maximum number of retry attempts (default is 1).
+    ///   - transform: An async closure executed before each retry, returning an `AsyncSequence` whose elements are ignored but fully consumed.
     ///
-    /// - Returns: An `AsyncSequence` that emits the same output as the upstream but retries on failure up to the specified number of times, with the applied transformation.
+    /// - Returns: An `AsyncSequence` that retries on failure up to the specified number of times, performing the transformation before each retry.
     public func retry<D: AsyncSequence>(
         _ retries: UInt = 1, _ transform: @Sendable @escaping (Error) async throws -> D
     ) -> AsyncSequences.RetryAfterFlatMapping<Self, D, RetryByCountStrategy> {
@@ -310,14 +351,30 @@ extension AsyncSequence where Self: Sendable {
             upstream: self, strategy: .byCount(retries), transform: transform)
     }
 
-    /// Retries the upstream `AsyncSequence` up to a specified number of times only when a specific error occurs, while applying a transformation on error.
+    /// Retries the upstream `AsyncSequence` up to a specified number of times only when a specific error occurs.
+    ///
+    /// The transformation closure is executed *before* each retry on the specified error to perform side effects such as refreshing tokens or resetting state.
+    /// The returned sequence is fully consumed before the retry and its element type does not need to match the upstream.
+    ///
+    /// This enables targeted retry behavior on specific errors with side effects executed prior to retrying.
+    ///
+    /// ## Example: Retry only on a specific error with side effect
+    ///
+    /// ```
+    /// let retried = myAsyncSequence.retry(3, on: MyError.tokenExpired) { error in
+    ///     DeferredTask {
+    ///         try await refreshAuthToken()
+    ///     }
+    ///     .toAsyncSequence() // Fully consumed before retrying
+    /// }
+    /// ```
     ///
     /// - Parameters:
-    ///   - retries: The maximum number of times to retry the upstream, defaulting to 1.
-    ///   - error: The specific error that should trigger a retry.
-    ///   - transform: An async closure that takes the error from the upstream and returns a new `AsyncSequence`.
+    ///   - retries: The maximum number of retry attempts (default is 1).
+    ///   - error: The specific error to retry on.
+    ///   - transform: An async closure executed before retrying on the specified error, returning an `AsyncSequence` fully consumed before retry.
     ///
-    /// - Returns: An `AsyncSequence` that emits the same output as the upstream but retries on the specified error up to the specified number of times, with the applied transformation.
+    /// - Returns: An `AsyncSequence` that retries only on the specified error, running the transformation before each retry.
     public func retry<D: AsyncSequence, E: Error & Equatable>(
         _ retries: UInt = 1, on error: E, _ transform: @Sendable @escaping (E) async throws -> D
     ) -> AsyncSequences.RetryOnAfterFlatMapping<Self, E, D, RetryByCountStrategy> {
@@ -325,14 +382,30 @@ extension AsyncSequence where Self: Sendable {
             upstream: self, strategy: .byCount(retries), error: error, transform: transform)
     }
 
-    /// Retries the upstream `AsyncSequence` up to a specified number of times only when a specific error occurs, while applying a transformation on error.
+    /// Retries the upstream `AsyncSequence` with a custom retry strategy only on a specific error.
+    ///
+    /// The transformation closure runs *before* each retry if the error matches, for side effects such as refreshing tokens.
+    /// The returned sequence's elements are ignored but the sequence is fully consumed before retrying.
+    ///
+    /// This is useful for applying custom retry strategies with side effects on specific error types.
+    ///
+    /// ## Example: Custom retry on error with side effect
+    ///
+    /// ```
+    /// let retried = myAsyncSequence.retry(.byCount(3), on: MyError.tokenExpired) { error in
+    ///     DeferredTask {
+    ///         try await refreshAuthToken()
+    ///     }
+    ///     .toAsyncSequence() // Fully consumed before retry
+    /// }
+    /// ```
     ///
     /// - Parameters:
-    ///   - strategy: The strategy to use when retrying
-    ///   - error: The specific error that should trigger a transform.
-    ///   - transform: An async closure that takes the error from the upstream and returns a new `AsyncSequence`.
+    ///   - strategy: The retry strategy to use.
+    ///   - error: The specific error that triggers the retry and transformation.
+    ///   - transform: The transformation executed before retrying on the error, producing a sequence fully consumed before retry.
     ///
-    /// - Returns: An `AsyncSequence` that emits the same output as the upstream but retries on the specified error up to the specified number of times, with the applied transformation.
+    /// - Returns: An `AsyncSequence` retrying with the given strategy on the specified error.
     public func retry<D: AsyncSequence, E: Error & Equatable, S: RetryStrategy>(
         _ strategy: S, on error: E, _ transform: @Sendable @escaping (E) async throws -> D
     ) -> AsyncSequences.RetryOnAfterFlatMapping<Self, E, D, S> {
@@ -340,14 +413,30 @@ extension AsyncSequence where Self: Sendable {
             upstream: self, strategy: strategy, error: error, transform: transform)
     }
     
-    /// Retries the upstream `AsyncSequence` up to a specified number of times only when a specific error occurs, while applying a transformation on error.
+    /// Retries the upstream `AsyncSequence` up to a specified number of times only when an error can be cast to a specific type.
+    ///
+    /// The transformation closure executes *before* each retry if the error is of the specified type, allowing side effects such as refreshing tokens.
+    /// The returned sequence is always fully consumed before retrying and its elements are ignored.
+    ///
+    /// This allows retrying only on errors castable to a given type, performing asynchronous side effects beforehand.
+    ///
+    /// ## Example: Retry on error cast with side effect
+    ///
+    /// ```
+    /// let retried = myAsyncSequence.retry(3, on: MyError.self) { error in
+    ///     DeferredTask {
+    ///         try await refreshAuthToken()
+    ///     }
+    ///     .toAsyncSequence() // Fully consumed before retry
+    /// }
+    /// ```
     ///
     /// - Parameters:
-    ///   - retries: The maximum number of times to retry the upstream, defaulting to 1.
-    ///   - error: The specific error that should trigger a retry if a cast succeeds.
-    ///   - transform: An async closure that takes the error from the upstream and returns a new `AsyncSequence`.
+    ///   - retries: The maximum retry attempts.
+    ///   - error: The error type to match for retry and transformation.
+    ///   - transform: The transformation executed before retrying when the cast succeeds, fully consuming its sequence.
     ///
-    /// - Returns: An `AsyncSequence` that emits the same output as the upstream but retries on the specified error up to the specified number of times, with the applied transformation.
+    /// - Returns: An `AsyncSequence` that retries on errors castable to the specified type.
     public func retry<D: AsyncSequence, E: Error>(
         _ retries: UInt = 1, on error: E.Type, _ transform: @Sendable @escaping (E) async throws -> D
     ) -> AsyncSequences.RetryOnCastAfterFlatMapping<Self, E, D, RetryByCountStrategy> {
@@ -355,14 +444,31 @@ extension AsyncSequence where Self: Sendable {
             upstream: self, strategy: .byCount(retries), error: error, transform: transform)
     }
 
-    /// Retries the upstream `AsyncSequence` up to a specified number of times only when a specific error occurs, while applying a transformation on error.
+    /// Retries the upstream `AsyncSequence` with a custom strategy when the error is castable to a specific type.
+    ///
+    /// The transformation runs *before* each retry if the error cast succeeds, useful for side effects like refreshing tokens.
+    /// The returned sequence is fully consumed before retrying, ignoring its elements.
+    ///
+    /// This enables retrying with custom strategy only when the error can be cast to the specified type,
+    /// performing asynchronous side effects prior to retry.
+    ///
+    /// ## Example: Custom retry on casted error with side effect
+    ///
+    /// ```
+    /// let retried = myAsyncSequence.retry(.byCount(3), on: MyError.self) { error in
+    ///     DeferredTask {
+    ///         try await refreshAuthToken()
+    ///     }
+    ///     .toAsyncSequence() // Fully consumed before retry
+    /// }
+    /// ```
     ///
     /// - Parameters:
-    ///   - strategy: The strategy to use when retrying
-    ///   - error: The specific error that should trigger a transform if a cast succeeds.
-    ///   - transform: An async closure that takes the error from the upstream and returns a new `AsyncSequence`.
+    ///   - strategy: The retry strategy to apply.
+    ///   - error: The error type to match via casting.
+    ///   - transform: The transformation executed before retrying when the cast succeeds, fully consuming the returned sequence.
     ///
-    /// - Returns: An `AsyncSequence` that emits the same output as the upstream but retries on the specified error up to the specified number of times, with the applied transformation.
+    /// - Returns: An `AsyncSequence` retrying with the given strategy only when the error can be cast to the specified type.
     public func retry<D: AsyncSequence, E: Error, S: RetryStrategy>(
         _ strategy: S, on error: E.Type, _ transform: @Sendable @escaping (E) async throws -> D
     ) -> AsyncSequences.RetryOnCastAfterFlatMapping<Self, E, D, S> {
@@ -370,3 +476,4 @@ extension AsyncSequence where Self: Sendable {
             upstream: self, strategy: strategy, error: error, transform: transform)
     }
 }
+

--- a/Sources/Afluent/SequenceOperators/ScanSequence.swift
+++ b/Sources/Afluent/SequenceOperators/ScanSequence.swift
@@ -42,16 +42,42 @@ extension AsyncSequences {
 }
 
 extension AsyncSequence where Self: Sendable {
-    /// Transforms elements from the upstream sequence by providing the current
-    /// element to a closure along with the last value returned by the closure.
+    /// Accumulates state over the elements of an asynchronous sequence, emitting each intermediate accumulated value.
     ///
-    /// Use ``AsyncSequence/scan(_:_:)`` to accumulate all previously-published values into a single
-    /// value, which you then combine with each newly-published value.
+    /// This operator works similarly to Combine's `scan` operator. It produces a sequence of values by repeatedly combining a running
+    /// accumulated value with each new element from the upstream async sequence using the provided closure.
+    ///
+    /// This is useful for computing running totals, aggregating state, or applying stateful transformations over time.
+    ///
+    /// ## Example
+    /// The following example demonstrates accumulating a running sum over an asynchronous sequence of integers:
+    /// ```swift
+    /// // An async sequence producing the numbers 1 through 5
+    /// let numbers = AsyncStream<Int> { continuation in
+    ///     for i in 1...5 {
+    ///         continuation.yield(i)
+    ///     }
+    ///     continuation.finish()
+    /// }
+    ///
+    /// // Use scan to accumulate a running sum
+    /// let runningSum = numbers.scan(0) { partialSum, nextNumber in
+    ///     return partialSum + nextNumber
+    /// }
+    ///
+    /// // Consume the running sums
+    /// Task {
+    ///     for try await sum in runningSum {
+    ///         print(sum) // Prints: 1, 3, 6, 10, 15
+    ///     }
+    /// }
+    /// ```
     ///
     /// - Parameters:
-    ///   - initialResult: The previous result returned by the `nextPartialResult` closure.
-    ///   - nextPartialResult: A closure that takes as its arguments the previous value returned by the closure and the next element emitted from the upstream sequence.
-    /// - Returns: A sequence that transforms elements by applying a closure that receives its previous return value and the next element from the upstream sequence.
+    ///   - initialResult: The initial accumulated value to start with.
+    ///   - nextPartialResult: A closure that takes the current accumulated value and the next element from the upstream sequence,
+    ///                        and returns a new accumulated value asynchronously.
+    /// - Returns: An asynchronous sequence that produces each intermediate accumulated result.
     public func scan<T>(_ initialResult: T, _ nextPartialResult: @Sendable @escaping (T, Self.Element) async throws -> T) -> AsyncSequences.Scan<Self, T> {
         .init(upstream: self, initialResult: initialResult, nextPartialResult: nextPartialResult)
     }

--- a/Sources/Afluent/SequenceOperators/ShareFromCacheSequence.swift
+++ b/Sources/Afluent/SequenceOperators/ShareFromCacheSequence.swift
@@ -36,7 +36,26 @@ extension AsyncSequence where Self: Sendable, Element: Sendable {
         }
     }
 
-    /// Shares data from the given cache based on a specified caching strategy and additional context information.
+    /// This operator enables sharing and caching of results from an async sequence
+    /// based on a specified caching strategy and the context in which it is called
+    /// (file, function, line, column). The cache keys uniquely identify the shared sequence 
+    /// in the cache using these call-site identifiers.
+    ///
+    /// ## Example
+    /// ```swift
+    /// let cache = AsyncSequenceCache()
+    /// let sequence = fetchNetworkData() // Some async sequence fetching network data
+    /// let sharedSequence = sequence.shareFromCache(cache, strategy: .cacheUntilCompletionOrCancellation)
+    ///
+    /// Task {
+    ///     for await data in sharedSequence {
+    ///         print("Received data: \(data)")
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// In this example, calls from the same file, function, line, and column will share and cache
+    /// the results of `fetchNetworkData()`, preventing redundant network requests within the same call site.
     ///
     /// - Parameters:
     ///   - cache: The cache from which to share data.
@@ -45,7 +64,8 @@ extension AsyncSequence where Self: Sendable, Element: Sendable {
     ///   - function: The name of the calling function. Defaults to `#function`.
     ///   - line: The line number where this function is called. Defaults to `#line`.
     ///   - column: The column where this function is called. Defaults to `#column`.
-    /// - Returns: An asynchronous unit of work encapsulating the operation's success or failure.
+    /// - Returns: An asynchronous broadcast sequence that shares the underlying sequence's values according to the cache and strategy.
+    /// - Important: This operator should generally be placed at the end of an operator chain. Any operators applied after `shareFromCache` will not be shared and may result in duplicated work or side effects.
     public func shareFromCache(
         _ cache: AsyncSequenceCache, strategy: AsyncSequenceCache.Strategy,
         fileId: String = #fileID,
@@ -57,13 +77,34 @@ extension AsyncSequence where Self: Sendable, Element: Sendable {
             line: line, column: column)
     }
 
-    /// Shares data from the given cache based on a specified caching strategy and hashable keys.
+    /// This operator enables sharing and caching of results from an async sequence
+    /// based on a specified caching strategy and a single hashable cache key.
+    /// The hashable key uniquely identifies the shared sequence in the cache.
+    ///
+    /// ## Example
+    /// ```swift
+    /// struct UserID: Hashable { let id: Int }
+    ///
+    /// let cache = AsyncSequenceCache()
+    /// let userSequence = fetchUserData(userId: 42) // Async sequence fetching user data
+    /// let sharedUserSequence = userSequence.shareFromCache(cache, strategy: .cacheUntilCompletionOrCancellation, keys: UserID(id: 42))
+    ///
+    /// Task {
+    ///     for await user in sharedUserSequence {
+    ///         print("User data: \(user)")
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// Here, the cache key `UserID(id: 42)` uniquely identifies the cached shared sequence,
+    /// ensuring that requests for the same user share the underlying async sequence.
     ///
     /// - Parameters:
     ///   - cache: The cache from which to share data.
     ///   - strategy: The caching strategy to use.
-    ///   - keys: One or more hashable keys used to look up the data in the cache.
-    /// - Returns: An asynchronous unit of work encapsulating the operation's success or failure.
+    ///   - keys k0: A hashable key used to uniquely identify the shared sequence in the cache.
+    /// - Returns: An asynchronous broadcast sequence that shares the underlying sequence's values according to the cache and strategy.
+    /// - Important: This operator should generally be placed at the end of an operator chain. Any operators applied after `shareFromCache` will not be shared and may result in duplicated work or side effects.
     public func shareFromCache<H0: Hashable>(
         _ cache: AsyncSequenceCache, strategy: AsyncSequenceCache.Strategy, keys k0: H0
     ) -> AsyncBroadcastSequence<AsyncSequences.HandleEvents<Self>> {
@@ -72,13 +113,33 @@ extension AsyncSequence where Self: Sendable, Element: Sendable {
         return _shareFromCache(cache, strategy: strategy, hasher: &hasher)
     }
 
-    /// Shares data from the given cache based on a specified caching strategy and hashable keys.
+    /// This operator enables sharing and caching of results from an async sequence
+    /// based on a specified caching strategy and two hashable cache keys.
+    /// The combined hashable keys uniquely identify the shared sequence in the cache.
+    ///
+    /// ## Example
+    /// ```swift
+    /// let cache = AsyncSequenceCache()
+    /// let sequence = expensiveComputation(param1: "abc", param2: 123)
+    /// let sharedSequence = sequence.shareFromCache(cache, strategy: .cacheUntilCompletionOrCancellation, keys: "abc", 123)
+    ///
+    /// Task {
+    ///     for await result in sharedSequence {
+    ///         print("Computation result: \(result)")
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// The keys `"abc"` and `123` combined serve as a unique cache key, allowing sharing
+    /// and caching of results for the specific combination of parameters.
     ///
     /// - Parameters:
     ///   - cache: The cache from which to share data.
     ///   - strategy: The caching strategy to use.
-    ///   - keys: One or more hashable keys used to look up the data in the cache.
-    /// - Returns: An asynchronous unit of work encapsulating the operation's success or failure.
+    ///   - keys k0: The first hashable key.
+    ///   - k1: The second hashable key.
+    /// - Returns: An asynchronous broadcast sequence that shares the underlying sequence's values according to the cache and strategy.
+    /// - Important: This operator should generally be placed at the end of an operator chain. Any operators applied after `shareFromCache` will not be shared and may result in duplicated work or side effects.
     public func shareFromCache<H0: Hashable, H1: Hashable>(
         _ cache: AsyncSequenceCache, strategy: AsyncSequenceCache.Strategy, keys k0: H0, _ k1: H1
     ) -> AsyncBroadcastSequence<AsyncSequences.HandleEvents<Self>> {
@@ -88,13 +149,33 @@ extension AsyncSequence where Self: Sendable, Element: Sendable {
         return _shareFromCache(cache, strategy: strategy, hasher: &hasher)
     }
 
-    /// Shares data from the given cache based on a specified caching strategy and hashable keys.
+    /// This operator enables sharing and caching of results from an async sequence
+    /// based on a specified caching strategy and three hashable cache keys.
+    /// The combined hashable keys uniquely identify the shared sequence in the cache.
+    ///
+    /// ## Example
+    /// ```swift
+    /// let cache = AsyncSequenceCache()
+    /// let sequence = fetchData(category: "books", page: 2, filter: "bestsellers")
+    /// let sharedSequence = sequence.shareFromCache(cache, strategy: .cacheUntilCompletionOrCancellation, keys: "books", 2, "bestsellers")
+    ///
+    /// Task {
+    ///     for await data in sharedSequence {
+    ///         print("Fetched data: \(data)")
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// The combination of keys `"books"`, `2`, and `"bestsellers"` uniquely identifies the cache entry.
     ///
     /// - Parameters:
     ///   - cache: The cache from which to share data.
     ///   - strategy: The caching strategy to use.
-    ///   - keys: One or more hashable keys used to look up the data in the cache.
-    /// - Returns: An asynchronous unit of work encapsulating the operation's success or failure.
+    ///   - keys k0: The first hashable key.
+    ///   - k1: The second hashable key.
+    ///   - k2: The third hashable key.
+    /// - Returns: An asynchronous broadcast sequence that shares the underlying sequence's values according to the cache and strategy.
+    /// - Important: This operator should generally be placed at the end of an operator chain. Any operators applied after `shareFromCache` will not be shared and may result in duplicated work or side effects.
     public func shareFromCache<H0: Hashable, H1: Hashable, H2: Hashable>(
         _ cache: AsyncSequenceCache, strategy: AsyncSequenceCache.Strategy, keys k0: H0, _ k1: H1,
         _ k2: H2
@@ -106,13 +187,34 @@ extension AsyncSequence where Self: Sendable, Element: Sendable {
         return _shareFromCache(cache, strategy: strategy, hasher: &hasher)
     }
 
-    /// Shares data from the given cache based on a specified caching strategy and hashable keys.
+    /// This operator enables sharing and caching of results from an async sequence
+    /// based on a specified caching strategy and four hashable cache keys.
+    /// The combined hashable keys uniquely identify the shared sequence in the cache.
+    ///
+    /// ## Example
+    /// ```swift
+    /// let cache = AsyncSequenceCache()
+    /// let sequence = fetchEvents(year: 2025, month: 7, day: 4, location: "NYC")
+    /// let sharedSequence = sequence.shareFromCache(cache, strategy: .cacheUntilCompletionOrCancellation, keys: 2025, 7, 4, "NYC")
+    ///
+    /// Task {
+    ///     for await event in sharedSequence {
+    ///         print("Event: \(event)")
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// These keys combined uniquely identify the cached shared sequence.
     ///
     /// - Parameters:
     ///   - cache: The cache from which to share data.
     ///   - strategy: The caching strategy to use.
-    ///   - keys: One or more hashable keys used to look up the data in the cache.
-    /// - Returns: An asynchronous unit of work encapsulating the operation's success or failure.
+    ///   - keys k0: The first hashable key.
+    ///   - k1: The second hashable key.
+    ///   - k2: The third hashable key.
+    ///   - k3: The fourth hashable key.
+    /// - Returns: An asynchronous broadcast sequence that shares the underlying sequence's values according to the cache and strategy.
+    /// - Important: This operator should generally be placed at the end of an operator chain. Any operators applied after `shareFromCache` will not be shared and may result in duplicated work or side effects.
     public func shareFromCache<H0: Hashable, H1: Hashable, H2: Hashable, H3: Hashable>(
         _ cache: AsyncSequenceCache, strategy: AsyncSequenceCache.Strategy, keys k0: H0, _ k1: H1,
         _ k2: H2, _ k3: H3
@@ -125,13 +227,35 @@ extension AsyncSequence where Self: Sendable, Element: Sendable {
         return _shareFromCache(cache, strategy: strategy, hasher: &hasher)
     }
 
-    /// Shares data from the given cache based on a specified caching strategy and hashable keys.
+    /// This operator enables sharing and caching of results from an async sequence
+    /// based on a specified caching strategy and five hashable cache keys.
+    /// The combined hashable keys uniquely identify the shared sequence in the cache.
+    ///
+    /// ## Example
+    /// ```swift
+    /// let cache = AsyncSequenceCache()
+    /// let sequence = fetchWeatherData(year: 2025, month: 7, day: 4, city: "Seattle", metric: true)
+    /// let sharedSequence = sequence.shareFromCache(cache, strategy: .cacheUntilCompletionOrCancellation, keys: 2025, 7, 4, "Seattle", true)
+    ///
+    /// Task {
+    ///     for await weather in sharedSequence {
+    ///         print("Weather data: \(weather)")
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// The keys specify the unique cache entry for this query.
     ///
     /// - Parameters:
     ///   - cache: The cache from which to share data.
     ///   - strategy: The caching strategy to use.
-    ///   - keys: One or more hashable keys used to look up the data in the cache.
-    /// - Returns: An asynchronous unit of work encapsulating the operation's success or failure.
+    ///   - keys k0: The first hashable key.
+    ///   - k1: The second hashable key.
+    ///   - k2: The third hashable key.
+    ///   - k3: The fourth hashable key.
+    ///   - k4: The fifth hashable key.
+    /// - Returns: An asynchronous broadcast sequence that shares the underlying sequence's values according to the cache and strategy.
+    /// - Important: This operator should generally be placed at the end of an operator chain. Any operators applied after `shareFromCache` will not be shared and may result in duplicated work or side effects.
     public func shareFromCache<
         H0: Hashable, H1: Hashable, H2: Hashable, H3: Hashable, H4: Hashable
     >(
@@ -148,13 +272,36 @@ extension AsyncSequence where Self: Sendable, Element: Sendable {
         return _shareFromCache(cache, strategy: strategy, hasher: &hasher)
     }
 
-    /// Shares data from the given cache based on a specified caching strategy and hashable keys.
+    /// This operator enables sharing and caching of results from an async sequence
+    /// based on a specified caching strategy and six hashable cache keys.
+    /// The combined hashable keys uniquely identify the shared sequence in the cache.
+    ///
+    /// ## Example
+    /// ```swift
+    /// let cache = AsyncSequenceCache()
+    /// let sequence = fetchMetrics(region: "US", year: 2025, month: 7, day: 4, category: "sales", subcategory: "online")
+    /// let sharedSequence = sequence.shareFromCache(cache, strategy: .cacheUntilCompletionOrCancellation, keys: "US", 2025, 7, 4, "sales", "online")
+    ///
+    /// Task {
+    ///     for await metric in sharedSequence {
+    ///         print("Metric: \(metric)")
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// These six keys combined provide a unique cache key.
     ///
     /// - Parameters:
     ///   - cache: The cache from which to share data.
     ///   - strategy: The caching strategy to use.
-    ///   - keys: One or more hashable keys used to look up the data in the cache.
-    /// - Returns: An asynchronous unit of work encapsulating the operation's success or failure.
+    ///   - keys k0: The first hashable key.
+    ///   - k1: The second hashable key.
+    ///   - k2: The third hashable key.
+    ///   - k3: The fourth hashable key.
+    ///   - k4: The fifth hashable key.
+    ///   - k5: The sixth hashable key.
+    /// - Returns: An asynchronous broadcast sequence that shares the underlying sequence's values according to the cache and strategy.
+    /// - Important: This operator should generally be placed at the end of an operator chain. Any operators applied after `shareFromCache` will not be shared and may result in duplicated work or side effects.
     public func shareFromCache<
         H0: Hashable, H1: Hashable, H2: Hashable, H3: Hashable, H4: Hashable, H5: Hashable
     >(
@@ -172,13 +319,37 @@ extension AsyncSequence where Self: Sendable, Element: Sendable {
         return _shareFromCache(cache, strategy: strategy, hasher: &hasher)
     }
 
-    /// Shares data from the given cache based on a specified caching strategy and hashable keys.
+    /// This operator enables sharing and caching of results from an async sequence
+    /// based on a specified caching strategy and seven hashable cache keys.
+    /// The combined hashable keys uniquely identify the shared sequence in the cache.
+    ///
+    /// ## Example
+    /// ```swift
+    /// let cache = AsyncSequenceCache()
+    /// let sequence = fetchReportData(region: "EU", year: 2025, month: 7, day: 4, reportType: "summary", version: 2, language: "en")
+    /// let sharedSequence = sequence.shareFromCache(cache, strategy: .cacheUntilCompletionOrCancellation, keys: "EU", 2025, 7, 4, "summary", 2, "en")
+    ///
+    /// Task {
+    ///     for await report in sharedSequence {
+    ///         print("Report: \(report)")
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// These seven keys combined provide a unique cache key.
     ///
     /// - Parameters:
     ///   - cache: The cache from which to share data.
     ///   - strategy: The caching strategy to use.
-    ///   - keys: One or more hashable keys used to look up the data in the cache.
-    /// - Returns: An asynchronous unit of work encapsulating the operation's success or failure.
+    ///   - keys k0: The first hashable key.
+    ///   - k1: The second hashable key.
+    ///   - k2: The third hashable key.
+    ///   - k3: The fourth hashable key.
+    ///   - k4: The fifth hashable key.
+    ///   - k5: The sixth hashable key.
+    ///   - k6: The seventh hashable key.
+    /// - Returns: An asynchronous broadcast sequence that shares the underlying sequence's values according to the cache and strategy.
+    /// - Important: This operator should generally be placed at the end of an operator chain. Any operators applied after `shareFromCache` will not be shared and may result in duplicated work or side effects.
     public func shareFromCache<
         H0: Hashable, H1: Hashable, H2: Hashable, H3: Hashable, H4: Hashable, H5: Hashable,
         H6: Hashable
@@ -198,13 +369,38 @@ extension AsyncSequence where Self: Sendable, Element: Sendable {
         return _shareFromCache(cache, strategy: strategy, hasher: &hasher)
     }
 
-    /// Shares data from the given cache based on a specified caching strategy and hashable keys.
+    /// This operator enables sharing and caching of results from an async sequence
+    /// based on a specified caching strategy and eight hashable cache keys.
+    /// The combined hashable keys uniquely identify the shared sequence in the cache.
+    ///
+    /// ## Example
+    /// ```swift
+    /// let cache = AsyncSequenceCache()
+    /// let sequence = fetchDataSet(a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7, h: 8)
+    /// let sharedSequence = sequence.shareFromCache(cache, strategy: .cacheUntilCompletionOrCancellation, keys: 1, 2, 3, 4, 5, 6, 7, 8)
+    ///
+    /// Task {
+    ///     for await item in sharedSequence {
+    ///         print("Item: \(item)")
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// These eight keys combined provide a unique cache key.
     ///
     /// - Parameters:
     ///   - cache: The cache from which to share data.
     ///   - strategy: The caching strategy to use.
-    ///   - keys: One or more hashable keys used to look up the data in the cache.
-    /// - Returns: An asynchronous unit of work encapsulating the operation's success or failure.
+    ///   - keys k0: The first hashable key.
+    ///   - k1: The second hashable key.
+    ///   - k2: The third hashable key.
+    ///   - k3: The fourth hashable key.
+    ///   - k4: The fifth hashable key.
+    ///   - k5: The sixth hashable key.
+    ///   - k6: The seventh hashable key.
+    ///   - k7: The eighth hashable key.
+    /// - Returns: An asynchronous broadcast sequence that shares the underlying sequence's values according to the cache and strategy.
+    /// - Important: This operator should generally be placed at the end of an operator chain. Any operators applied after `shareFromCache` will not be shared and may result in duplicated work or side effects.
     public func shareFromCache<
         H0: Hashable, H1: Hashable, H2: Hashable, H3: Hashable, H4: Hashable, H5: Hashable,
         H6: Hashable, H7: Hashable
@@ -225,13 +421,39 @@ extension AsyncSequence where Self: Sendable, Element: Sendable {
         return _shareFromCache(cache, strategy: strategy, hasher: &hasher)
     }
 
-    /// Shares data from the given cache based on a specified caching strategy and hashable keys.
+    /// This operator enables sharing and caching of results from an async sequence
+    /// based on a specified caching strategy and nine hashable cache keys.
+    /// The combined hashable keys uniquely identify the shared sequence in the cache.
+    ///
+    /// ## Example
+    /// ```swift
+    /// let cache = AsyncSequenceCache()
+    /// let sequence = fetchData(a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7, h: 8, i: 9)
+    /// let sharedSequence = sequence.shareFromCache(cache, strategy: .cacheUntilCompletionOrCancellation, keys: 1, 2, 3, 4, 5, 6, 7, 8, 9)
+    ///
+    /// Task {
+    ///     for await item in sharedSequence {
+    ///         print("Item: \(item)")
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// These nine keys combined provide a unique cache key.
     ///
     /// - Parameters:
     ///   - cache: The cache from which to share data.
     ///   - strategy: The caching strategy to use.
-    ///   - keys: One or more hashable keys used to look up the data in the cache.
-    /// - Returns: An asynchronous unit of work encapsulating the operation's success or failure.
+    ///   - keys k0: The first hashable key.
+    ///   - k1: The second hashable key.
+    ///   - k2: The third hashable key.
+    ///   - k3: The fourth hashable key.
+    ///   - k4: The fifth hashable key.
+    ///   - k5: The sixth hashable key.
+    ///   - k6: The seventh hashable key.
+    ///   - k7: The eighth hashable key.
+    ///   - k8: The ninth hashable key.
+    /// - Returns: An asynchronous broadcast sequence that shares the underlying sequence's values according to the cache and strategy.
+    /// - Important: This operator should generally be placed at the end of an operator chain. Any operators applied after `shareFromCache` will not be shared and may result in duplicated work or side effects.
     public func shareFromCache<
         H0: Hashable, H1: Hashable, H2: Hashable, H3: Hashable, H4: Hashable, H5: Hashable,
         H6: Hashable, H7: Hashable, H8: Hashable
@@ -253,13 +475,40 @@ extension AsyncSequence where Self: Sendable, Element: Sendable {
         return _shareFromCache(cache, strategy: strategy, hasher: &hasher)
     }
 
-    /// Shares data from the given cache based on a specified caching strategy and hashable keys.
+    /// This operator enables sharing and caching of results from an async sequence
+    /// based on a specified caching strategy and ten hashable cache keys.
+    /// The combined hashable keys uniquely identify the shared sequence in the cache.
+    ///
+    /// ## Example
+    /// ```swift
+    /// let cache = AsyncSequenceCache()
+    /// let sequence = fetchData(a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7, h: 8, i: 9, j: 10)
+    /// let sharedSequence = sequence.shareFromCache(cache, strategy: .cacheUntilCompletionOrCancellation, keys: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+    ///
+    /// Task {
+    ///     for await item in sharedSequence {
+    ///         print("Item: \(item)")
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// These ten keys combined provide a unique cache key.
     ///
     /// - Parameters:
     ///   - cache: The cache from which to share data.
     ///   - strategy: The caching strategy to use.
-    ///   - keys: One or more hashable keys used to look up the data in the cache.
-    /// - Returns: An asynchronous unit of work encapsulating the operation's success or failure.
+    ///   - keys k0: The first hashable key.
+    ///   - k1: The second hashable key.
+    ///   - k2: The third hashable key.
+    ///   - k3: The fourth hashable key.
+    ///   - k4: The fifth hashable key.
+    ///   - k5: The sixth hashable key.
+    ///   - k6: The seventh hashable key.
+    ///   - k7: The eighth hashable key.
+    ///   - k8: The ninth hashable key.
+    ///   - 🐶: The tenth hashable key.
+    /// - Returns: An asynchronous broadcast sequence that shares the underlying sequence's values according to the cache and strategy.
+    /// - Important: This operator should generally be placed at the end of an operator chain. Any operators applied after `shareFromCache` will not be shared and may result in duplicated work or side effects.
     public func shareFromCache<
         H0: Hashable, H1: Hashable, H2: Hashable, H3: Hashable, H4: Hashable, H5: Hashable,
         H6: Hashable, H7: Hashable, H8: Hashable, H9: Hashable

--- a/Sources/Afluent/SequenceOperators/TimerSequence.swift
+++ b/Sources/Afluent/SequenceOperators/TimerSequence.swift
@@ -9,7 +9,13 @@ import Foundation
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
 extension AsyncSequences {
-    /// A sequence that repeatedly emits an instant on a given interval.
+    /// A timer-based asynchronous sequence that emits the current instant of a specified clock
+    /// at a regular interval.
+    ///
+    /// This sequence repeatedly waits for the specified time interval, then emits a timestamp
+    /// representing the current instant according to the clock.
+    ///
+    /// This can be used to perform periodic asynchronous tasks or to observe regular time ticks.
     public struct TimerSequence<C: Clock>: AsyncSequence, Sendable {
         public typealias Element = C.Instant
 
@@ -66,11 +72,20 @@ public typealias TimerSequence = AsyncSequences.TimerSequence
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
 extension TimerSequence where C == ContinuousClock {
-    /// Returns a sequence that repeatedly emits an instant of a continuous clock on the given interval.
+    /// Creates a timer sequence that emits the current instant of a continuous clock at the specified interval.
     ///
     /// - Parameters:
-    ///   - interval: The time interval on which to publish events. For example, a value of `.milliseconds(1)` will publish an event approximately every 0.01 seconds.
-    ///   - tolerance: The allowed timing variance when emitting events. Defaults to `nil`, which will schedule with the default tolerance strategy.
+    ///   - interval: The time interval between emitted instants.
+    ///   - tolerance: An optional tolerance for scheduling, allowing slight variance in timing.
+    ///
+    /// ## Example
+    /// ```swift
+    /// let timer = TimerSequence<ContinuousClock>.publish(every: .seconds(1))
+    /// for await instant in timer {
+    ///     print("Tick at \(instant)")
+    /// }
+    /// // Prints a line every second with the current instant.
+    /// ```
     public static func publish(every interval: C.Duration, tolerance: C.Duration? = nil)
         -> AsyncSequences.TimerSequence<C>
     {
@@ -80,12 +95,22 @@ extension TimerSequence where C == ContinuousClock {
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
 extension TimerSequence {
-    /// Returns a sequence that repeatedly emits an instant of the passed clock on the given interval.
+    /// Creates a timer sequence that emits the current instant of the specified clock at the given interval.
     ///
     /// - Parameters:
-    ///   - interval: The time interval on which to publish events. For example, a value of `.milliseconds(1)` will publish an event approximately every 0.01 seconds.
-    ///   - tolerance: The allowed timing variance when emitting events. Defaults to `nil`, which will schedule with the default tolerance strategy.
-    ///   - clock: The clock instance to utilize for sequence timing. For example, `ContinuousClock` or `SuspendingClock`.
+    ///   - interval: The time interval between emitted instants.
+    ///   - tolerance: An optional tolerance for scheduling, allowing slight variance in timing.
+    ///   - clock: The clock instance to use for timing.
+    ///
+    /// ## Example
+    /// ```swift
+    /// let customClock = ContinuousClock()
+    /// let timer = TimerSequence.publish(every: .seconds(1), tolerance: nil, clock: customClock)
+    /// for await instant in timer {
+    ///     print("Tick at \(instant)")
+    /// }
+    /// // Prints a line every second with the current instant.
+    /// ```
     public static func publish(every interval: C.Duration, tolerance: C.Duration? = nil, clock: C)
         -> AsyncSequences.TimerSequence<C>
     {

--- a/Sources/Afluent/Subscription/AnyCancellable.swift
+++ b/Sources/Afluent/Subscription/AnyCancellable.swift
@@ -7,8 +7,21 @@
 
 import Foundation
 
-/// Stores an erased unit of work and provides a mechanism to cancel it
-/// - NOTE: The unit of work will be cancelled when the AnyCancellable is deinitialized
+/// Stores an erased unit of work and provides a mechanism to cancel it.
+///
+/// `AnyCancellable` acts as a type-erased token that manages the lifecycle of an asynchronous unit of work.
+/// When this instance is deinitialized, the associated unit of work is automatically cancelled, ensuring
+/// that ongoing asynchronous operations do not continue unnecessarily.
+///
+/// Use `AnyCancellable` to hold onto and control asynchronous tasks, typically returned from operations that
+/// support cancellation.
+///
+/// ```swift
+/// let cancellable = someAsynchronousUnitOfWork.subscribe()
+/// // To cancel explicitly:
+/// cancellable.cancel()
+/// // Or let `cancellable` go out of scope to cancel automatically.
+/// ```
 public final class AnyCancellable: Hashable, Sendable {
     public static func == (lhs: AnyCancellable, rhs: AnyCancellable) -> Bool {
         lhs === rhs
@@ -27,24 +40,64 @@ public final class AnyCancellable: Hashable, Sendable {
         hasher.combine(ObjectIdentifier(self))
     }
 
-    /// Cancels the asynchronous unit of work
+    /// Cancels the asynchronous unit of work immediately.
+    ///
+    /// Call this method to explicitly cancel the associated asynchronous operation before the
+    /// `AnyCancellable` instance is deallocated. This prevents any further work or callbacks from
+    /// occurring related to the unit of work.
+    ///
+    /// - Important: If not called manually, cancellation will occur automatically when this instance is deinitialized.
     public func cancel() {
         unitOfWork.cancel()
     }
 
     /// Stores this type-erasing cancellable instance in the specified collection.
+    ///
+    /// This is useful for managing multiple cancellables together, such as storing them in an array
+    /// to maintain their lifetime for the duration of a scope.
+    ///
+    /// - Parameter collection: A range-replaceable collection of `AnyCancellable` to append to.
+    /// 
+    /// ```swift
+    /// var cancellables: [AnyCancellable] = []
+    /// someUnitOfWork.subscribe().store(in: &cancellables)
+    /// ```
     public func store(in collection: inout some RangeReplaceableCollection<AnyCancellable>) {
         collection.append(self)
     }
 
     /// Stores this type-erasing cancellable instance in the specified set.
+    ///
+    /// This allows efficient management of cancellables with uniqueness guaranteed.
+    ///
+    /// - Parameter set: A set of `AnyCancellable` instances to insert into.
+    ///
+    /// ```swift
+    /// var cancellableSet: Set<AnyCancellable> = []
+    /// someUnitOfWork.subscribe().store(in: &cancellableSet)
+    /// ```
     public func store(in set: inout Set<AnyCancellable>) {
         set.insert(self)
     }
 }
 
 extension AsynchronousUnitOfWork {
-    /// Executes the current asynchronous unit of work and returns an AnyCancellable token to cancel the subscription
+    /// Executes the current asynchronous unit of work and returns an `AnyCancellable` token to cancel the subscription.
+    ///
+    /// Calling this method starts the asynchronous operation immediately.
+    /// The returned `AnyCancellable` instance can be held to keep the operation alive or cancelled to stop it early.
+    ///
+    /// - Parameter priority: Optional priority value to run the unit of work.
+    /// - Returns: An `AnyCancellable` token that can be used to cancel the running operation.
+    ///
+    /// - Note: The operation will also be cancelled automatically when the returned token is deinitialized.
+    ///
+    /// Usage example:
+    /// ```swift
+    /// let cancellable = networkRequest.subscribe(priority: .userInitiated)
+    /// // Later, if needed:
+    /// cancellable.cancel()
+    /// ```
     public func subscribe(priority: TaskPriority? = nil) -> AnyCancellable {
         defer { run(priority: priority) }
         return AnyCancellable(self)
@@ -63,12 +116,50 @@ extension AsynchronousUnitOfWork {
 }
 
 extension AsyncSequence where Self: Sendable {
-    /// Executes the current async sequence and returns an AnyCancellable token to cancel the subscription.
+    /// Starts processing the elements of this async sequence, handling output and completion events,
+    /// and returns an `AnyCancellable` token that can be used to cancel the subscription.
+    ///
+    /// This method allows you to asynchronously receive each element emitted by the sequence and respond
+    /// to completion or failure. The stream runs until all elements are consumed, an error occurs,
+    /// or cancellation is triggered via the returned token.
     ///
     /// - Parameters:
-    ///   - receiveCompletion: A function that is executed when the stream has completed normally with `nil` or an error.
-    ///   - receiveOutput: A function that is executed when output is received from the sequence.
-    ///   If this function throws an error, then the stream is completed.
+    ///   - receiveCompletion: An optional async closure invoked when the sequence completes, either normally with `.finished`
+    ///                        or with an error `.failure`. Called exactly once.
+    ///   - receiveOutput: An optional async throwing closure invoked for each element produced by the sequence.
+    ///                    If this closure throws an error, the sequence is terminated and completion closure is called with `.failure`.
+    ///
+    /// - Returns: An `AnyCancellable` token that can be stored and used to cancel the ongoing subscription.
+    ///
+    /// Usage example:
+    /// ```swift
+    /// let publisher: AsyncStream<Int> = AsyncStream { continuation in
+    ///     Task {
+    ///         for i in 1...5 {
+    ///             continuation.yield(i)
+    ///             try await Task.sleep(nanoseconds: 500_000_000)
+    ///         }
+    ///         continuation.finish()
+    ///     }
+    /// }
+    ///
+    /// let cancellable = publisher.sink(
+    ///     receiveCompletion: { completion in
+    ///         switch completion {
+    ///         case .finished:
+    ///             print("Stream completed successfully")
+    ///         case .failure(let error):
+    ///             print("Stream failed with error: \(error)")
+    ///         }
+    ///     },
+    ///     receiveOutput: { value in
+    ///         print("Received value: \(value)")
+    ///     }
+    /// )
+    ///
+    /// // To cancel early:
+    /// // cancellable.cancel()
+    /// ```
     public func sink(
         receiveCompletion: (@Sendable (AsyncSequences.Completion<Error>) async -> Void)? = nil,
         receiveOutput: (@Sendable (Element) async throws -> Void)? = nil
@@ -88,7 +179,10 @@ extension AsyncSequence where Self: Sendable {
 }
 
 extension AsyncSequences {
-    /// A type that represents the completion of a sequence, either due to a normal completion with `nil` or an error.
+    /// A type that represents the completion of a sequence, either due to a normal completion or an error.
+    ///
+    /// - `finished`: Indicates that the sequence completed normally without errors.
+    /// - `failure`: Indicates that the sequence terminated with the specified error.
     public enum Completion<Failure: Error> {
         /// The sequence finished normally.
         case finished

--- a/Sources/Afluent/Workers/AssertNoFailure.swift
+++ b/Sources/Afluent/Workers/AssertNoFailure.swift
@@ -31,12 +31,30 @@ extension Workers {
 }
 
 extension AsynchronousUnitOfWork {
-    /// Adds a behavior to the unit of work that asserts no failures are emitted.
+    /// Returns a new unit of work that asserts if the upstream unit of work throws any error other than cancellation.
     ///
-    /// This is often useful for debugging or in scenarios where you are certain
-    /// that the upstream `AsynchronousUnitOfWork` should not emit any errors.
+    /// This operator is useful for debugging or development when you expect the upstream
+    /// `AsynchronousUnitOfWork` to never fail. If an unexpected error is thrown, an assertion failure
+    /// will be triggered, helping you catch and diagnose issues early.
     ///
-    /// - Returns: A new `AsynchronousUnitOfWork` that will assert if any failures are emitted from the upstream unit of work.
+    /// ## Example
+    /// ```swift
+    /// // A unit of work that succeeds
+    /// let successWork = DeferredTask {
+    ///     return "Success"
+    /// }
+    ///
+    /// // Wrapping with `assertNoFailure` should not cause assertion failures here
+    /// let guaranteedSuccess = successWork.assertNoFailure()
+    ///
+    /// // Uncommenting the following would trigger an assertion failure if the task throws:
+    /// // let failingWork = DeferredTask<String> {
+    /// //     throw NSError(domain: "TestError", code: 1)
+    /// // }
+    /// // let assertedFailingWork = failingWork.assertNoFailure()
+    /// ```
+    ///
+    /// - Returns: A new `AsynchronousUnitOfWork` that will assert if the upstream unit of work throws any non-cancellation error.
     public func assertNoFailure() -> some AsynchronousUnitOfWork<Success> {
         Workers.AssertNoFailure(upstream: self)
     }

--- a/Sources/Afluent/Workers/Assign.swift
+++ b/Sources/Afluent/Workers/Assign.swift
@@ -8,10 +8,31 @@
 import Foundation
 
 extension AsynchronousUnitOfWork {
-    /// Assigns the output of an asynchronous unit of work to a key path on an object.
-    ///  - Parameter keyPath: The key path to assign the output to.
-    ///  - Parameter object: The object to assign the output to.
-    ///  - Note: This method will not retain the object passed in. If the object is deallocated the assignment will stop.
+    /// Assigns the output of an asynchronous unit of work to a key path on an object when the work completes successfully.
+    ///
+    /// This method allows you to bind the result of the asynchronous operation to a property of an object, updating that property automatically upon completion.
+    /// The object is held weakly to avoid retain cycles, so if the object is deallocated before the asynchronous work completes, the assignment will not occur.
+    ///
+    /// ## Example
+    /// ```swift
+    /// class MyModel: Sendable {
+    ///     var value: Int = 0
+    /// }
+    ///
+    /// let model = MyModel()
+    /// let unitOfWork: AsynchronousUnitOfWork<Int> = ...
+    ///
+    /// Task {
+    ///     try await unitOfWork.assign(to: \.value, on: model)
+    ///     print("Model value updated to \(model.value)")
+    /// }
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - keyPath: The key path to assign the output to.
+    ///   - object: The object to assign the output to.
+    /// - Throws: Rethrows any error thrown by the asynchronous unit of work.
+    /// - Note: This method is asynchronous and will complete when the assignment has been made or the operation fails.
     public func assign<Root: AnyObject & Sendable>(
         to keyPath: ReferenceWritableKeyPath<Root, Success>, on object: Root
     ) async throws {

--- a/Sources/Afluent/Workers/Breakpoint.swift
+++ b/Sources/Afluent/Workers/Breakpoint.swift
@@ -8,16 +8,48 @@
 import Foundation
 
 extension AsynchronousUnitOfWork {
-    /// Introduces a breakpoint into the asynchronous unit of work.
+    /// Inserts conditional breakpoints into the asynchronous unit of work,
+    /// allowing you to pause execution when specific output values or errors occur.
     ///
-    /// This function allows you to introduce conditional breakpoints based on the output or error of the asynchronous operation.
-    /// If the provided conditions are met, a `SIGTRAP` signal is raised, pausing execution in a debugger.
+    /// ## Discussion
+    /// When the provided conditions evaluate to `true`, a `SIGTRAP` signal is raised,
+    /// which typically causes the program to pause execution in a debugger.
+    /// This enables you to inspect state or step through code at critical points.
     ///
     /// - Parameters:
-    ///   - receiveOutput: A closure that takes the successful output of the operation. If this closure returns `true`, a breakpoint is triggered. Default is `nil`.
-    ///   - receiveError: A closure that takes any error produced by the operation. If this closure returns `true`, a breakpoint is triggered. Default is `nil`.
+    ///   - receiveOutput: A closure that asynchronously receives successful output values.
+    ///     If this closure returns `true`, a breakpoint is triggered.
+    ///     If `nil`, no breakpoint is triggered based on output values.
+    ///   - receiveError: A closure that asynchronously receives errors produced by the operation.
+    ///     If this closure returns `true`, a breakpoint is triggered.
+    ///     If `nil`, no breakpoint is triggered based on errors.
     ///
-    /// - Returns: An asynchronous unit of work with the breakpoint conditions applied.
+    /// ## Example
+    /// ```swift
+    /// let task = DeferredTask<Int, Error> {
+    ///     42
+    /// }
+    ///
+    /// // Breakpoint when the output value is exactly 42
+    /// let breakpointedTask = task.breakpoint(receiveOutput: { output in
+    ///     return output == 42
+    /// })
+    ///
+    /// try await breakpointedTask.value
+    /// ```
+    ///
+    /// ```swift
+    /// let failingTask = DeferredTask<Int, Error> {
+    ///     throw NSError(domain: "Example", code: -1, userInfo: nil)
+    /// }
+    ///
+    /// // Breakpoint when any error occurs
+    /// let breakpointedTask = failingTask.breakpoint(receiveError: { error in
+    ///     return true
+    /// })
+    ///
+    /// try await breakpointedTask.value
+    /// ```
     @_transparent @_alwaysEmitIntoClient @inlinable public func breakpoint(
         receiveOutput: (@Sendable (Success) async throws -> Bool)? = nil,
         receiveError: (@Sendable (Error) async throws -> Bool)? = nil
@@ -35,14 +67,27 @@ extension AsynchronousUnitOfWork {
             })
     }
 
-    /// Introduces a breakpoint into the asynchronous unit of work when an error occurs.
+    /// Inserts an unconditional breakpoint on error into the asynchronous unit of work.
     ///
-    /// This function triggers a `SIGTRAP` signal, pausing execution in a debugger, whenever the asynchronous operation produces an error.
+    /// ## Discussion
+    /// This function triggers a `SIGTRAP` signal whenever the asynchronous operation produces an error,
+    /// allowing you to pause execution immediately when any failure occurs.
     ///
-    /// - Returns: An asynchronous unit of work with the breakpoint-on-error condition applied.
+    /// ## Example
+    /// ```swift
+    /// let failingTask = DeferredTask<Int, Error> {
+    ///     throw NSError(domain: "Example", code: -1, userInfo: nil)
+    /// }
+    ///
+    /// // Breakpoint on any error
+    /// let breakpointedTask = failingTask.breakpointOnError()
+    ///
+    /// try await breakpointedTask.value
+    /// ```
     @_transparent @_alwaysEmitIntoClient @inlinable public func breakpointOnError()
         -> some AsynchronousUnitOfWork<Success>
     {
         breakpoint(receiveError: { _ in true })
     }
 }
+

--- a/Sources/Afluent/Workers/Catch.swift
+++ b/Sources/Afluent/Workers/Catch.swift
@@ -40,12 +40,38 @@ extension Workers {
 }
 
 extension AsynchronousUnitOfWork {
-    /// Catches any errors emitted by the upstream `AsynchronousUnitOfWork` and handles them using the provided closure.
+    /// Returns an asynchronous unit of work that catches any errors emitted by the upstream asynchronous unit of work
+    /// and recovers by replacing the failure with a new unit of work produced by the given non-throwing handler.
+    ///
+    /// The provided handler receives the caught error and must return a new asynchronous unit of work that produces the same success type.
+    ///
+    /// This operator is useful for implementing fallback or recovery logic when any error occurs.
     ///
     /// - Parameters:
-    ///   - handler: A closure that takes an `Error` and returns an `AsynchronousUnitOfWork`.
+    ///   - handler: A closure that takes the caught `Error` and returns an `AsynchronousUnitOfWork` to recover with.
     ///
-    /// - Returns: An `AsynchronousUnitOfWork` that will catch and handle any errors emitted by the upstream unit of work.
+    /// - Returns: An `AsynchronousUnitOfWork` that will catch any error from the upstream and replace it by the unit of work returned by the handler.
+    ///
+    /// ## Example
+    /// ```swift
+    /// struct FallbackError: Error {}
+    ///
+    /// let primaryTask = DeferredTask<Int> {
+    ///     throw FallbackError()
+    /// }
+    ///
+    /// let fallbackTask = DeferredTask<Int> {
+    ///     return 42
+    /// }
+    ///
+    /// let recoveredTask = primaryTask.catch { error in
+    ///     print("Caught error: \(error), recovering with fallback")
+    ///     return fallbackTask
+    /// }
+    ///
+    /// let result = try await recoveredTask.operation().value
+    /// // result == 42
+    /// ```
     public func `catch`<D: AsynchronousUnitOfWork>(
         @_inheritActorContext @_implicitSelfCapture _ handler: @Sendable @escaping (Error) async ->
             D
@@ -53,13 +79,41 @@ extension AsynchronousUnitOfWork {
         Workers.Catch(upstream: self, handler)
     }
 
-    /// Catches a specific type of error emitted by the upstream `AsynchronousUnitOfWork` and handles them using the provided closure.
+    /// Returns an asynchronous unit of work that catches a specific equatable error emitted by the upstream asynchronous unit of work
+    /// and recovers by replacing the failure with a new unit of work produced by the given non-throwing handler.
+    ///
+    /// The handler is invoked only if the caught error matches the specified error value, otherwise the error is rethrown.
+    ///
+    /// Use this operator to selectively recover from specific error cases.
     ///
     /// - Parameters:
-    ///   - error: The specific error type to catch.
-    ///   - handler: A closure that takes an `Error` and returns an `AsynchronousUnitOfWork`.
+    ///   - error: The specific error value to catch.
+    ///   - handler: A closure that takes the caught error of type `E` and returns an `AsynchronousUnitOfWork` to recover with.
     ///
-    /// - Returns: An `AsynchronousUnitOfWork` that will catch and handle the specific error.
+    /// - Returns: An `AsynchronousUnitOfWork` that will catch and replace the specified error with the returned unit of work.
+    ///
+    /// ## Example
+    /// ```swift
+    /// enum NetworkError: Error, Equatable {
+    ///     case timeout
+    ///     case unreachable
+    /// }
+    ///
+    /// let networkRequest = DeferredTask<Data> {
+    ///     throw NetworkError.timeout
+    /// }
+    ///
+    /// let fallbackRequest = DeferredTask<Data> {
+    ///     return Data()
+    /// }
+    ///
+    /// let recoveredRequest = networkRequest.catch(NetworkError.timeout) { error in
+    ///     print("Caught timeout error, retrying with fallback")
+    ///     return fallbackRequest
+    /// }
+    ///
+    /// let data = try await recoveredRequest.operation().value
+    /// ```
     public func `catch`<D: AsynchronousUnitOfWork, E: Error & Equatable>(
         _ error: E,
         @_inheritActorContext @_implicitSelfCapture _ handler: @Sendable @escaping (E) async -> D
@@ -72,12 +126,42 @@ extension AsynchronousUnitOfWork {
         }
     }
 
-    /// Tries to catch any errors emitted by the upstream `AsynchronousUnitOfWork` and handles them using the provided throwing closure.
+    /// Returns an asynchronous unit of work that tries to catch any errors emitted by the upstream asynchronous unit of work
+    /// and recovers by replacing the failure with a new unit of work produced by the given throwing handler.
+    ///
+    /// The handler receives the caught error and can throw. If the handler throws, the error is rethrown.
+    ///
+    /// This operator is useful when recovery logic itself can throw asynchronously.
     ///
     /// - Parameters:
-    ///   - handler: A closure that takes an `Error` and returns an `AsynchronousUnitOfWork`, potentially throwing an error.
+    ///   - handler: A closure that takes the caught `Error` and asynchronously throws or returns an `AsynchronousUnitOfWork` to recover with.
     ///
-    /// - Returns: An `AsynchronousUnitOfWork` that will try to catch and handle any errors emitted by the upstream unit of work.
+    /// - Returns: An `AsynchronousUnitOfWork` that tries to catch and replace any error with the unit of work returned by the handler.
+    ///
+    /// ## Example
+    /// ```swift
+    /// struct FallbackError: Error {}
+    ///
+    /// let primaryTask = DeferredTask<Int> {
+    ///     throw FallbackError()
+    /// }
+    ///
+    /// let fallbackTask = DeferredTask<Int> {
+    ///     return 42
+    /// }
+    ///
+    /// let recoveredTask = primaryTask.tryCatch { error in
+    ///     print("Caught error: \(error), attempting recovery")
+    ///     // Recovery could fail, so handler can throw
+    ///     if Bool.random() {
+    ///         return fallbackTask
+    ///     } else {
+    ///         throw error
+    ///     }
+    /// }
+    ///
+    /// let result = try await recoveredTask.operation().value
+    /// ```
     public func tryCatch<D: AsynchronousUnitOfWork>(
         @_inheritActorContext @_implicitSelfCapture _ handler: @Sendable @escaping (Error)
             async throws -> D
@@ -85,13 +169,45 @@ extension AsynchronousUnitOfWork {
         Workers.Catch(upstream: self, handler)
     }
 
-    /// Tries to catch a specific type of error emitted by the upstream `AsynchronousUnitOfWork` and handles them using the provided throwing closure.
+    /// Returns an asynchronous unit of work that tries to catch a specific equatable error emitted by the upstream asynchronous unit of work
+    /// and recovers by replacing the failure with a new unit of work produced by the given throwing handler.
+    ///
+    /// The handler is invoked only if the caught error matches the specified error value. If the handler throws, the error is rethrown.
+    ///
+    /// Use this operator to selectively recover from specific error cases with potentially throwing recovery logic.
     ///
     /// - Parameters:
-    ///   - error: The specific error type to catch.
-    ///   - handler: A closure that takes an `Error` and returns an `AsynchronousUnitOfWork`, potentially throwing an error.
+    ///   - error: The specific error value to catch.
+    ///   - handler: A closure that takes the caught error of type `E`, asynchronously throws or returns an `AsynchronousUnitOfWork` to recover with.
     ///
-    /// - Returns: An `AsynchronousUnitOfWork` that will try to catch and handle the specific error.
+    /// - Returns: An `AsynchronousUnitOfWork` that tries to catch and replace the specified error with the returned unit of work.
+    ///
+    /// ## Example
+    /// ```swift
+    /// enum NetworkError: Error, Equatable {
+    ///     case timeout
+    ///     case unreachable
+    /// }
+    ///
+    /// let networkRequest = DeferredTask<Data> {
+    ///     throw NetworkError.timeout
+    /// }
+    ///
+    /// let fallbackRequest = DeferredTask<Data> {
+    ///     return Data()
+    /// }
+    ///
+    /// let recoveredRequest = networkRequest.tryCatch(NetworkError.timeout) { error in
+    ///     print("Handling timeout error with potentially throwing recovery")
+    ///     if Bool.random() {
+    ///         return fallbackRequest
+    ///     } else {
+    ///         throw error
+    ///     }
+    /// }
+    ///
+    /// let data = try await recoveredRequest.operation().value
+    /// ```
     public func tryCatch<D: AsynchronousUnitOfWork, E: Error & Equatable>(
         _ error: E,
         @_inheritActorContext @_implicitSelfCapture _ handler: @Sendable @escaping (E) async throws

--- a/Sources/Afluent/Workers/Decode.swift
+++ b/Sources/Afluent/Workers/Decode.swift
@@ -50,7 +50,32 @@ extension Workers {
 }
 
 extension AsynchronousUnitOfWork {
-    /// Decodes the output from the upstream `AsynchronousUnitOfWork` using the specified top-level decoder.
+    /// Decodes the output from the upstream `AsynchronousUnitOfWork` into a model of type `T` using the given top-level decoder.
+    ///
+    /// This operator transforms the upstream's output by applying the specified decoder to convert the data into a `Decodable` type.
+    /// The upstream's output must be compatible with the input type expected by the provided decoder (e.g., `Data` for `JSONDecoder`).
+    ///
+    /// ## Discussion
+    /// This is typically used to decode raw data (such as JSON `Data`) emitted by an upstream asynchronous unit of work into a strongly typed model.
+    /// It simplifies chaining asynchronous operations that involve fetching raw encoded data and decoding it into usable Swift types.
+    ///
+    /// ## Example
+    /// ```swift
+    /// struct User: Decodable, Sendable {
+    ///     let id: Int
+    ///     let name: String
+    /// }
+    ///
+    /// let jsonDataTask: DeferredTask<Data> = DeferredTask {
+    ///     // Imagine this fetches JSON data asynchronously
+    ///     Data("""{"id": 1, "name": "Alice"}""".utf8)
+    /// }
+    ///
+    /// let userTask = jsonDataTask.decode(type: User.self, decoder: JSONDecoder())
+    ///
+    /// let user = try await userTask.operation()
+    /// print(user.name) // prints "Alice"
+    /// ```
     ///
     /// - Parameters:
     ///   - type: The type `T` to decode into, conforming to the `Decodable` protocol.

--- a/Sources/Afluent/Workers/Delay.swift
+++ b/Sources/Afluent/Workers/Delay.swift
@@ -29,14 +29,30 @@ extension Workers {
 }
 
 extension AsynchronousUnitOfWork {
-    /// Delays the emission of output from the upstream `AsynchronousUnitOfWork` by a specified duration using a given clock.
+    /// Delays the emission of output from the upstream `AsynchronousUnitOfWork` by a specified duration.
     ///
-    /// - Parameters:
-    ///   - duration: The duration to delay the output.
+    /// This operator suspends the emission of output for the given duration before returning the value.
     ///
+    /// ## Discussion
+    /// Delayed work is useful in scenarios such as throttling requests, implementing retry backoff strategies,
+    /// or scheduling work to occur after a fixed interval. By delaying the emission, you can control timing
+    /// behavior in asynchronous workflows in a straightforward and composable manner.
+    ///
+    /// ## Example
+    /// ```swift
+    /// let start = Date()
+    /// let delayedTask = DeferredTask {
+    ///     "Hello, world!"
+    /// }.delay(for: .seconds(2))
+    /// let result = try await delayedTask.execute()
+    /// let elapsed = Date().timeIntervalSince(start)
+    /// print("Result: \(result) after \(elapsed) seconds")
+    /// ```
+    ///
+    /// - Parameter duration: The duration to delay the output.
     /// - Returns: An `AsynchronousUnitOfWork` that emits the upstream output after the specified delay.
     ///
-    /// - Availability: macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0 and above.
+    /// - Availability: macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0 and above.
     @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
     public func delay(for duration: Duration) -> some AsynchronousUnitOfWork<Success> {
         Workers.Delay(upstream: self, clock: SuspendingClock(), duration: duration, tolerance: nil)
@@ -44,14 +60,32 @@ extension AsynchronousUnitOfWork {
 
     /// Delays the emission of output from the upstream `AsynchronousUnitOfWork` by a specified duration using a given clock.
     ///
+    /// This operator suspends the emission of output for the specified duration according to the provided clock.
+    ///
+    /// ## Discussion
+    /// Delaying work using a custom clock is beneficial when you need precise control over timing behavior,
+    /// such as testing with test clocks or synchronizing work with specific time sources.
+    /// Use this operator to implement retry backoff, throttling, or scheduled tasks that depend on a particular clock implementation.
+    ///
+    /// ## Example
+    /// ```swift
+    /// let start = Date()
+    /// let clock = SuspendingClock()
+    /// let delayedTask = DeferredTask {
+    ///     "Delayed with custom clock"
+    /// }.delay(for: .seconds(1), clock: clock, tolerance: .milliseconds(100))
+    /// let result = try await delayedTask.execute()
+    /// let elapsed = Date().timeIntervalSince(start)
+    /// print("Result: \(result) after \(elapsed) seconds")
+    /// ```
+    ///
     /// - Parameters:
-    ///   - duration: The duration to delay the output, conforming to the `C.Instant.Duration` type.
+    ///   - duration: The duration to delay the output, conforming to the clock's associated `Duration` type.
     ///   - clock: The clock used for timekeeping. Defaults to `SuspendingClock()`.
     ///   - tolerance: An optional tolerance for the delay. Defaults to `nil`.
-    ///
     /// - Returns: An `AsynchronousUnitOfWork` that emits the upstream output after the specified delay.
     ///
-    /// - Availability: macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0 and above.
+    /// - Availability: macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0 and above.
     @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
     public func delay<C: Clock>(for duration: C.Duration, clock: C, tolerance: C.Duration? = nil)
         -> some AsynchronousUnitOfWork<Success>
@@ -59,3 +93,4 @@ extension AsynchronousUnitOfWork {
         Workers.Delay(upstream: self, clock: clock, duration: duration, tolerance: tolerance)
     }
 }
+

--- a/Sources/Afluent/Workers/DiscardOutput.swift
+++ b/Sources/Afluent/Workers/DiscardOutput.swift
@@ -10,8 +10,26 @@ import Foundation
 extension AsynchronousUnitOfWork {
     /// Discards the output values from the upstream `AsynchronousUnitOfWork`.
     ///
+    /// Use this method when you are interested in the completion of the asynchronous operation
+    /// but do not need the actual output values.
+    ///
+    /// Example:
+    /// ```swift
+    /// let originalWork: some AsynchronousUnitOfWork<Int> = ...
+    /// let voidWork = originalWork.discardOutput()
+    /// voidWork.start { result in
+    ///     switch result {
+    ///     case .success():
+    ///         print("Completed successfully without output")
+    ///     case .failure(let error):
+    ///         print("Failed with error: \(error)")
+    ///     }
+    /// }
+    /// ```
+    ///
     /// - Returns: An `AsynchronousUnitOfWork` of type `Void` that emits a completion event when the upstream completes.
     public func discardOutput() -> some AsynchronousUnitOfWork<Void> {
         map { _ in }
     }
 }
+

--- a/Sources/Afluent/Workers/Encode.swift
+++ b/Sources/Afluent/Workers/Encode.swift
@@ -50,13 +50,22 @@ extension Workers {
 }
 
 extension AsynchronousUnitOfWork {
-    /// Encodes the successful output values from the upstream `AsynchronousUnitOfWork` using the provided encoder.
+    /// Encodes the successful output value from the upstream `AsynchronousUnitOfWork` using the provided encoder.
     ///
-    /// - Parameter encoder: The encoder to use for encoding the successful output values.
+    /// Use this operator when you want to transform an encodable output (such as a model or primitive value) into an encoded form (like Data) using a given encoder (e.g., JSONEncoder).
     ///
-    /// - Returns: An `AsynchronousUnitOfWork` emitting the encoded values as output of type `E.Output`.
+    /// ## Example
+    /// ```
+    /// struct Person: Encodable { let name: String }
+    /// let work = DeferredTask { Person(name: "Alice") }
+    /// let encoded: some AsynchronousUnitOfWork<Data> = work.encode(encoder: JSONEncoder())
+    /// let data = try await encoded.execute()
+    /// // 'data' now contains the encoded JSON representation of the Person
+    /// ```
     ///
-    /// - Note: The returned `AsynchronousUnitOfWork` will fail if the encoding process fails.
+    /// - Parameter encoder: The encoder to use for encoding the successful output value.
+    /// - Returns: An `AsynchronousUnitOfWork` emitting the encoded value as output of type `E.Output`.
+    /// - Note: The returned unit of work will fail if the encoding process throws an error.
     public func encode<E: TopLevelEncoder>(encoder: E) -> some AsynchronousUnitOfWork<E.Output>
     where Success: Encodable, E.Output: Sendable {
         Workers.Encode(upstream: self, encoder: encoder)

--- a/Sources/Afluent/Workers/EraseToAnyAsynchronousUnitOfWork.swift
+++ b/Sources/Afluent/Workers/EraseToAnyAsynchronousUnitOfWork.swift
@@ -59,7 +59,19 @@ public struct AnyAsynchronousUnitOfWork<Success: Sendable>: AsynchronousUnitOfWo
 }
 
 extension AsynchronousUnitOfWork {
-    /// Type erases the current unit of work, useful when you need a concrete type
+    /// Type-erases this unit of work to `AnyAsynchronousUnitOfWork`, hiding its concrete type.
+    ///
+    /// Use this method when you need to store or pass around an `AsynchronousUnitOfWork` without exposing its underlying type, such as when collecting heterogeneous unit of work instances in a single array.
+    ///
+    /// ## Example
+    /// ```
+    /// struct User: Sendable {}
+    /// let original: some AsynchronousUnitOfWork<User> = DeferredTask { User() }
+    /// let erased: AnyAsynchronousUnitOfWork<User> = original.eraseToAnyUnitOfWork()
+    /// // 'erased' can now be used wherever a concrete type is needed.
+    /// ```
+    ///
+    /// - Returns: An `AnyAsynchronousUnitOfWork` that wraps this unit of work.
     public func eraseToAnyUnitOfWork() -> AnyAsynchronousUnitOfWork<Success> {
         AnyAsynchronousUnitOfWork(self)
     }

--- a/Sources/Afluent/Workers/HandleEvents.swift
+++ b/Sources/Afluent/Workers/HandleEvents.swift
@@ -65,15 +65,31 @@ extension Workers {
 extension AsynchronousUnitOfWork {
     /// Adds side-effects to the receiving events of the upstream `AsynchronousUnitOfWork`.
     ///
+    /// This operator allows you to hook into the lifecycle events of the asynchronous unit of work, 
+    /// enabling actions to be performed immediately before the operation starts, upon successful output, 
+    /// on errors, or cancellation.
+    ///
+    /// ## Example
+    /// ```
+    /// try await DeferredTask { try await fetchUser() }
+    ///     .handleEvents(
+    ///         receiveOperation: { print("About to start") },
+    ///         receiveOutput: { user in print("Received user: \(user)") },
+    ///         receiveError: { error in print("Failed with error: \(error)") },
+    ///         receiveCancel: { print("Cancelled") }
+    ///     )
+    ///     .execute()
+    /// ```
+    ///
     /// - Parameters:
-    ///   - receiveOperation: A closure that is invoked immediately before the upstream operation is executed. The closure can throw errors.
-    ///   - receiveOutput: A closure that is invoked when the upstream emits a successful output. The closure can throw errors.
-    ///   - receiveError: A closure that is invoked when the upstream emits an error. The closure can throw errors.
-    ///   - receiveCancel: A closure that is invoked when the unit of work is cancelled. The closure can throw errors.
+    ///   - receiveOperation: A closure invoked immediately before the upstream operation is executed. Can throw errors.
+    ///   - receiveOutput: A closure invoked when the upstream emits a successful output. Can throw errors.
+    ///   - receiveError: A closure invoked when the upstream emits an error. Can throw errors.
+    ///   - receiveCancel: A closure invoked when the unit of work is cancelled. Can throw errors.
     ///
-    /// - Returns: An `AsynchronousUnitOfWork` that performs the side-effects for the specified receiving events.
+    /// - Returns: An `AsynchronousUnitOfWork` that performs the specified side-effects during the receiving events.
     ///
-    /// - Note: The returned `AsynchronousUnitOfWork` forwards all receiving events from the upstream unit of work.
+    /// - Note: Errors thrown by any of the provided closures will propagate downstream and cancel the operation.
     public func handleEvents(
         @_inheritActorContext @_implicitSelfCapture receiveOperation: (
             @Sendable () async throws -> Void
@@ -93,3 +109,4 @@ extension AsynchronousUnitOfWork {
             receiveError: receiveError, receiveCancel: receiveCancel)
     }
 }
+

--- a/Sources/Afluent/Workers/MapError.swift
+++ b/Sources/Afluent/Workers/MapError.swift
@@ -40,9 +40,21 @@ extension AsynchronousUnitOfWork {
     ///
     /// This function allows you to modify or replace the error produced by the current unit of work. It's useful for converting between error types or adding additional context to errors.
     ///
+    /// ## Example
+    /// ```
+    /// enum MyError: Error { case network, wrapped(Error) }
+    /// let task = DeferredTask { throw URLError(.notConnectedToInternet) }
+    ///     .mapError { error in
+    ///         MyError.wrapped(error) // wrap any error in your custom error type
+    ///     }
+    /// try await task.execute()
+    /// ```
+    ///
     /// - Parameter transform: A closure that takes the original error and returns a transformed error.
     ///
     /// - Returns: An asynchronous unit of work that produces the transformed error.
+    ///
+    /// - Note: The transform closure is called for any error thrown, except `CancellationError` which is propagated as is.
     public func mapError(_ transform: @Sendable @escaping (Error) -> Error)
         -> some AsynchronousUnitOfWork<Success>
     {
@@ -53,11 +65,23 @@ extension AsynchronousUnitOfWork {
     ///
     /// This function allows you to modify or replace a specific error produced by the current unit of work. If the error produced matches the provided error, the transform closure is applied; otherwise, the original error is propagated unchanged.
     ///
+    /// ## Example
+    /// ```
+    /// enum MyError: Error, Equatable { case network, other }
+    /// let task = DeferredTask { throw MyError.network }
+    ///     .mapError(MyError.network) { error in
+    ///         MyError.other // only transforms if error matches
+    ///     }
+    /// try await task.execute()
+    /// ```
+    ///
     /// - Parameters:
     ///   - error: The specific error to be transformed. This error is equatable, allowing for precise matching.
     ///   - transform: A closure that takes the matched error and returns a transformed error.
     ///
     /// - Returns: An asynchronous unit of work that produces either the transformed error (if a match was found) or the original error.
+    ///
+    /// - Note: Only errors equal to the specified error are transformed; others are propagated unchanged.
     public func mapError<E: Error & Equatable>(
         _ error: E, _ transform: @Sendable @escaping (Error) -> Error
     ) -> some AsynchronousUnitOfWork<Success> {
@@ -67,3 +91,4 @@ extension AsynchronousUnitOfWork {
         }
     }
 }
+

--- a/Sources/Afluent/Workers/Print.swift
+++ b/Sources/Afluent/Workers/Print.swift
@@ -8,12 +8,23 @@
 import Foundation
 
 extension AsynchronousUnitOfWork {
-    /// Logs events from the upstream `AsynchronousUnitOfWork` to the console.
+    /// Prints all events from this unit of work to the console, including operation start, output, error, and cancellation events.
     ///
-    /// - Parameters:
-    ///   - prefix: A string to prefix each log message with. Default is an empty string.
+    /// Use this operator for debugging or observing the lifecycle and values of an asynchronous unit of work. Output is sent to the standard output (console).
     ///
-    /// - Returns: An `AsynchronousUnitOfWork` that behaves identically to the upstream but logs events.
+    /// ## Example
+    /// ```
+    /// try await DeferredTask { 42 }
+    ///     .print("[Example]")
+    ///     .execute()
+    /// // Console output:
+    /// // [Example] received operation
+    /// // [Example] received output: 42
+    /// ```
+    ///
+    /// - Parameter prefix: A string to prefix each log message with. Default is an empty string.
+    /// - Returns: An `AsynchronousUnitOfWork` that forwards all events and logs them to the console.
+    /// - Note: This operator is intended for debugging and observation purposes only.
     public func print(_ prefix: String = "") -> some AsynchronousUnitOfWork<Success> {
         handleEvents {
             Swift.print("\(prefix) received operation")

--- a/Sources/Afluent/Workers/ReplaceError.swift
+++ b/Sources/Afluent/Workers/ReplaceError.swift
@@ -33,11 +33,22 @@ extension Workers {
 }
 
 extension AsynchronousUnitOfWork {
-    /// Replaces any errors from the upstream `AsynchronousUnitOfWork` with the provided value.
+    /// Replaces any error emitted by this unit of work with the provided value, allowing the operation to yield a fallback result instead of failing.
     ///
-    /// - Parameter value: The value to emit upon encountering an error.
+    /// Use this operator to recover from errors by substituting a default value, making the unit of work non-throwing for downstream consumers.
     ///
-    /// - Returns: An `AsynchronousUnitOfWork` that emits the specified value instead of failing when the upstream fails.
+    /// ## Example
+    /// ```
+    /// enum MyError: Error { case network }
+    /// let value = try await DeferredTask { throw MyError.network }
+    ///     .replaceError(with: 0)
+    ///     .execute()
+    /// // value is 0 even if an error occurs upstream
+    /// ```
+    ///
+    /// - Parameter value: The value to emit if an error occurs.
+    /// - Returns: An `AsynchronousUnitOfWork` that emits the specified value if the upstream throws an error.
+    /// - Note: Cancellation errors are always propagated and are not replaced.
     public func replaceError(with value: Success) -> some AsynchronousUnitOfWork<Success> {
         Workers.ReplaceError(upstream: self, newValue: value)
     }

--- a/Sources/Afluent/Workers/ReplaceNil.swift
+++ b/Sources/Afluent/Workers/ReplaceNil.swift
@@ -32,11 +32,21 @@ extension Workers {
 }
 
 extension AsynchronousUnitOfWork {
-    /// Replaces any `nil` values from the upstream `AsynchronousUnitOfWork` with the provided non-nil value.
+    /// Replaces any `nil` value emitted by this unit of work with the provided non-nil value.
+    ///
+    /// Use this operator to guarantee a non-optional result from an asynchronous unit of work that may emit `nil`.
+    ///
+    /// ## Example
+    /// ```
+    /// let result = try await DeferredTask { Int?.none }
+    ///     .replaceNil(with: 42)
+    ///     .execute()
+    /// // result is 42 if the upstream produces nil
+    /// ```
     ///
     /// - Parameter value: The value to emit when the upstream emits `nil`.
-    ///
-    /// - Returns: An `AsynchronousUnitOfWork` that emits the specified value instead of `nil` when the upstream emits `nil`.
+    /// - Returns: An `AsynchronousUnitOfWork` that emits the specified value instead of `nil`.
+    /// - Note: Only `nil` values are replaced; non-nil values pass through unchanged.
     public func replaceNil<S: Sendable>(with value: S) -> some AsynchronousUnitOfWork<S>
     where Success == S? {
         Workers.ReplaceNil<Self, S>(upstream: self, newValue: value)

--- a/Sources/Afluent/Workers/Retain.swift
+++ b/Sources/Afluent/Workers/Retain.swift
@@ -39,7 +39,22 @@ extension Workers {
 }
 
 extension AsynchronousUnitOfWork {
-    /// Retains a successful result of the current unit of work, will not execute the operation again, even if retried.
+    /// Retains the successful result of this unit of work, ensuring the operation is performed only once. Subsequent executions return the cached result.
+    ///
+    /// Use this operator when you want to prevent repeated side effects or recomputation by caching the result of the first execution.
+    ///
+    /// ## Example
+    /// ```
+    /// var runCount = 0
+    /// let task = DeferredTask { runCount += 1; return 42 }
+    ///     .retain()
+    ///
+    /// let a = try await task.execute() // runCount is 1
+    /// let b = try await task.execute() // runCount is still 1, value is cached
+    /// ```
+    ///
+    /// - Returns: An `AsynchronousUnitOfWork` that caches and reuses its initial successful result.
+    /// - Note: If the operation fails, no value is cached and subsequent executions will retry the operation.
     public func retain() -> some AsynchronousUnitOfWork<Success> {
         Workers.Retain(upstream: self)
     }

--- a/Sources/Afluent/Workers/Retry.swift
+++ b/Sources/Afluent/Workers/Retry.swift
@@ -119,44 +119,72 @@ extension Workers {
 }
 
 extension AsynchronousUnitOfWork {
-    /// Retries the upstream `AsynchronousUnitOfWork` up to a specified number of times.
+    /// Retries this unit of work using the provided retry strategy.
+    ///
+    /// Use this operator to control retry behavior with custom or built-in strategies, mirroring the power and flexibility of the AsyncSequence retry operator.
+    ///
+    /// ## Example
+    /// ```
+    /// try await DeferredTask { try await fetchData() }
+    ///     .retry(strategy: .byCount(3))
+    ///     .execute()
+    /// ```
     ///
     /// - Parameter strategy: The retry strategy to use.
-    ///
-    /// - Returns: An `AsynchronousUnitOfWork` that emits the same output as the upstream but retries on failure up to the specified number of times.
+    /// - Returns: An `AsynchronousUnitOfWork` that retries the operation according to the given strategy.
     public func retry(_ strategy: some RetryStrategy) -> some AsynchronousUnitOfWork<Success> {
         Workers.Retry(upstream: self, strategy: strategy)
     }
 
-    /// Retries the upstream `AsynchronousUnitOfWork` up to a specified number of times.
+    /// Retries this unit of work up to the specified number of times on failure.
     ///
-    /// - Parameter retries: The maximum number of times to retry the upstream, defaulting to 1.
+    /// ## Example
+    /// ```
+    /// try await DeferredTask { try await fetchData() }
+    ///     .retry(3)
+    ///     .execute()
+    /// ```
     ///
-    /// - Returns: An `AsynchronousUnitOfWork` that emits the same output as the upstream but retries on failure up to the specified number of times.
+    /// - Parameter retries: The maximum number of retry attempts (default is 1).
+    /// - Returns: An `AsynchronousUnitOfWork` that retries on failure up to the specified times.
     public func retry(_ retries: UInt = 1) -> some AsynchronousUnitOfWork<Success> {
         Workers.Retry(upstream: self, strategy: .byCount(retries))
     }
 
-    /// Retries the upstream `AsynchronousUnitOfWork` up to a specified number of times only when a specific error occurs.
+    /// Retries this unit of work up to the specified number of times, but only when the error matches the given equatable error.
+    ///
+    /// ## Example
+    /// ```
+    /// enum NetworkError: Error, Equatable { case offline, timeout }
+    /// try await DeferredTask { throw NetworkError.offline }
+    ///     .retry(3, on: NetworkError.offline)
+    ///     .execute()
+    /// ```
     ///
     /// - Parameters:
-    ///   - retries: The maximum number of times to retry the upstream, defaulting to 1.
-    ///   - error: The specific error that should trigger a retry.
-    ///
-    /// - Returns: An `AsynchronousUnitOfWork` that emits the same output as the upstream but retries on the specified error up to the specified number of times.
+    ///   - retries: The max number of retry attempts (default is 1).
+    ///   - error: The specific error that triggers a retry.
+    /// - Returns: An `AsynchronousUnitOfWork` that retries on the specified error up to the given count.
     public func retry<E: Error & Equatable>(_ retries: UInt = 1, on error: E)
         -> some AsynchronousUnitOfWork<Success>
     {
         Workers.RetryOn(upstream: self, strategy: .byCount(retries), error: error)
     }
     
-    /// Retries the upstream `AsynchronousUnitOfWork` up to a specified number of times only when a specific error occurs.
+    /// Retries this unit of work up to the specified number of times, but only when the error is of the given type.
+    ///
+    /// ## Example
+    /// ```
+    /// enum NetworkError: Error { case offline, timeout }
+    /// try await DeferredTask { throw NetworkError.timeout }
+    ///     .retry(3, on: NetworkError.self)
+    ///     .execute()
+    /// ```
     ///
     /// - Parameters:
-    ///   - retries: The maximum number of times to retry the upstream, defaulting to 1.
-    ///   - error: The specific error that should trigger a retry after a successful cast.
-    ///
-    /// - Returns: An `AsynchronousUnitOfWork` that emits the same output as the upstream but retries on the specified error up to the specified number of times.
+    ///   - retries: The max number of retry attempts (default is 1).
+    ///   - error: The error type that triggers a retry if a cast succeeds.
+    /// - Returns: An `AsynchronousUnitOfWork` that retries on the specified error type up to the given count.
     public func retry<E: Error>(_ retries: UInt = 1, on error: E.Type)
         -> some AsynchronousUnitOfWork<Success>
     {

--- a/Sources/Afluent/Workers/Share.swift
+++ b/Sources/Afluent/Workers/Share.swift
@@ -47,9 +47,23 @@ extension Workers {
 }
 
 extension AsynchronousUnitOfWork {
-    /// Shares the upstream `AsynchronousUnitOfWork` among multiple downstream subscribers.
+    /// Shares the result of this unit of work among multiple subscribers, ensuring the upstream operation is only performed once.
     ///
-    /// - Returns: An `AsynchronousUnitOfWork` that shares a single subscription to the upstream, allowing multiple downstream subscribers to receive the same values.
+    /// Use this operator to avoid duplicate work when multiple parts of your code need the result of the same asynchronous operation.
+    ///
+    /// ## Example
+    /// ```
+    /// let sharedTask = DeferredTask { UUID() }
+    ///     .share()
+    ///
+    /// async let value1 = sharedTask.execute()
+    /// async let value2 = sharedTask.execute()
+    /// let (a, b) = try await (value1, value2)
+    /// // 'a' and 'b' are guaranteed to be the same UUID instance
+    /// ```
+    ///
+    /// - Returns: An `AsynchronousUnitOfWork` that shares a single execution among all subscribers.
+    /// - Note: The upstream operation runs only once, regardless of the number of calls to `execute()`.
     public func share() -> some AsynchronousUnitOfWork<Success> & Actor {
         Workers.Share(upstream: self)
     }

--- a/Sources/Afluent/Workers/ShareFromCache.swift
+++ b/Sources/Afluent/Workers/ShareFromCache.swift
@@ -22,16 +22,30 @@ extension AsynchronousUnitOfWork {
         return strategy.handle(unitOfWork: self, keyedBy: key, storedIn: cache)
     }
 
-    /// Shares data from the given cache based on a specified caching strategy and additional context information.
+    /// Shares the result of this unit of work from the given cache using the specified strategy and call-site context (file, function, line, column).
+    ///
+    /// Use this operator to ensure that the same cache entry is used for identical call sites, preventing duplicate work and sharing cached results.
+    ///
+    /// ## Example
+    /// ```
+    /// let cache = AUOWCache()
+    /// let shared = DeferredTask { UUID() }
+    ///     .shareFromCache(cache, strategy: .cacheUntilCompletionOrCancellation)
+    /// async let a = shared.execute()
+    /// async let b = shared.execute()
+    /// let (val1, val2) = try await (a, b)
+    /// // val1 and val2 are guaranteed to be identical (from cache)
+    /// ```
     ///
     /// - Parameters:
-    ///   - cache: The cache from which to share data.
-    ///   - strategy: The caching strategy to use.
-    ///   - fileId: The ID of the file where this function is called. Defaults to `#fileID`.
-    ///   - function: The name of the calling function. Defaults to `#function`.
-    ///   - line: The line number where this function is called. Defaults to `#line`.
-    ///   - column: The column where this function is called. Defaults to `#column`.
-    /// - Returns: An asynchronous unit of work encapsulating the operation's success or failure.
+    ///   - cache: The cache to share results from.
+    ///   - strategy: The caching strategy.
+    ///   - fileId: Call site file identifier (default: #fileID).
+    ///   - function: Caller function (default: #function).
+    ///   - line: Line number (default: #line).
+    ///   - column: Column number (default: #column).
+    /// - Returns: An `AsynchronousUnitOfWork` that shares its results from cache.
+    /// - Important: This operator should generally be placed at the end of an operator chain. Any operators applied after `shareFromCache` will not be shared and may result in duplicated work or side effects.
     public func shareFromCache(
         _ cache: AUOWCache, strategy: any AUOWCacheStrategy, fileId: String = #fileID,
         function: String = #function, line: UInt = #line, column: UInt = #column
@@ -42,13 +56,27 @@ extension AsynchronousUnitOfWork {
             line: line, column: column)
     }
 
-    /// Shares data from the given cache based on a specified caching strategy and hashable keys.
+    /// Shares the result of this unit of work from the given cache using the specified strategy and custom cache keys.
+    ///
+    /// Use this operator to share or de-duplicate expensive work based on custom, hashable cache keys.
+    ///
+    /// ## Example
+    /// ```
+    /// let cache = AUOWCache()
+    /// let shared = DeferredTask { UUID() }
+    ///     .shareFromCache(cache, strategy: .cacheUntilCompletionOrCancellation, keys: "user42")
+    /// async let a = shared.execute()
+    /// async let b = shared.execute()
+    /// let (val1, val2) = try await (a, b)
+    /// // val1 and val2 are guaranteed to be identical (from cache)
+    /// ```
     ///
     /// - Parameters:
-    ///   - cache: The cache from which to share data.
-    ///   - strategy: The caching strategy to use.
-    ///   - keys: One or more hashable keys used to look up the data in the cache.
-    /// - Returns: An asynchronous unit of work encapsulating the operation's success or failure.
+    ///   - cache: The cache to share results from.
+    ///   - strategy: The caching strategy.
+    ///   - keys: Hashable key(s) to identify the cache entry.
+    /// - Returns: An `AsynchronousUnitOfWork` that shares its results from cache.
+    /// - Important: This operator should generally be placed at the end of an operator chain. Any operators applied after `shareFromCache` will not be shared and may result in duplicated work or side effects.
     public func shareFromCache<H0: Hashable>(
         _ cache: AUOWCache, strategy: any AUOWCacheStrategy, keys k0: H0
     ) -> some AsynchronousUnitOfWork<Success> {
@@ -57,13 +85,27 @@ extension AsynchronousUnitOfWork {
         return _shareFromCache(cache, strategy: strategy, hasher: &hasher)
     }
 
-    /// Shares data from the given cache based on a specified caching strategy and hashable keys.
+    /// Shares the result of this unit of work from the given cache using the specified strategy and custom cache keys.
+    ///
+    /// Use this operator to share or de-duplicate expensive work based on custom, hashable cache keys.
+    ///
+    /// ## Example
+    /// ```
+    /// let cache = AUOWCache()
+    /// let shared = DeferredTask { UUID() }
+    ///     .shareFromCache(cache, strategy: .cacheUntilCompletionOrCancellation, keys: "user", 42)
+    /// async let a = shared.execute()
+    /// async let b = shared.execute()
+    /// let (val1, val2) = try await (a, b)
+    /// // val1 and val2 are guaranteed to be identical (from cache)
+    /// ```
     ///
     /// - Parameters:
-    ///   - cache: The cache from which to share data.
-    ///   - strategy: The caching strategy to use.
-    ///   - keys: One or more hashable keys used to look up the data in the cache.
-    /// - Returns: An asynchronous unit of work encapsulating the operation's success or failure.
+    ///   - cache: The cache to share results from.
+    ///   - strategy: The caching strategy.
+    ///   - keys: Hashable key(s) to identify the cache entry.
+    /// - Returns: An `AsynchronousUnitOfWork` that shares its results from cache.
+    /// - Important: This operator should generally be placed at the end of an operator chain. Any operators applied after `shareFromCache` will not be shared and may result in duplicated work or side effects.
     public func shareFromCache<H0: Hashable, H1: Hashable>(
         _ cache: AUOWCache, strategy: any AUOWCacheStrategy, keys k0: H0, _ k1: H1
     ) -> some AsynchronousUnitOfWork<Success> {
@@ -73,13 +115,27 @@ extension AsynchronousUnitOfWork {
         return _shareFromCache(cache, strategy: strategy, hasher: &hasher)
     }
 
-    /// Shares data from the given cache based on a specified caching strategy and hashable keys.
+    /// Shares the result of this unit of work from the given cache using the specified strategy and custom cache keys.
+    ///
+    /// Use this operator to share or de-duplicate expensive work based on custom, hashable cache keys.
+    ///
+    /// ## Example
+    /// ```
+    /// let cache = AUOWCache()
+    /// let shared = DeferredTask { UUID() }
+    ///     .shareFromCache(cache, strategy: .cacheUntilCompletionOrCancellation, keys: "user", 42, "session")
+    /// async let a = shared.execute()
+    /// async let b = shared.execute()
+    /// let (val1, val2) = try await (a, b)
+    /// // val1 and val2 are guaranteed to be identical (from cache)
+    /// ```
     ///
     /// - Parameters:
-    ///   - cache: The cache from which to share data.
-    ///   - strategy: The caching strategy to use.
-    ///   - keys: One or more hashable keys used to look up the data in the cache.
-    /// - Returns: An asynchronous unit of work encapsulating the operation's success or failure.
+    ///   - cache: The cache to share results from.
+    ///   - strategy: The caching strategy.
+    ///   - keys: Hashable key(s) to identify the cache entry.
+    /// - Returns: An `AsynchronousUnitOfWork` that shares its results from cache.
+    /// - Important: This operator should generally be placed at the end of an operator chain. Any operators applied after `shareFromCache` will not be shared and may result in duplicated work or side effects.
     public func shareFromCache<H0: Hashable, H1: Hashable, H2: Hashable>(
         _ cache: AUOWCache, strategy: any AUOWCacheStrategy, keys k0: H0, _ k1: H1, _ k2: H2
     ) -> some AsynchronousUnitOfWork<Success> {
@@ -90,13 +146,27 @@ extension AsynchronousUnitOfWork {
         return _shareFromCache(cache, strategy: strategy, hasher: &hasher)
     }
 
-    /// Shares data from the given cache based on a specified caching strategy and hashable keys.
+    /// Shares the result of this unit of work from the given cache using the specified strategy and custom cache keys.
+    ///
+    /// Use this operator to share or de-duplicate expensive work based on custom, hashable cache keys.
+    ///
+    /// ## Example
+    /// ```
+    /// let cache = AUOWCache()
+    /// let shared = DeferredTask { UUID() }
+    ///     .shareFromCache(cache, strategy: .cacheUntilCompletionOrCancellation, keys: "user", 42, "session", 1)
+    /// async let a = shared.execute()
+    /// async let b = shared.execute()
+    /// let (val1, val2) = try await (a, b)
+    /// // val1 and val2 are guaranteed to be identical (from cache)
+    /// ```
     ///
     /// - Parameters:
-    ///   - cache: The cache from which to share data.
-    ///   - strategy: The caching strategy to use.
-    ///   - keys: One or more hashable keys used to look up the data in the cache.
-    /// - Returns: An asynchronous unit of work encapsulating the operation's success or failure.
+    ///   - cache: The cache to share results from.
+    ///   - strategy: The caching strategy.
+    ///   - keys: Hashable key(s) to identify the cache entry.
+    /// - Returns: An `AsynchronousUnitOfWork` that shares its results from cache.
+    /// - Important: This operator should generally be placed at the end of an operator chain. Any operators applied after `shareFromCache` will not be shared and may result in duplicated work or side effects.
     public func shareFromCache<H0: Hashable, H1: Hashable, H2: Hashable, H3: Hashable>(
         _ cache: AUOWCache, strategy: any AUOWCacheStrategy, keys k0: H0, _ k1: H1, _ k2: H2, _ k3: H3
     ) -> some AsynchronousUnitOfWork<Success> {
@@ -108,13 +178,27 @@ extension AsynchronousUnitOfWork {
         return _shareFromCache(cache, strategy: strategy, hasher: &hasher)
     }
 
-    /// Shares data from the given cache based on a specified caching strategy and hashable keys.
+    /// Shares the result of this unit of work from the given cache using the specified strategy and custom cache keys.
+    ///
+    /// Use this operator to share or de-duplicate expensive work based on custom, hashable cache keys.
+    ///
+    /// ## Example
+    /// ```
+    /// let cache = AUOWCache()
+    /// let shared = DeferredTask { UUID() }
+    ///     .shareFromCache(cache, strategy: .cacheUntilCompletionOrCancellation, keys: "user", 42, "session", 1, "extra")
+    /// async let a = shared.execute()
+    /// async let b = shared.execute()
+    /// let (val1, val2) = try await (a, b)
+    /// // val1 and val2 are guaranteed to be identical (from cache)
+    /// ```
     ///
     /// - Parameters:
-    ///   - cache: The cache from which to share data.
-    ///   - strategy: The caching strategy to use.
-    ///   - keys: One or more hashable keys used to look up the data in the cache.
-    /// - Returns: An asynchronous unit of work encapsulating the operation's success or failure.
+    ///   - cache: The cache to share results from.
+    ///   - strategy: The caching strategy.
+    ///   - keys: Hashable key(s) to identify the cache entry.
+    /// - Returns: An `AsynchronousUnitOfWork` that shares its results from cache.
+    /// - Important: This operator should generally be placed at the end of an operator chain. Any operators applied after `shareFromCache` will not be shared and may result in duplicated work or side effects.
     public func shareFromCache<
         H0: Hashable, H1: Hashable, H2: Hashable, H3: Hashable, H4: Hashable
     >(
@@ -130,13 +214,27 @@ extension AsynchronousUnitOfWork {
         return _shareFromCache(cache, strategy: strategy, hasher: &hasher)
     }
 
-    /// Shares data from the given cache based on a specified caching strategy and hashable keys.
+    /// Shares the result of this unit of work from the given cache using the specified strategy and custom cache keys.
+    ///
+    /// Use this operator to share or de-duplicate expensive work based on custom, hashable cache keys.
+    ///
+    /// ## Example
+    /// ```
+    /// let cache = AUOWCache()
+    /// let shared = DeferredTask { UUID() }
+    ///     .shareFromCache(cache, strategy: .cacheUntilCompletionOrCancellation, keys: "user", 42, "session", 1, "extra", 99)
+    /// async let a = shared.execute()
+    /// async let b = shared.execute()
+    /// let (val1, val2) = try await (a, b)
+    /// // val1 and val2 are guaranteed to be identical (from cache)
+    /// ```
     ///
     /// - Parameters:
-    ///   - cache: The cache from which to share data.
-    ///   - strategy: The caching strategy to use.
-    ///   - keys: One or more hashable keys used to look up the data in the cache.
-    /// - Returns: An asynchronous unit of work encapsulating the operation's success or failure.
+    ///   - cache: The cache to share results from.
+    ///   - strategy: The caching strategy.
+    ///   - keys: Hashable key(s) to identify the cache entry.
+    /// - Returns: An `AsynchronousUnitOfWork` that shares its results from cache.
+    /// - Important: This operator should generally be placed at the end of an operator chain. Any operators applied after `shareFromCache` will not be shared and may result in duplicated work or side effects.
     public func shareFromCache<
         H0: Hashable, H1: Hashable, H2: Hashable, H3: Hashable, H4: Hashable, H5: Hashable
     >(
@@ -153,13 +251,27 @@ extension AsynchronousUnitOfWork {
         return _shareFromCache(cache, strategy: strategy, hasher: &hasher)
     }
 
-    /// Shares data from the given cache based on a specified caching strategy and hashable keys.
+    /// Shares the result of this unit of work from the given cache using the specified strategy and custom cache keys.
+    ///
+    /// Use this operator to share or de-duplicate expensive work based on custom, hashable cache keys.
+    ///
+    /// ## Example
+    /// ```
+    /// let cache = AUOWCache()
+    /// let shared = DeferredTask { UUID() }
+    ///     .shareFromCache(cache, strategy: .cacheUntilCompletionOrCancellation, keys: "user", 42, "session", 1, "extra", 99, "flag")
+    /// async let a = shared.execute()
+    /// async let b = shared.execute()
+    /// let (val1, val2) = try await (a, b)
+    /// // val1 and val2 are guaranteed to be identical (from cache)
+    /// ```
     ///
     /// - Parameters:
-    ///   - cache: The cache from which to share data.
-    ///   - strategy: The caching strategy to use.
-    ///   - keys: One or more hashable keys used to look up the data in the cache.
-    /// - Returns: An asynchronous unit of work encapsulating the operation's success or failure.
+    ///   - cache: The cache to share results from.
+    ///   - strategy: The caching strategy.
+    ///   - keys: Hashable key(s) to identify the cache entry.
+    /// - Returns: An `AsynchronousUnitOfWork` that shares its results from cache.
+    /// - Important: This operator should generally be placed at the end of an operator chain. Any operators applied after `shareFromCache` will not be shared and may result in duplicated work or side effects.
     public func shareFromCache<
         H0: Hashable, H1: Hashable, H2: Hashable, H3: Hashable, H4: Hashable, H5: Hashable,
         H6: Hashable
@@ -178,13 +290,27 @@ extension AsynchronousUnitOfWork {
         return _shareFromCache(cache, strategy: strategy, hasher: &hasher)
     }
 
-    /// Shares data from the given cache based on a specified caching strategy and hashable keys.
+    /// Shares the result of this unit of work from the given cache using the specified strategy and custom cache keys.
+    ///
+    /// Use this operator to share or de-duplicate expensive work based on custom, hashable cache keys.
+    ///
+    /// ## Example
+    /// ```
+    /// let cache = AUOWCache()
+    /// let shared = DeferredTask { UUID() }
+    ///     .shareFromCache(cache, strategy: .cacheUntilCompletionOrCancellation, keys: "user", 42, "session", 1, "extra", 99, "flag", true)
+    /// async let a = shared.execute()
+    /// async let b = shared.execute()
+    /// let (val1, val2) = try await (a, b)
+    /// // val1 and val2 are guaranteed to be identical (from cache)
+    /// ```
     ///
     /// - Parameters:
-    ///   - cache: The cache from which to share data.
-    ///   - strategy: The caching strategy to use.
-    ///   - keys: One or more hashable keys used to look up the data in the cache.
-    /// - Returns: An asynchronous unit of work encapsulating the operation's success or failure.
+    ///   - cache: The cache to share results from.
+    ///   - strategy: The caching strategy.
+    ///   - keys: Hashable key(s) to identify the cache entry.
+    /// - Returns: An `AsynchronousUnitOfWork` that shares its results from cache.
+    /// - Important: This operator should generally be placed at the end of an operator chain. Any operators applied after `shareFromCache` will not be shared and may result in duplicated work or side effects.
     public func shareFromCache<
         H0: Hashable, H1: Hashable, H2: Hashable, H3: Hashable, H4: Hashable, H5: Hashable,
         H6: Hashable, H7: Hashable
@@ -204,13 +330,27 @@ extension AsynchronousUnitOfWork {
         return _shareFromCache(cache, strategy: strategy, hasher: &hasher)
     }
 
-    /// Shares data from the given cache based on a specified caching strategy and hashable keys.
+    /// Shares the result of this unit of work from the given cache using the specified strategy and custom cache keys.
+    ///
+    /// Use this operator to share or de-duplicate expensive work based on custom, hashable cache keys.
+    ///
+    /// ## Example
+    /// ```
+    /// let cache = AUOWCache()
+    /// let shared = DeferredTask { UUID() }
+    ///     .shareFromCache(cache, strategy: .cacheUntilCompletionOrCancellation, keys: "user", 42, "session", 1, "extra", 99, "flag", true, 1000)
+    /// async let a = shared.execute()
+    /// async let b = shared.execute()
+    /// let (val1, val2) = try await (a, b)
+    /// // val1 and val2 are guaranteed to be identical (from cache)
+    /// ```
     ///
     /// - Parameters:
-    ///   - cache: The cache from which to share data.
-    ///   - strategy: The caching strategy to use.
-    ///   - keys: One or more hashable keys used to look up the data in the cache.
-    /// - Returns: An asynchronous unit of work encapsulating the operation's success or failure.
+    ///   - cache: The cache to share results from.
+    ///   - strategy: The caching strategy.
+    ///   - keys: Hashable key(s) to identify the cache entry.
+    /// - Returns: An `AsynchronousUnitOfWork` that shares its results from cache.
+    /// - Important: This operator should generally be placed at the end of an operator chain. Any operators applied after `shareFromCache` will not be shared and may result in duplicated work or side effects.
     public func shareFromCache<
         H0: Hashable, H1: Hashable, H2: Hashable, H3: Hashable, H4: Hashable, H5: Hashable,
         H6: Hashable, H7: Hashable, H8: Hashable
@@ -231,19 +371,33 @@ extension AsynchronousUnitOfWork {
         return _shareFromCache(cache, strategy: strategy, hasher: &hasher)
     }
 
-    /// Shares data from the given cache based on a specified caching strategy and hashable keys.
+    /// Shares the result of this unit of work from the given cache using the specified strategy and custom cache keys.
+    ///
+    /// Use this operator to share or de-duplicate expensive work based on custom, hashable cache keys.
+    ///
+    /// ## Example
+    /// ```
+    /// let cache = AUOWCache()
+    /// let shared = DeferredTask { UUID() }
+    ///     .shareFromCache(cache, strategy: .cacheUntilCompletionOrCancellation, keys: "user", 42, "session", 1, "extra", 99, "flag", true, 1000, false)
+    /// async let a = shared.execute()
+    /// async let b = shared.execute()
+    /// let (val1, val2) = try await (a, b)
+    /// // val1 and val2 are guaranteed to be identical (from cache)
+    /// ```
     ///
     /// - Parameters:
-    ///   - cache: The cache from which to share data.
-    ///   - strategy: The caching strategy to use.
-    ///   - keys: One or more hashable keys used to look up the data in the cache.
-    /// - Returns: An asynchronous unit of work encapsulating the operation's success or failure.
+    ///   - cache: The cache to share results from.
+    ///   - strategy: The caching strategy.
+    ///   - keys: Hashable key(s) to identify the cache entry.
+    /// - Returns: An `AsynchronousUnitOfWork` that shares its results from cache.
+    /// - Important: This operator should generally be placed at the end of an operator chain. Any operators applied after `shareFromCache` will not be shared and may result in duplicated work or side effects.
     public func shareFromCache<
         H0: Hashable, H1: Hashable, H2: Hashable, H3: Hashable, H4: Hashable, H5: Hashable,
         H6: Hashable, H7: Hashable, H8: Hashable, H9: Hashable
     >(
         _ cache: AUOWCache, strategy: any AUOWCacheStrategy, keys k0: H0, _ k1: H1, _ k2: H2, _ k3: H3,
-        _ k4: H4, _ k5: H5, _ k6: H6, _ k7: H7, _ k8: H8, _ 🐶: H9
+        _ k4: H4, _ k5: H5, _ k6: H6, _ k7: H7, _ k8: H8, _ k9: H9
     ) -> some AsynchronousUnitOfWork<Success> {
         var hasher = Hasher()
         hasher.combine(k0)
@@ -255,7 +409,8 @@ extension AsynchronousUnitOfWork {
         hasher.combine(k6)
         hasher.combine(k7)
         hasher.combine(k8)
-        hasher.combine(🐶)
+        hasher.combine(k9)
         return _shareFromCache(cache, strategy: strategy, hasher: &hasher)
     }
 }
+

--- a/Sources/Afluent/Workers/SingleValueChannel.swift
+++ b/Sources/Afluent/Workers/SingleValueChannel.swift
@@ -7,12 +7,25 @@
 
 import Foundation
 
-/// A channel that emits a single value or an error.
+/// A channel for bridging callback-based APIs to async/await, emitting a single value or error.
 ///
-/// ` SingleValueChannel` is an `AsynchronousUnitOfWork` that can be manually completed with either a success value or an error. It's useful for scenarios where you need to bridge callback-based APIs into the world of `async/await`.
+/// `SingleValueChannel` is an `AsynchronousUnitOfWork` that can be manually completed exactly once, making it ideal for integrating legacy or delegate/callback APIs with modern async workflows.
 ///
-/// - Note: Once completed, any further attempts to send a value or an error will result in a `ChannelError.alreadyCompleted`.
-/// - Important: This is very similar to a `SingleValueSubject`, but shares more similarities with `AsyncChannel` in swift-async-algorithms. Sending is an `async` operation, and therefore the ergonomics of this type are a little different. However, it should generally be preferred where possible over `SingleValueSubject`
+/// ## Example: Bridging a callback to async/await
+/// ```
+/// func fetchData(url: URL) async throws -> Data {
+///     let channel = SingleValueChannel<Data>()
+///     let task = URLSession.shared.dataTask(with: url) { data, _, error in
+///         if let data { try? channel.send(data) }
+///         else if let error { try? channel.send(error: error) }
+///     }
+///     task.resume()
+///     return try await channel.execute()
+/// }
+/// ```
+///
+/// - Note: Once completed, any further send or error will throw `ChannelError.alreadyCompleted`.
+/// - Important: Prefer this over a subject for bridging when possible, as it is more ergonomic for async/await and similar to `AsyncChannel` in swift-async-algorithms.
 public actor SingleValueChannel<Success: Sendable>: AsynchronousUnitOfWork {
     /// Errors specific to `SingleValueChannel`.
     public enum ChannelError: Error {

--- a/Sources/Afluent/Workers/SingleValueSubject.swift
+++ b/Sources/Afluent/Workers/SingleValueSubject.swift
@@ -7,11 +7,27 @@
 
 import Foundation
 
-/// A subject that emits a single value or an error.
+/// A subject for bridging callback-based APIs to async/await, emitting a single value or error.
 ///
-/// `SingleValueSubject` is an `AsynchronousUnitOfWork` that can be manually completed with either a success value or an error. It's useful for scenarios where you need to bridge callback-based APIs into the world of `async/await`.
+/// `SingleValueSubject` is an `AsynchronousUnitOfWork` that you manually complete once, making it useful for integrating legacy, delegate, or callback-style APIs into modern async workflows.
 ///
-/// - Note: Once completed, any further attempts to send a value or an error will result in a `SubjectError.alreadyCompleted`.
+/// ## Example: Bridging a delegate to async/await
+/// ```
+/// final class MyDelegate: NSObject, SomeLegacyDelegate {
+///     let subject = SingleValueSubject<Data>()
+///     func didReceive(data: Data) { try? subject.send(data) }
+///     func didFail(error: Error) { try? subject.send(error: error) }
+/// }
+///
+/// func fetchDataWithDelegate() async throws -> Data {
+///     let delegate = MyDelegate()
+///     startLegacyOperation(delegate: delegate)
+///     return try await delegate.subject.execute()
+/// }
+/// ```
+///
+/// - Note: Once completed, any further send or error will throw `SubjectError.alreadyCompleted`.
+/// - Important: This is conceptually similar to a Combine subject, but for async/await. Prefer `SingleValueChannel` for most bridging tasks—use this type when manual, thread-safe completion is required.
 public final class SingleValueSubject<Success: Sendable>: AsynchronousUnitOfWork, @unchecked
     Sendable
 {

--- a/Sources/Afluent/Workers/Timeout.swift
+++ b/Sources/Afluent/Workers/Timeout.swift
@@ -45,14 +45,20 @@ extension Workers {
 }
 
 extension AsynchronousUnitOfWork {
-    /// Adds a timeout to the current asynchronous unit of work.
+    /// Adds a timeout to this unit of work, cancelling it if it does not complete within the specified duration.
     ///
-    /// If the operation does not complete within the specified duration, it will be terminated.
+    /// ## Example
+    /// ```
+    /// try await DeferredTask { try await fetchData() }
+    ///     .timeout(.seconds(5))
+    ///     .execute()
+    /// // Throws TimeoutError.timedOut if more than 5 seconds elapse
+    /// ```
     ///
-    /// - Parameter duration: The maximum duration the operation is allowed to take, represented as a `Duration`.
-    /// - Parameter customError: A custom error to throw if timeout occurs. If no value is supplied a `CancellationError` is thrown.
-    /// - Returns: An asynchronous unit of work that includes the timeout behavior, encapsulating the operation's success or failure.
-    /// - Throws: ``TimeoutError`` if the timeout limit is reached.
+    /// - Parameter duration: The maximum allowed time for the operation (as a `Duration`).
+    /// - Parameter customError: Optional error to throw if a timeout occurs. Defaults to `TimeoutError.timedOut`.
+    /// - Returns: An `AsynchronousUnitOfWork` that throws if the duration is exceeded.
+    /// - Throws: `TimeoutError` if the duration elapses before completion.
     @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
     public func timeout(_ duration: Duration, customError: Error? = nil)
         -> some AsynchronousUnitOfWork<Success>
@@ -62,16 +68,22 @@ extension AsynchronousUnitOfWork {
             tolerance: nil)
     }
 
-    /// Adds a timeout to the current asynchronous unit of work.
+    /// Adds a timeout to this unit of work, cancelling it if it does not complete in time, measured against the given clock.
     ///
-    /// If the operation does not complete within the specified duration, it will be terminated.
+    /// ## Example
+    /// ```
+    /// let clock = SuspendingClock()
+    /// try await DeferredTask { try await fetchData() }
+    ///     .timeout(.seconds(2), clock: clock, tolerance: .milliseconds(100))
+    ///     .execute()
+    /// ```
     ///
-    /// - Parameter duration: The maximum duration the operation is allowed to take, represented as a `Clock.Duration`.
-    /// - Parameter clock: The clock used for timekeeping. Defaults to `SuspendingClock()`.
-    /// - Parameter tolerance: An optional tolerance for the delay. Defaults to `nil`.
-    /// - Parameter customError: A custom error to throw if timeout occurs. If no value is supplied a `CancellationError` is thrown.
-    /// - Returns: An asynchronous unit of work that includes the timeout behavior, encapsulating the operation's success or failure.
-    /// - Throws: ``TimeoutError`` if the timeout limit is reached.
+    /// - Parameter duration: The maximum allowed time for the operation (as a `Clock.Duration`).
+    /// - Parameter clock: The clock used to measure timeouts (defaults to `SuspendingClock()`).
+    /// - Parameter tolerance: Optional tolerance for the delay (defaults to `nil`).
+    /// - Parameter customError: Optional error to throw if a timeout occurs. Defaults to `TimeoutError.timedOut`.
+    /// - Returns: An `AsynchronousUnitOfWork` that throws if the duration is exceeded.
+    /// - Throws: `TimeoutError` if the duration elapses before completion.
     @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
     public func timeout<C: Clock>(
         _ duration: C.Duration, clock: C, tolerance: C.Duration? = nil, customError: Error? = nil
@@ -81,3 +93,4 @@ extension AsynchronousUnitOfWork {
             tolerance: tolerance)
     }
 }
+

--- a/Sources/Afluent/Workers/ToAsyncSequence.swift
+++ b/Sources/Afluent/Workers/ToAsyncSequence.swift
@@ -59,13 +59,19 @@ extension AsynchronousUnitOfWork {
         }
     }
 
-    /// Converts the asynchronous unit of work into an `AsyncSequence`.
+    /// Converts this asynchronous unit of work into an `AsyncSequence` that emits a single value and then completes.
     ///
-    /// This method transforms the result of an `AsynchronousUnitOfWork` into an `AsyncSequence`. It's useful for integrating the single-value asynchronous operation into APIs that work with sequences, or for using async/await in a more sequential, iterative manner.
+    /// Use this operator to integrate single-value asynchronous operations into sequence-based workflows, or to use sequence algorithms and idioms with a single result.
     ///
-    /// The resulting sequence emits a single value if the operation succeeds, or throws an error if the operation fails. After emitting its single value or error, the sequence completes.
+    /// ## Example
+    /// ```
+    /// for try await value in DeferredTask { 42 }.toAsyncSequence() {
+    ///     print(value) // prints 42
+    /// }
+    /// ```
     ///
-    /// - Returns: An `AsynchronousUnitOfWorkSequence` that represents the operation of the `AsynchronousUnitOfWork`.
+    /// - Returns: An `AsyncSequence` that emits the operation's result and then completes.
+    /// - Note: The sequence emits one value if the operation succeeds or fails if the operation throws.
     public func toAsyncSequence() -> AsynchronousUnitOfWorkSequence<Self> {
         AsynchronousUnitOfWorkSequence(unitOfWork: self)
     }

--- a/Sources/Afluent/Workers/UnwrapOrThrow.swift
+++ b/Sources/Afluent/Workers/UnwrapOrThrow.swift
@@ -8,7 +8,20 @@
 import Foundation
 
 extension AsynchronousUnitOfWork {
-    /// Unwraps the optional value if present, or throws an error.
+    /// Unwraps the optional value from this unit of work, or throws the given error if it is nil.
+    ///
+    /// Use this operator to convert an optional result into a non-optional one, failing the operation with your custom error if no value is present.
+    ///
+    /// ## Example
+    /// ```
+    /// enum MyError: Error { case missing }
+    /// let result = try await DeferredTask { Int?.none }
+    ///     .unwrap(orThrow: MyError.missing)
+    ///     .execute() // throws MyError.missing if the task returns nil
+    /// ```
+    ///
+    /// - Parameter error: The error to throw if the value is nil.
+    /// - Returns: An `AsynchronousUnitOfWork` emitting the unwrapped value, or failing with the given error if nil.
     public func unwrap<T>(orThrow error: @Sendable @escaping @autoclosure () -> Error)
         -> some AsynchronousUnitOfWork<T> where Success == T?
     {

--- a/Sources/Afluent/Workers/WithUnretained.swift
+++ b/Sources/Afluent/Workers/WithUnretained.swift
@@ -14,12 +14,24 @@ public enum UnretainedError: Error, Equatable {
 // Heavily based on the RxSwift operator - `withUnretained`.
 // https://github.com/ReactiveX/RxSwift/blob/main/RxSwift/Observables/WithUnretained.swift
 extension AsynchronousUnitOfWork {
-    /// Provides an unretained, safe to use (i.e. not implicitly unwrapped), reference to an object along with the events emitted by the operator.
-    /// In the case the provided object cannot be retained successfully, the sequence will throw.
+    /// Combines this unit of work's value with an unretained reference to the given object, or throws if the object has been deallocated.
+    ///
+    /// Use this operator to safely pass both a value and an object into a closure, without retaining the object.
+    ///
+    /// ## Example
+    /// ```
+    /// final class MyController: Sendable {}
+    /// let controller = MyController()
+    /// let combined = DeferredTask { 42 }
+    ///     .withUnretained(controller) { ctrl, value in (ctrl, value) }
+    /// let result = try await combined.execute()
+    /// // 'result' is a tuple of (controller, 42) if controller is still alive
+    /// ```
+    ///
     /// - Parameters:
-    ///   - obj: The object to provide an unretained reference on.
-    ///   - resultSelector: A function to combine the unretained referenced on `obj` and the value of the observable sequence.
-    /// - Returns: An AsynchronousUnitOfWork that contains the result of `resultSelector` being called with an unretained reference on `obj` and the values of the original sequence.
+    ///   - obj: The object to provide as an unretained reference.
+    ///   - resultSelector: Closure combining the object and the value.
+    /// - Returns: An `AsynchronousUnitOfWork` containing the result of `resultSelector`, or failing if `obj` is nil.
     public func withUnretained<Object: AnyObject & Sendable, Out: Sendable>(
         _ obj: Object, resultSelector: @Sendable @escaping (Object, Success) -> Out
     ) -> some AsynchronousUnitOfWork<Out> {

--- a/Sources/Afluent/Workers/Zip.swift
+++ b/Sources/Afluent/Workers/Zip.swift
@@ -94,23 +94,39 @@ extension Workers {
 }
 
 extension AsynchronousUnitOfWork {
-    /// Zips the result of the current unit of work with another asynchronous unit of work.
+    /// Zips the result of this unit of work with another, producing a tuple of both results when both complete.
     ///
-    /// - Parameters:
-    ///   - downstream: The second asynchronous unit of work to zip with.
-    /// - Returns: A new asynchronous unit of work that produces a tuple containing results from both upstream and downstream when completed.
+    /// ## Example
+    /// ```
+    /// let zipped = DeferredTask { "a" }
+    ///     .zip(DeferredTask { 42 })
+    /// let (str, num) = try await zipped.execute()
+    /// // 'str' is "a", 'num' is 42
+    /// ```
+    ///
+    /// - Parameter downstream: The unit of work to zip with.
+    /// - Returns: An `AsynchronousUnitOfWork` producing a tuple of both results.
     public func zip<D: AsynchronousUnitOfWork>(_ downstream: D) -> some AsynchronousUnitOfWork<
         (Success, D.Success)
     > {
         Workers.Zip(upstream: self, downstream: downstream)
     }
 
-    /// Zips the result of the current unit of work with another and applies a transform function.
+    /// Zips the result of this unit of work with another and applies a transform function.
     ///
-    /// - Parameters:
-    ///   - downstream: The second asynchronous unit of work to zip with.
-    ///   - transform: A function that takes a tuple of results from both units of work and returns a transformed result.
-    /// - Returns: A new asynchronous unit of work that produces the transformed result when completed.
+    /// ## Example
+    /// ```
+    /// let zipped = DeferredTask { "a" }
+    ///     .zip(DeferredTask { 42 }) { (str, num) in
+    ///         "\(str): \(num)"
+    ///     }
+    /// let result = try await zipped.execute()
+    /// // result is "a: 42"
+    /// ```
+    ///
+    /// - Parameter downstream: The unit of work to zip with.
+    /// - Parameter transform: Closure combining both results.
+    /// - Returns: An `AsynchronousUnitOfWork` producing the transformed result.
     public func zip<D: AsynchronousUnitOfWork, T: Sendable>(
         _ downstream: D,
         @_inheritActorContext @_implicitSelfCapture transform: @Sendable @escaping (
@@ -123,25 +139,43 @@ extension AsynchronousUnitOfWork {
     }
 
     // zip3
-    /// Zips the result of the current unit of work with two other asynchronous units of work.
+    /// Zips the result of this unit of work with two other asynchronous units of work, producing a tuple of all three results.
+    ///
+    /// ## Example
+    /// ```
+    /// let zipped = DeferredTask { "a" }
+    ///     .zip(DeferredTask { 42 }, DeferredTask { true })
+    /// let (str, num, bool) = try await zipped.execute()
+    /// // 'str' is "a", 'num' is 42, 'bool' is true
+    /// ```
     ///
     /// - Parameters:
-    ///   - d0: The first additional asynchronous unit of work to zip with.
-    ///   - d1: The second additional asynchronous unit of work to zip with.
-    /// - Returns: A new asynchronous unit of work that produces a tuple containing results from the upstream and both downstreams when completed.
+    ///   - d0: The first additional unit of work to zip with.
+    ///   - d1: The second additional unit of work to zip with.
+    /// - Returns: An `AsynchronousUnitOfWork` producing a tuple of all three results.
     public func zip<D0: AsynchronousUnitOfWork, D1: AsynchronousUnitOfWork>(_ d0: D0, _ d1: D1)
         -> some AsynchronousUnitOfWork<(Success, D0.Success, D1.Success)>
     {
         Workers.Zip3(upstream: self, d0: d0, d1: d1)
     }
 
-    /// Zips the result of the current unit of work with two other units of work and applies a transform function.
+    /// Zips the result of this unit of work with two others and applies a transform function.
+    ///
+    /// ## Example
+    /// ```
+    /// let zipped = DeferredTask { "a" }
+    ///     .zip(DeferredTask { 42 }, DeferredTask { true }) { (str, num, bool) in
+    ///         "\(str): \(num), flag is \(bool)"
+    ///     }
+    /// let result = try await zipped.execute()
+    /// // result is "a: 42, flag is true"
+    /// ```
     ///
     /// - Parameters:
-    ///   - d0: The first additional asynchronous unit of work to zip with.
-    ///   - d1: The second additional asynchronous unit of work to zip with.
-    ///   - transform: A function that takes a tuple of results from all units of work and returns a transformed result.
-    /// - Returns: A new asynchronous unit of work that produces the transformed result when completed.
+    ///   - d0: The first additional unit of work to zip with.
+    ///   - d1: The second additional unit of work to zip with.
+    ///   - transform: Closure combining all three results.
+    /// - Returns: An `AsynchronousUnitOfWork` producing the transformed result.
     public func zip<D0: AsynchronousUnitOfWork, D1: AsynchronousUnitOfWork, T: Sendable>(
         _ d0: D0, _ d1: D1,
         @_inheritActorContext @_implicitSelfCapture transform: @Sendable @escaping (
@@ -154,13 +188,21 @@ extension AsynchronousUnitOfWork {
     }
 
     // zip4
-    /// Zips the result of the current unit of work with three other asynchronous units of work.
+    /// Zips the result of this unit of work with three other asynchronous units of work, producing a tuple of all four results.
+    ///
+    /// ## Example
+    /// ```
+    /// let zipped = DeferredTask { "a" }
+    ///     .zip(DeferredTask { 42 }, DeferredTask { true }, DeferredTask { 3.14 })
+    /// let (str, num, bool, pi) = try await zipped.execute()
+    /// // 'str' is "a", 'num' is 42, 'bool' is true, 'pi' is 3.14
+    /// ```
     ///
     /// - Parameters:
-    ///   - d0: The first additional asynchronous unit of work to zip with.
-    ///   - d1: The second additional asynchronous unit of work to zip with.
-    ///   - d2: The third additional asynchronous unit of work to zip with.
-    /// - Returns: A new asynchronous unit of work that produces a tuple containing results from the upstream and all three downstreams when completed.
+    ///   - d0: The first additional unit of work to zip with.
+    ///   - d1: The second additional unit of work to zip with.
+    ///   - d2: The third additional unit of work to zip with.
+    /// - Returns: An `AsynchronousUnitOfWork` producing a tuple of all four results.
     public func zip<
         D0: AsynchronousUnitOfWork, D1: AsynchronousUnitOfWork, D2: AsynchronousUnitOfWork
     >(_ d0: D0, _ d1: D1, _ d2: D2) -> some AsynchronousUnitOfWork<
@@ -169,14 +211,24 @@ extension AsynchronousUnitOfWork {
         Workers.Zip4(upstream: self, d0: d0, d1: d1, d2: d2)
     }
 
-    /// Zips the result of the current unit of work with three other units of work and applies a transform function.
+    /// Zips the result of this unit of work with three others and applies a transform function.
+    ///
+    /// ## Example
+    /// ```
+    /// let zipped = DeferredTask { "a" }
+    ///     .zip(DeferredTask { 42 }, DeferredTask { true }, DeferredTask { 3.14 }) { (str, num, bool, pi) in
+    ///         "\(str): \(num), flag is \(bool), π is \(pi)"
+    ///     }
+    /// let result = try await zipped.execute()
+    /// // result is "a: 42, flag is true, π is 3.14"
+    /// ```
     ///
     /// - Parameters:
-    ///   - d0: The first additional asynchronous unit of work to zip with.
-    ///   - d1: The second additional asynchronous unit of work to zip with.
-    ///   - d2: The third additional asynchronous unit of work to zip with.
-    ///   - transform: A function that takes a tuple of results from all units of work and returns a transformed result.
-    /// - Returns: A new asynchronous unit of work that produces the transformed result when completed.
+    ///   - d0: The first additional unit of work to zip with.
+    ///   - d1: The second additional unit of work to zip with.
+    ///   - d2: The third additional unit of work to zip with.
+    ///   - transform: Closure combining all four results.
+    /// - Returns: An `AsynchronousUnitOfWork` producing the transformed result.
     public func zip<
         D0: AsynchronousUnitOfWork, D1: AsynchronousUnitOfWork, D2: AsynchronousUnitOfWork,
         T: Sendable

--- a/Sources/AfluentTesting/WaitUntilCondition.swift
+++ b/Sources/AfluentTesting/WaitUntilCondition.swift
@@ -7,7 +7,28 @@
 
 import Afluent
 
-/// Waits for some condition before proceeding, unless the specified timeout is reached, in which case an error is thrown.
+/// Waits asynchronously until the given condition evaluates to `true` or the specified timeout is reached.
+/// 
+/// This function repeatedly evaluates the condition and suspends the current task until the condition is met or the timeout expires.
+/// 
+/// - Parameters:
+///   - condition: An asynchronous boolean condition to evaluate.
+///   - timeout: The maximum duration to wait for the condition to become `true`.
+/// 
+/// - Throws: `TimeoutError.timedOut` if the timeout duration is exceeded before the condition becomes `true`.
+/// 
+/// ## Example
+/// ```swift
+/// var resourceIsReady = false
+/// Task {
+///     // Simulate resource initialization
+///     try await Task.sleep(nanoseconds: 2_000_000_000) // 2 seconds
+///     resourceIsReady = true
+/// }
+/// // Wait up to 5 seconds for the resource to become ready
+/// try await wait(until: resourceIsReady, timeout: .seconds(5))
+/// print("Resource is ready, proceeding with setup.")
+/// ```
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 public func wait(
     until condition: @autoclosure @escaping @Sendable () async -> Bool, timeout: Duration
@@ -17,7 +38,31 @@ public func wait(
     try await wait(until: await condition(), timeout: timeout, clock: ContinuousClock())
 }
 
-/// Waits for some condition before proceeding, unless the specified timeout is reached, in which case an error is thrown.
+/// Waits asynchronously until the given condition evaluates to `true` or the specified timeout is reached,
+/// using a custom clock to measure time.
+///
+/// This function repeatedly evaluates the condition and suspends the current task until the condition is met or the timeout expires.
+/// Use this overload when you want to specify a custom clock instance (e.g., for testing or alternative time sources).
+///
+/// - Parameters:
+///   - condition: An asynchronous boolean condition to evaluate.
+///   - timeout: The maximum duration to wait for the condition to become `true`.
+///   - clock: A clock instance used to measure the timeout duration.
+/// 
+/// - Throws: `TimeoutError.timedOut` if the timeout duration is exceeded before the condition becomes `true`.
+///
+/// ## Example
+/// ```
+/// let clock = TestClock()
+/// var isDone = false
+/// Task {
+///     // Simulate some work completing later
+///     try await clock.sleep(for: .seconds(2))
+///     isDone = true
+/// }
+/// // This will wait for isDone or throw if 5 simulated seconds pass
+/// try await wait(until: isDone, timeout: .seconds(5), clock: clock)
+/// ```
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 public func wait<C: Clock>(
     until condition: @autoclosure @escaping @Sendable () async -> Bool, timeout: C.Duration,
@@ -35,3 +80,4 @@ public func wait<C: Clock>(
         try await clock.sleep(for: clock.minimumResolution)
     }
 }
+

--- a/Sources/AfluentTesting/WaitUntilScheduled.swift
+++ b/Sources/AfluentTesting/WaitUntilScheduled.swift
@@ -8,7 +8,35 @@
 import Afluent
 
 extension Task where Failure == Error {
-    /// Spawns a new Task to run some async operation and waits for that task to begin execution before proceeding.
+    /// Spawns a new task to run an asynchronous operation and waits until that task has started execution before returning.
+    ///
+    /// This method is useful when you want to guarantee that the spawned task has begun running before the caller continues, for example, to safely interact with shared state or resources initialized by the task.
+    ///
+    /// - Parameters:
+    ///   - operation: An async throwing closure representing the operation to run in the spawned task.
+    /// - Throws: Rethrows any error thrown by the operation during its execution.
+    /// - Returns: The spawned `Task` running the specified operation.
+    ///
+    /// ## Example
+    /// ```
+    /// @Sendable func fetchData() async throws -> String {
+    ///     // Simulates network request
+    ///     try await Task.sleep(nanoseconds: 1_000_000_000)
+    ///     return "Data"
+    /// }
+    ///
+    /// func testWaitUntilExecutionStarted() async throws {
+    ///     var hasStarted = false
+    ///     let task = try await Task.waitUntilExecutionStarted {
+    ///         hasStarted = true
+    ///         return try await fetchData()
+    ///     }
+    ///     // At this point `hasStarted` is guaranteed to be true because the task has started.
+    ///     assert(hasStarted)
+    ///     let result = try await task.value
+    ///     XCTAssertEqual(result, "Data")
+    /// }
+    /// ```
     public static func waitUntilExecutionStarted(
         operation: @escaping @Sendable () async throws -> Success
     ) async throws -> Self {


### PR DESCRIPTION
There's been some desire to have better documentation for Afluent. I used Xcode 26 to help me generate examples for everything. I reviewed what it spat out, but there are a lot of changes. The biggest point here is just to enhance the documentation in Xcode and align a bit more closely with the quality of Combine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Significantly expanded and clarified documentation across many async sequence and asynchronous unit of work operators, including detailed usage examples and behavior explanations.
  * Added new caching strategy for cancel-and-retry behavior and enhanced caching strategy docs.
  * Introduced multicasting async sequence operators `broadcast()` and `share()` with detailed docs.
  * Enhanced documentation for error handling, retry strategies, timeout, delay, and bridging APIs to async/await.
  * Improved parameter descriptions, usage guidance, and best practice notes for sharing, caching, retry, and sequence transformation operators.
  * Clarified equality semantics and added convenience properties for timeout errors.
  * Refined documentation for lifecycle event handlers, breakpoint operators, and assertion helpers.
  * Expanded documentation for caching classes, asynchronous unit of work cache, and deferred task actor with usage examples.
  * Enhanced docs for subjects, serial task queue, and single-value bridging types.
  * Added detailed examples and clarifications for operators like `shareFromCache`, `retry`, `flatMap`, `assign`, `handleEvents`, and `timeout`.

* **Tests**
  * Updated a test to use an actor for queue state management, improving concurrency safety in test logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->