### PR TITLE
Added syntax highlighting for DocC on web

### DIFF
--- a/Sources/Afluent/AsyncSequenceCache.swift
+++ b/Sources/Afluent/AsyncSequenceCache.swift
@@ -11,7 +11,7 @@ import Foundation
 /// This cache is commonly used with the `shareFromCache` operator to reuse sequences.
 ///
 /// ## Example
-/// ```
+/// ```swift
 /// let cache = AsyncSequenceCache()
 /// let sequence = fetchData() // Some async sequence
 /// let shared = sequence.shareFromCache(cache, strategy: .cacheUntilCompletionOrCancellation, keys: "myKey")

--- a/Sources/Afluent/AsynchronousUnitOfWorkCache.swift
+++ b/Sources/Afluent/AsynchronousUnitOfWorkCache.swift
@@ -16,7 +16,7 @@ public typealias AnySendableReference = AnyObject & Sendable
 ///
 /// Use this cache to avoid redundant execution of identical units of work, especially those that are expensive or should only be performed once for a given key.
 /// ## Example
-/// ```
+/// ```swift
 /// let cache = AUOWCache()
 /// let work = DeferredTask { await fetchUser() }
 ///     .shareFromCache(cache, strategy: .cacheUntilCompletionOrCancellation, keys: "user42")

--- a/Sources/Afluent/CurrentValueSubject.swift
+++ b/Sources/Afluent/CurrentValueSubject.swift
@@ -10,7 +10,7 @@
 /// This is an `AsyncSequence` that allows multiple tasks to asynchronously consume values and mimics Combine's CurrentValueSubject.
 ///
 /// ## Example
-/// ```
+/// ```swift
 /// let subject = CurrentValueSubject(0)
 ///
 /// Task {

--- a/Sources/Afluent/DeferredTask.swift
+++ b/Sources/Afluent/DeferredTask.swift
@@ -19,7 +19,7 @@ import Foundation
 /// ## Example
 ///
 /// Basic usage with `execute()` to start and await the operation:
-/// ```
+/// ```swift
 /// let deferred = DeferredTask<Int> {
 ///     try await Task.sleep(nanoseconds: 1_000_000_000)
 ///     return 42
@@ -29,7 +29,7 @@ import Foundation
 /// ```
 ///
 /// Accessing the result via the `result` property (an async property that awaits completion):
-/// ```
+/// ```swift
 /// let deferred = DeferredTask<Int> {
 ///     10 * 5
 /// }
@@ -38,7 +38,7 @@ import Foundation
 /// ```
 ///
 /// Running the operation without awaiting its result immediately, via `run()`:
-/// ```
+/// ```swift
 /// let deferred = DeferredTask<Int> {
 ///     7 + 3
 /// }
@@ -47,7 +47,7 @@ import Foundation
 /// ```
 ///
 /// Subscribing to the task's events using `subscribe()`:
-/// ```
+/// ```swift
 /// let deferred = DeferredTask<String> {
 ///     "Hello, World!"
 /// }
@@ -62,7 +62,7 @@ import Foundation
 /// ```
 ///
 /// Storing the subscription in a collection for lifecycle management:
-/// ```
+/// ```swift
 /// var cancellables = Set<AnyCancellable>()
 /// let deferred = DeferredTask<Void> {
 ///     print("Task executed")
@@ -71,7 +71,7 @@ import Foundation
 /// ```
 ///
 /// Chaining with operators:
-/// ```
+/// ```swift
 /// let result = try await DeferredTask { 21 }
 ///     .map { $0 * 2 }
 ///     .execute() // result is 42

--- a/Sources/Afluent/PassthroughSubject.swift
+++ b/Sources/Afluent/PassthroughSubject.swift
@@ -11,7 +11,7 @@
 /// This is an `AsyncSequence` that allows multiple tasks to asynchronously consume values and mimics Combine's PassthroughSubject.
 ///
 /// ## Example
-/// ```
+/// ```swift
 /// let subject = PassthroughSubject<Int>()
 ///
 /// Task {

--- a/Sources/Afluent/RetryStrategies/RetryByBackoffStrategy.swift
+++ b/Sources/Afluent/RetryStrategies/RetryByBackoffStrategy.swift
@@ -19,7 +19,7 @@ where Self == RetryByBackoffStrategy<ExponentialBackoffStrategy<ContinuousClock>
     /// This convenience function can be used with operators such as `.retry(strategy:)`.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// try await DeferredTask { /* some fallible work */ }
     ///     .retry(strategy: .backoff(.exponential(base: 2, maxCount: 3)))
     ///     .execute()
@@ -36,7 +36,7 @@ where Self == RetryByBackoffStrategy<ExponentialBackoffStrategy<ContinuousClock>
 /// This actor manages retry attempts with a configurable `BackoffStrategy` and clock. It determines delays between retries using this strategy.
 ///
 /// ## Example
-/// ```
+/// ```swift
 /// try await DeferredTask { /* some fallible work */ }
 ///     .retry(strategy: .backoff(.exponential(base: 2, maxCount: 3)))
 ///     .execute()
@@ -74,7 +74,7 @@ public actor RetryByBackoffStrategy<Strategy: BackoffStrategy>: RetryStrategy {
 /// Conforming types provide logic to determine the delay between retry attempts using a clock and a duration unit.
 ///
 /// ## Example
-/// ```
+/// ```swift
 /// struct MyStrategy: BackoffStrategy {
 ///     func backoff<T: BinaryInteger>(clock: ContinuousClock, durationUnit: @escaping ClockDurationUnit<ContinuousClock, T>) async throws -> Bool {
 ///         try await clock.sleep(for: durationUnit(1))

--- a/Sources/Afluent/RetryStrategies/RetryByCountStrategy.swift
+++ b/Sources/Afluent/RetryStrategies/RetryByCountStrategy.swift
@@ -11,7 +11,7 @@ extension RetryStrategy where Self == RetryByCountStrategy {
     /// Use this strategy with operators like `.retry(strategy:)` to control how many times an operation will be retried.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// try await DeferredTask { /* some fallible work */ }
     ///     .retry(strategy: .byCount(3))
     ///     .execute()
@@ -26,7 +26,7 @@ extension RetryStrategy where Self == RetryByCountStrategy {
 /// This strategy retries an operation a specified number of times before giving up.
 ///
 /// ## Example
-/// ```
+/// ```swift
 /// try await DeferredTask { /* some fallible work */ }
 ///     .retry(strategy: .byCount(3))
 ///     .execute()

--- a/Sources/Afluent/RetryStrategies/RetryStrategy.swift
+++ b/Sources/Afluent/RetryStrategies/RetryStrategy.swift
@@ -11,7 +11,7 @@
 /// This protocol also allows executing any pre-retry logic, such as logging or cleanup, before attempting a retry.
 ///
 /// ## Example
-/// ```
+/// ```swift
 /// actor AlwaysRetryOnce: RetryStrategy {
 ///     private var hasRetried = false
 ///     func handle(error: Error, beforeRetry: @Sendable (Error) async throws -> Void) async throws -> Bool {

--- a/Sources/Afluent/SequenceOperators/AnyAsyncSequence.swift
+++ b/Sources/Afluent/SequenceOperators/AnyAsyncSequence.swift
@@ -70,7 +70,7 @@ extension AsyncSequence where Self: Sendable, Element: Sendable {
     /// Use this to hide the underlying concrete type of an async sequence when you need to pass it generically.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// let stream = AsyncStream<Int> { continuation in
     ///     continuation.yield(1)
     ///     continuation.yield(2)

--- a/Sources/Afluent/SequenceOperators/AssertNoFailureSequence.swift
+++ b/Sources/Afluent/SequenceOperators/AssertNoFailureSequence.swift
@@ -42,7 +42,7 @@ extension AsyncSequence where Self: Sendable {
     /// Use this to assert that a sequence is infallible, propagating values and terminating with a fatal error if any error occurs.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// let numbers = AsyncStream<Int> { continuation in
     ///     continuation.yield(1)
     ///     continuation.yield(2)

--- a/Sources/Afluent/SequenceOperators/BreakpointSequence.swift
+++ b/Sources/Afluent/SequenceOperators/BreakpointSequence.swift
@@ -18,7 +18,7 @@ extension AsyncSequence where Self: Sendable {
     ///   - receiveError: Closure called with each error. Return `true` to trigger a breakpoint. Default is `nil`.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// let numbers = AsyncStream<Int> { continuation in
     ///     continuation.yield(1)
     ///     continuation.yield(42)
@@ -48,7 +48,7 @@ extension AsyncSequence where Self: Sendable {
     /// Introduces a breakpoint into the async sequence when an error occurs.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// let stream = AsyncStream<Int> { continuation in
     ///     continuation.finish(throwing: MyError())
     /// }

--- a/Sources/Afluent/SequenceOperators/CatchSequence.swift
+++ b/Sources/Afluent/SequenceOperators/CatchSequence.swift
@@ -58,7 +58,7 @@ extension AsyncSequence where Self: Sendable {
     /// Catches any errors emitted by the upstream `AsyncSequence` and handles them using the provided closure.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// for try await value in Just(1).catch { _ in Just(0) } {
     ///     print(value)
     /// }
@@ -73,7 +73,7 @@ extension AsyncSequence where Self: Sendable {
     /// Catches a specific type of error emitted by the upstream `AsyncSequence` and handles them using the provided closure.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// for try await value in Just(1).catch(MyError()) { _ in Just(0) } {
     ///     print(value)
     /// }
@@ -93,7 +93,7 @@ extension AsyncSequence where Self: Sendable {
     /// Tries to catch any errors emitted by the upstream `AsyncSequence` and handles them using the provided throwing closure.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// for try await value in Just(1).tryCatch { _ in Just(0) } {
     ///     print(value)
     /// }
@@ -108,7 +108,7 @@ extension AsyncSequence where Self: Sendable {
     /// Tries to catch a specific type of error emitted by the upstream `AsyncSequence` and handles them using the provided throwing closure.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// for try await value in Just(1).tryCatch(MyError()) { _ in Just(0) } {
     ///     print(value)
     /// }

--- a/Sources/Afluent/SequenceOperators/CollectSequence.swift
+++ b/Sources/Afluent/SequenceOperators/CollectSequence.swift
@@ -45,7 +45,7 @@ extension AsyncSequence where Self: Sendable {
     /// - Important: Be cautious using `collect()` on sequences that emit a large number of elements or never complete, as this can lead to high memory usage.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// for try await values in Just(1).collect() {
     ///     print(values) // Prints: [1]
     /// }

--- a/Sources/Afluent/SequenceOperators/DecodeSequence.swift
+++ b/Sources/Afluent/SequenceOperators/DecodeSequence.swift
@@ -63,7 +63,7 @@ extension AsyncSequence where Self: Sendable {
     /// Use this to decode values from upstream elements (such as encoded JSON) to a concrete type.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// struct Person: Decodable { let name: String }
     /// let json = try JSONEncoder().encode(Person(name: "Alice"))
     /// for try await person in Just(json).decode(type: Person.self, decoder: JSONDecoder()) {

--- a/Sources/Afluent/SequenceOperators/DelaySequence.swift
+++ b/Sources/Afluent/SequenceOperators/DelaySequence.swift
@@ -76,7 +76,7 @@ extension AsyncSequence where Self: Sendable, Element: Sendable {
     /// The default clock is `SuspendingClock`.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// for try await value in Just(1).delay(for: .seconds(1), tolerance: .milliseconds(100)) {
     ///     print(value)
     /// }
@@ -96,7 +96,7 @@ extension AsyncSequence where Self: Sendable, Element: Sendable {
     ///   - clock: The clock to use for timing the delay.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// for try await value in Just(1).delay(for: .seconds(1), clock: ContinuousClock()) {
     ///     print(value)
     /// }

--- a/Sources/Afluent/SequenceOperators/DematerializeSequence.swift
+++ b/Sources/Afluent/SequenceOperators/DematerializeSequence.swift
@@ -43,7 +43,7 @@ extension AsyncSequence where Self: Sendable {
     /// This is the inverse of `materialize()`. Use it to recover values and errors from a sequence of events.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// for try await value in Just(1).materialize().dematerialize() {
     ///     print(value) // Prints: 1
     /// }

--- a/Sources/Afluent/SequenceOperators/DiscardOutputSequence.swift
+++ b/Sources/Afluent/SequenceOperators/DiscardOutputSequence.swift
@@ -13,7 +13,7 @@ extension AsyncSequence where Self: Sendable {
     /// Use this to ignore the payload of each element, but still receive an event for every value.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// for await _ in Just(1).discardOutput() {
     ///     // Loop runs once for each element, but value is always Void
     /// }

--- a/Sources/Afluent/SequenceOperators/EncodeSequence.swift
+++ b/Sources/Afluent/SequenceOperators/EncodeSequence.swift
@@ -62,7 +62,7 @@ extension AsyncSequence where Self: Sendable {
     /// Use this to encode values into a data format (such as JSON) before further processing or output.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// struct Person: Encodable { let name: String }
     /// for try await data in Just(Person(name: "Alice")).encode(encoder: JSONEncoder()) {
     ///     print(data) // Encoded JSON data

--- a/Sources/Afluent/SequenceOperators/FlatMapSequence.swift
+++ b/Sources/Afluent/SequenceOperators/FlatMapSequence.swift
@@ -79,7 +79,7 @@ extension AsyncSequence {
     ///   - transform: Transforms each element into an `AsyncSequence`.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// for try await value in Just(1).flatMap(maxSubscriptions: .unlimited) { i in Just(i * 2) } {
     ///     print(value) // Prints: 2
     /// }

--- a/Sources/Afluent/SequenceOperators/GroupBySequence.swift
+++ b/Sources/Afluent/SequenceOperators/GroupBySequence.swift
@@ -72,7 +72,7 @@ extension AsyncSequence where Self: Sendable, Element: Sendable {
     /// - Warning: This operator stores each group in a dictionary. If the number of unique keys is very large or unbounded, memory usage may increase significantly.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// for await (key, group) in Just(1).groupBy { $0 % 2 } {
     ///     print("Key: \(key)")
     ///     for try await value in group {

--- a/Sources/Afluent/SequenceOperators/HandleEventsSequence.swift
+++ b/Sources/Afluent/SequenceOperators/HandleEventsSequence.swift
@@ -68,7 +68,7 @@ extension AsyncSequence where Self: Sendable {
     /// Use this to observe or act on events like output, error, completion, or cancellation.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// for try await value in Just(1).handleEvents(receiveOutput: { print("Saw value: \($0)") }) {
     ///     print("Received: \(value)")
     /// }

--- a/Sources/Afluent/SequenceOperators/JustSequence.swift
+++ b/Sources/Afluent/SequenceOperators/JustSequence.swift
@@ -13,7 +13,7 @@ extension AsyncSequences {
     /// Use `Just` to create a sequence that yields one value and then finishes, often for testing, composition, or as a source of a single known value.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// for await value in Just(1) {
     ///     print(value) // Prints: 1
     /// }

--- a/Sources/Afluent/SequenceOperators/MapErrorSequence.swift
+++ b/Sources/Afluent/SequenceOperators/MapErrorSequence.swift
@@ -42,7 +42,7 @@ extension AsyncSequence where Self: Sendable {
     /// This is useful for converting between error types or adding additional context to errors.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// enum NetworkError: Error { case timeout }
     /// enum UserError: Error { case displayMessage(String) }
     /// let throwing = Just(1).map { _ in throw NetworkError.timeout }
@@ -64,7 +64,7 @@ extension AsyncSequence where Self: Sendable {
     /// Transforms a specific error value produced by the sequence using the provided closure.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// enum NetworkError: Error, Equatable { case timeout }
     /// enum UserError: Error { case displayMessage(String) }
     /// let throwing = Just(1).map { _ in throw NetworkError.timeout }

--- a/Sources/Afluent/SequenceOperators/MaterializeSequence.swift
+++ b/Sources/Afluent/SequenceOperators/MaterializeSequence.swift
@@ -58,7 +58,7 @@ extension AsyncSequence where Self: Sendable {
     /// Use this to handle elements, errors, and completion uniformly as events.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// for await event in Just(1).materialize() {
     ///     switch event {
     ///     case .element(let value): print("Element: \(value)")

--- a/Sources/Afluent/SequenceOperators/PrintSequence.swift
+++ b/Sources/Afluent/SequenceOperators/PrintSequence.swift
@@ -15,7 +15,7 @@ extension AsyncSequence where Self: Sendable {
     /// - Parameter prefix: A string to prefix each log message with. Default is an empty string.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// for try await value in Just(1).print("MyPrefix") {
     ///     // Prints lifecycle events and value to the console with prefix "MyPrefix"
     /// }

--- a/Sources/Afluent/SequenceOperators/ReplaceErrorSequence.swift
+++ b/Sources/Afluent/SequenceOperators/ReplaceErrorSequence.swift
@@ -45,7 +45,7 @@ extension AsyncSequence where Self: Sendable {
     /// Use this to emit a fallback value instead of propagating an error downstream.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// let stream = Just(1).map { _ in throw MyError() }
     /// for await value in stream.replaceError(with: 42) {
     ///     print(value) // Prints: 42

--- a/Sources/Afluent/SequenceOperators/ReplaceNilSequence.swift
+++ b/Sources/Afluent/SequenceOperators/ReplaceNilSequence.swift
@@ -44,7 +44,7 @@ extension AsyncSequence where Self: Sendable {
     /// Use this to emit a fallback value whenever the upstream emits `nil`.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// let stream = AsyncStream<Int?> { continuation in
     ///     continuation.yield(1)
     ///     continuation.yield(nil)

--- a/Sources/Afluent/SequenceOperators/RetryAfterFlatMappingSequence.swift
+++ b/Sources/Afluent/SequenceOperators/RetryAfterFlatMappingSequence.swift
@@ -292,7 +292,7 @@ extension AsyncSequence where Self: Sendable {
     ///
     /// ## Example: Refreshing an access token on a 401 HTTP error before retrying the main request
     ///
-    /// ```
+    /// ```swift
     /// let mainRequest = URLSession.shared.dataTaskAsyncSequence(for: URLRequest(url: URL(string: "https://api.example.com/data")!))
     ///
     /// let retriedSequence = mainRequest.retry(.byCount(3)) { error in
@@ -328,7 +328,7 @@ extension AsyncSequence where Self: Sendable {
     ///
     /// ## Example: Refreshing tokens before retrying a network call
     ///
-    /// ```
+    /// ```swift
     /// let retriedSequence = myAsyncSequence.retry(3) { error in
     ///     DeferredTask {
     ///         if let authError = error as? MyAuthError {
@@ -360,7 +360,7 @@ extension AsyncSequence where Self: Sendable {
     ///
     /// ## Example: Retry only on a specific error with side effect
     ///
-    /// ```
+    /// ```swift
     /// let retried = myAsyncSequence.retry(3, on: MyError.tokenExpired) { error in
     ///     DeferredTask {
     ///         try await refreshAuthToken()
@@ -391,7 +391,7 @@ extension AsyncSequence where Self: Sendable {
     ///
     /// ## Example: Custom retry on error with side effect
     ///
-    /// ```
+    /// ```swift
     /// let retried = myAsyncSequence.retry(.byCount(3), on: MyError.tokenExpired) { error in
     ///     DeferredTask {
     ///         try await refreshAuthToken()
@@ -422,7 +422,7 @@ extension AsyncSequence where Self: Sendable {
     ///
     /// ## Example: Retry on error cast with side effect
     ///
-    /// ```
+    /// ```swift
     /// let retried = myAsyncSequence.retry(3, on: MyError.self) { error in
     ///     DeferredTask {
     ///         try await refreshAuthToken()
@@ -454,7 +454,7 @@ extension AsyncSequence where Self: Sendable {
     ///
     /// ## Example: Custom retry on casted error with side effect
     ///
-    /// ```
+    /// ```swift
     /// let retried = myAsyncSequence.retry(.byCount(3), on: MyError.self) { error in
     ///     DeferredTask {
     ///         try await refreshAuthToken()

--- a/Sources/Afluent/SequenceOperators/RetrySequence.swift
+++ b/Sources/Afluent/SequenceOperators/RetrySequence.swift
@@ -232,7 +232,7 @@ extension AsyncSequence where Self: Sendable, Element: Sendable {
     /// Not all `AsyncSequence`s can be retried. For example, `AsyncStream` and `AsyncThrowingStream` cannot be retried on their own.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// actor CallCounter {
     ///     private(set) var count = 0
     ///     func increment() -> Int {
@@ -276,7 +276,7 @@ extension AsyncSequence where Self: Sendable, Element: Sendable {
     /// Not all `AsyncSequence`s can be retried. For example, `AsyncStream` and `AsyncThrowingStream` cannot be retried on their own.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// actor CallCounter {
     ///     private(set) var count = 0
     ///     func increment() -> Int {
@@ -320,7 +320,7 @@ extension AsyncSequence where Self: Sendable, Element: Sendable {
     /// Not all `AsyncSequence`s can be retried. For example, `AsyncStream` and `AsyncThrowingStream` cannot be retried on their own.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// actor CallCounter {
     ///     private(set) var count = 0
     ///     func increment() -> Int {
@@ -372,7 +372,7 @@ extension AsyncSequence where Self: Sendable, Element: Sendable {
     /// Not all `AsyncSequence`s can be retried. For example, `AsyncStream` and `AsyncThrowingStream` cannot be retried on their own.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// actor CallCounter {
     ///     private(set) var count = 0
     ///     func increment() -> Int {

--- a/Sources/Afluent/Workers/Encode.swift
+++ b/Sources/Afluent/Workers/Encode.swift
@@ -55,7 +55,7 @@ extension AsynchronousUnitOfWork {
     /// Use this operator when you want to transform an encodable output (such as a model or primitive value) into an encoded form (like Data) using a given encoder (e.g., JSONEncoder).
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// struct Person: Encodable { let name: String }
     /// let work = DeferredTask { Person(name: "Alice") }
     /// let encoded: some AsynchronousUnitOfWork<Data> = work.encode(encoder: JSONEncoder())

--- a/Sources/Afluent/Workers/EraseToAnyAsynchronousUnitOfWork.swift
+++ b/Sources/Afluent/Workers/EraseToAnyAsynchronousUnitOfWork.swift
@@ -64,7 +64,7 @@ extension AsynchronousUnitOfWork {
     /// Use this method when you need to store or pass around an `AsynchronousUnitOfWork` without exposing its underlying type, such as when collecting heterogeneous unit of work instances in a single array.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// struct User: Sendable {}
     /// let original: some AsynchronousUnitOfWork<User> = DeferredTask { User() }
     /// let erased: AnyAsynchronousUnitOfWork<User> = original.eraseToAnyUnitOfWork()

--- a/Sources/Afluent/Workers/FlatMap.swift
+++ b/Sources/Afluent/Workers/FlatMap.swift
@@ -39,7 +39,7 @@ extension AsynchronousUnitOfWork {
     /// Use this operator to chain dependent asynchronous operations, where the output of the first is needed to create the second.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// let profile = try await DeferredTask { try await fetchUser() }
     ///     .flatMap { user in DeferredTask { try await fetchProfile(for: user) } }
     ///     .execute()
@@ -60,7 +60,7 @@ extension AsynchronousUnitOfWork {
     /// This is convenient for chaining side-effectful async operations where the upstream does not yield a value.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// let value = try await DeferredTask { }
     ///     .flatMap { DeferredTask { 42 } }
     ///     .execute()

--- a/Sources/Afluent/Workers/HandleEvents.swift
+++ b/Sources/Afluent/Workers/HandleEvents.swift
@@ -70,7 +70,7 @@ extension AsynchronousUnitOfWork {
     /// on errors, or cancellation.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// try await DeferredTask { try await fetchUser() }
     ///     .handleEvents(
     ///         receiveOperation: { print("About to start") },

--- a/Sources/Afluent/Workers/MapError.swift
+++ b/Sources/Afluent/Workers/MapError.swift
@@ -41,7 +41,7 @@ extension AsynchronousUnitOfWork {
     /// This function allows you to modify or replace the error produced by the current unit of work. It's useful for converting between error types or adding additional context to errors.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// enum MyError: Error { case network, wrapped(Error) }
     /// let task = DeferredTask { throw URLError(.notConnectedToInternet) }
     ///     .mapError { error in
@@ -66,7 +66,7 @@ extension AsynchronousUnitOfWork {
     /// This function allows you to modify or replace a specific error produced by the current unit of work. If the error produced matches the provided error, the transform closure is applied; otherwise, the original error is propagated unchanged.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// enum MyError: Error, Equatable { case network, other }
     /// let task = DeferredTask { throw MyError.network }
     ///     .mapError(MyError.network) { error in

--- a/Sources/Afluent/Workers/Print.swift
+++ b/Sources/Afluent/Workers/Print.swift
@@ -13,7 +13,7 @@ extension AsynchronousUnitOfWork {
     /// Use this operator for debugging or observing the lifecycle and values of an asynchronous unit of work. Output is sent to the standard output (console).
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// try await DeferredTask { 42 }
     ///     .print("[Example]")
     ///     .execute()

--- a/Sources/Afluent/Workers/ReplaceError.swift
+++ b/Sources/Afluent/Workers/ReplaceError.swift
@@ -38,7 +38,7 @@ extension AsynchronousUnitOfWork {
     /// Use this operator to recover from errors by substituting a default value, making the unit of work non-throwing for downstream consumers.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// enum MyError: Error { case network }
     /// let value = try await DeferredTask { throw MyError.network }
     ///     .replaceError(with: 0)

--- a/Sources/Afluent/Workers/ReplaceNil.swift
+++ b/Sources/Afluent/Workers/ReplaceNil.swift
@@ -37,7 +37,7 @@ extension AsynchronousUnitOfWork {
     /// Use this operator to guarantee a non-optional result from an asynchronous unit of work that may emit `nil`.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// let result = try await DeferredTask { Int?.none }
     ///     .replaceNil(with: 42)
     ///     .execute()

--- a/Sources/Afluent/Workers/Retain.swift
+++ b/Sources/Afluent/Workers/Retain.swift
@@ -44,7 +44,7 @@ extension AsynchronousUnitOfWork {
     /// Use this operator when you want to prevent repeated side effects or recomputation by caching the result of the first execution.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// var runCount = 0
     /// let task = DeferredTask { runCount += 1; return 42 }
     ///     .retain()

--- a/Sources/Afluent/Workers/Retry.swift
+++ b/Sources/Afluent/Workers/Retry.swift
@@ -124,7 +124,7 @@ extension AsynchronousUnitOfWork {
     /// Use this operator to control retry behavior with custom or built-in strategies, mirroring the power and flexibility of the AsyncSequence retry operator.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// try await DeferredTask { try await fetchData() }
     ///     .retry(.byCount(3))
     ///     .execute()
@@ -139,7 +139,7 @@ extension AsynchronousUnitOfWork {
     /// Retries this unit of work up to the specified number of times on failure.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// try await DeferredTask { try await fetchData() }
     ///     .retry(3)
     ///     .execute()
@@ -154,7 +154,7 @@ extension AsynchronousUnitOfWork {
     /// Retries this unit of work up to the specified number of times, but only when the error matches the given equatable error.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// enum NetworkError: Error, Equatable { case offline, timeout }
     /// try await DeferredTask { throw NetworkError.offline }
     ///     .retry(3, on: NetworkError.offline)
@@ -174,7 +174,7 @@ extension AsynchronousUnitOfWork {
     /// Retries this unit of work up to the specified number of times, but only when the error is of the given type.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// enum NetworkError: Error { case offline, timeout }
     /// try await DeferredTask { throw NetworkError.timeout }
     ///     .retry(3, on: NetworkError.self)

--- a/Sources/Afluent/Workers/RetryAfterFlatMapping.swift
+++ b/Sources/Afluent/Workers/RetryAfterFlatMapping.swift
@@ -159,7 +159,7 @@ extension AsynchronousUnitOfWork {
     /// This is useful for injecting retry-dependent side effects (such as refreshing tokens) before attempting another run.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// try await DeferredTask { try await fetchData() }
     ///     .retry(.byCount(3)) { error in
     ///         DeferredTask { try await refreshCredentials() }
@@ -182,7 +182,7 @@ extension AsynchronousUnitOfWork {
     /// Retries this unit of work up to a specified number of times, running an async side effect before each retry.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// try await DeferredTask { try await fetchData() }
     ///     .retry(3) { error in
     ///         DeferredTask { try await refreshCredentials() }
@@ -206,7 +206,7 @@ extension AsynchronousUnitOfWork {
     /// Retries this unit of work up to the specified number of times only when the error matches, running an async side effect before retrying.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// enum NetworkError: Error, Equatable { case unauthorized }
     /// try await DeferredTask { throw NetworkError.unauthorized }
     ///     .retry(3, on: NetworkError.unauthorized) { _ in
@@ -232,7 +232,7 @@ extension AsynchronousUnitOfWork {
     /// Retries this unit of work up to the specified number of times only when the error matches, running an async side effect before retrying.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// enum NetworkError: Error, Equatable { case unauthorized }
     /// try await DeferredTask { throw NetworkError.unauthorized }
     ///     .retry(.byCount(3), on: NetworkError.unauthorized) { _ in
@@ -258,7 +258,7 @@ extension AsynchronousUnitOfWork {
     /// Retries this unit of work up to the specified number of times only when the error is of the given type, running an async side effect before retrying.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// enum NetworkError: Error { case unauthorized }
     /// try await DeferredTask { throw NetworkError.unauthorized }
     ///     .retry(3, on: NetworkError.self) { _ in
@@ -284,7 +284,7 @@ extension AsynchronousUnitOfWork {
     /// Retries this unit of work up to the specified number of times only when the error is of the given type, running an async side effect before retrying.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// enum NetworkError: Error { case unauthorized }
     /// try await DeferredTask { throw NetworkError.unauthorized }
     ///     .retry(.byCount(3), on: NetworkError.self) { _ in

--- a/Sources/Afluent/Workers/Share.swift
+++ b/Sources/Afluent/Workers/Share.swift
@@ -52,7 +52,7 @@ extension AsynchronousUnitOfWork {
     /// Use this operator to avoid duplicate work when multiple parts of your code need the result of the same asynchronous operation.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// let sharedTask = DeferredTask { UUID() }
     ///     .share()
     ///

--- a/Sources/Afluent/Workers/ShareFromCache.swift
+++ b/Sources/Afluent/Workers/ShareFromCache.swift
@@ -27,7 +27,7 @@ extension AsynchronousUnitOfWork {
     /// Use this operator to ensure that the same cache entry is used for identical call sites, preventing duplicate work and sharing cached results.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// let cache = AUOWCache()
     /// let shared = DeferredTask { UUID() }
     ///     .shareFromCache(cache, strategy: .cacheUntilCompletionOrCancellation)
@@ -61,7 +61,7 @@ extension AsynchronousUnitOfWork {
     /// Use this operator to share or de-duplicate expensive work based on custom, hashable cache keys.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// let cache = AUOWCache()
     /// let shared = DeferredTask { UUID() }
     ///     .shareFromCache(cache, strategy: .cacheUntilCompletionOrCancellation, keys: "user42")
@@ -90,7 +90,7 @@ extension AsynchronousUnitOfWork {
     /// Use this operator to share or de-duplicate expensive work based on custom, hashable cache keys.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// let cache = AUOWCache()
     /// let shared = DeferredTask { UUID() }
     ///     .shareFromCache(cache, strategy: .cacheUntilCompletionOrCancellation, keys: "user", 42)
@@ -120,7 +120,7 @@ extension AsynchronousUnitOfWork {
     /// Use this operator to share or de-duplicate expensive work based on custom, hashable cache keys.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// let cache = AUOWCache()
     /// let shared = DeferredTask { UUID() }
     ///     .shareFromCache(cache, strategy: .cacheUntilCompletionOrCancellation, keys: "user", 42, "session")
@@ -151,7 +151,7 @@ extension AsynchronousUnitOfWork {
     /// Use this operator to share or de-duplicate expensive work based on custom, hashable cache keys.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// let cache = AUOWCache()
     /// let shared = DeferredTask { UUID() }
     ///     .shareFromCache(cache, strategy: .cacheUntilCompletionOrCancellation, keys: "user", 42, "session", 1)
@@ -183,7 +183,7 @@ extension AsynchronousUnitOfWork {
     /// Use this operator to share or de-duplicate expensive work based on custom, hashable cache keys.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// let cache = AUOWCache()
     /// let shared = DeferredTask { UUID() }
     ///     .shareFromCache(cache, strategy: .cacheUntilCompletionOrCancellation, keys: "user", 42, "session", 1, "extra")
@@ -219,7 +219,7 @@ extension AsynchronousUnitOfWork {
     /// Use this operator to share or de-duplicate expensive work based on custom, hashable cache keys.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// let cache = AUOWCache()
     /// let shared = DeferredTask { UUID() }
     ///     .shareFromCache(cache, strategy: .cacheUntilCompletionOrCancellation, keys: "user", 42, "session", 1, "extra", 99)
@@ -256,7 +256,7 @@ extension AsynchronousUnitOfWork {
     /// Use this operator to share or de-duplicate expensive work based on custom, hashable cache keys.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// let cache = AUOWCache()
     /// let shared = DeferredTask { UUID() }
     ///     .shareFromCache(cache, strategy: .cacheUntilCompletionOrCancellation, keys: "user", 42, "session", 1, "extra", 99, "flag")
@@ -295,7 +295,7 @@ extension AsynchronousUnitOfWork {
     /// Use this operator to share or de-duplicate expensive work based on custom, hashable cache keys.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// let cache = AUOWCache()
     /// let shared = DeferredTask { UUID() }
     ///     .shareFromCache(cache, strategy: .cacheUntilCompletionOrCancellation, keys: "user", 42, "session", 1, "extra", 99, "flag", true)
@@ -335,7 +335,7 @@ extension AsynchronousUnitOfWork {
     /// Use this operator to share or de-duplicate expensive work based on custom, hashable cache keys.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// let cache = AUOWCache()
     /// let shared = DeferredTask { UUID() }
     ///     .shareFromCache(cache, strategy: .cacheUntilCompletionOrCancellation, keys: "user", 42, "session", 1, "extra", 99, "flag", true, 1000)
@@ -376,7 +376,7 @@ extension AsynchronousUnitOfWork {
     /// Use this operator to share or de-duplicate expensive work based on custom, hashable cache keys.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// let cache = AUOWCache()
     /// let shared = DeferredTask { UUID() }
     ///     .shareFromCache(cache, strategy: .cacheUntilCompletionOrCancellation, keys: "user", 42, "session", 1, "extra", 99, "flag", true, 1000, false)

--- a/Sources/Afluent/Workers/SingleValueChannel.swift
+++ b/Sources/Afluent/Workers/SingleValueChannel.swift
@@ -12,7 +12,7 @@ import Foundation
 /// `SingleValueChannel` is an `AsynchronousUnitOfWork` that can be manually completed exactly once, making it ideal for integrating legacy or delegate/callback APIs with modern async workflows.
 ///
 /// ## Example: Bridging a callback to async/await
-/// ```
+/// ```swift
 /// func fetchData(url: URL) async throws -> Data {
 ///     let channel = SingleValueChannel<Data>()
 ///     let task = URLSession.shared.dataTask(with: url) { data, _, error in

--- a/Sources/Afluent/Workers/SingleValueSubject.swift
+++ b/Sources/Afluent/Workers/SingleValueSubject.swift
@@ -12,7 +12,7 @@ import Foundation
 /// `SingleValueSubject` is an `AsynchronousUnitOfWork` that you manually complete once, making it useful for integrating legacy, delegate, or callback-style APIs into modern async workflows.
 ///
 /// ## Example: Bridging a delegate to async/await
-/// ```
+/// ```swift
 /// final class MyDelegate: NSObject, SomeLegacyDelegate {
 ///     let subject = SingleValueSubject<Data>()
 ///     func didReceive(data: Data) { try? subject.send(data) }

--- a/Sources/Afluent/Workers/Timeout.swift
+++ b/Sources/Afluent/Workers/Timeout.swift
@@ -48,7 +48,7 @@ extension AsynchronousUnitOfWork {
     /// Adds a timeout to this unit of work, cancelling it if it does not complete within the specified duration.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// try await DeferredTask { try await fetchData() }
     ///     .timeout(.seconds(5))
     ///     .execute()
@@ -71,7 +71,7 @@ extension AsynchronousUnitOfWork {
     /// Adds a timeout to this unit of work, cancelling it if it does not complete in time, measured against the given clock.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// let clock = SuspendingClock()
     /// try await DeferredTask { try await fetchData() }
     ///     .timeout(.seconds(2), clock: clock, tolerance: .milliseconds(100))

--- a/Sources/Afluent/Workers/ToAsyncSequence.swift
+++ b/Sources/Afluent/Workers/ToAsyncSequence.swift
@@ -64,7 +64,7 @@ extension AsynchronousUnitOfWork {
     /// Use this operator to integrate single-value asynchronous operations into sequence-based workflows, or to use sequence algorithms and idioms with a single result.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// for try await value in DeferredTask { 42 }.toAsyncSequence() {
     ///     print(value) // prints 42
     /// }

--- a/Sources/Afluent/Workers/UnwrapOrThrow.swift
+++ b/Sources/Afluent/Workers/UnwrapOrThrow.swift
@@ -13,7 +13,7 @@ extension AsynchronousUnitOfWork {
     /// Use this operator to convert an optional result into a non-optional one, failing the operation with your custom error if no value is present.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// enum MyError: Error { case missing }
     /// let result = try await DeferredTask { Int?.none }
     ///     .unwrap(orThrow: MyError.missing)

--- a/Sources/Afluent/Workers/WithUnretained.swift
+++ b/Sources/Afluent/Workers/WithUnretained.swift
@@ -19,7 +19,7 @@ extension AsynchronousUnitOfWork {
     /// Use this operator to safely pass both a value and an object into a closure, without retaining the object.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// final class MyController: Sendable {}
     /// let controller = MyController()
     /// let combined = DeferredTask { 42 }

--- a/Sources/Afluent/Workers/Zip.swift
+++ b/Sources/Afluent/Workers/Zip.swift
@@ -97,7 +97,7 @@ extension AsynchronousUnitOfWork {
     /// Zips the result of this unit of work with another, producing a tuple of both results when both complete.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// let zipped = DeferredTask { "a" }
     ///     .zip(DeferredTask { 42 })
     /// let (str, num) = try await zipped.execute()
@@ -115,7 +115,7 @@ extension AsynchronousUnitOfWork {
     /// Zips the result of this unit of work with another and applies a transform function.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// let zipped = DeferredTask { "a" }
     ///     .zip(DeferredTask { 42 }) { (str, num) in
     ///         "\(str): \(num)"
@@ -142,7 +142,7 @@ extension AsynchronousUnitOfWork {
     /// Zips the result of this unit of work with two other asynchronous units of work, producing a tuple of all three results.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// let zipped = DeferredTask { "a" }
     ///     .zip(DeferredTask { 42 }, DeferredTask { true })
     /// let (str, num, bool) = try await zipped.execute()
@@ -162,7 +162,7 @@ extension AsynchronousUnitOfWork {
     /// Zips the result of this unit of work with two others and applies a transform function.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// let zipped = DeferredTask { "a" }
     ///     .zip(DeferredTask { 42 }, DeferredTask { true }) { (str, num, bool) in
     ///         "\(str): \(num), flag is \(bool)"
@@ -191,7 +191,7 @@ extension AsynchronousUnitOfWork {
     /// Zips the result of this unit of work with three other asynchronous units of work, producing a tuple of all four results.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// let zipped = DeferredTask { "a" }
     ///     .zip(DeferredTask { 42 }, DeferredTask { true }, DeferredTask { 3.14 })
     /// let (str, num, bool, pi) = try await zipped.execute()
@@ -214,7 +214,7 @@ extension AsynchronousUnitOfWork {
     /// Zips the result of this unit of work with three others and applies a transform function.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// let zipped = DeferredTask { "a" }
     ///     .zip(DeferredTask { 42 }, DeferredTask { true }, DeferredTask { 3.14 }) { (str, num, bool, pi) in
     ///         "\(str): \(num), flag is \(bool), π is \(pi)"

--- a/Sources/AfluentTesting/WaitUntilCondition.swift
+++ b/Sources/AfluentTesting/WaitUntilCondition.swift
@@ -52,7 +52,7 @@ public func wait(
 /// - Throws: `TimeoutError.timedOut` if the timeout duration is exceeded before the condition becomes `true`.
 ///
 /// ## Example
-/// ```
+/// ```swift
 /// let clock = TestClock()
 /// var isDone = false
 /// Task {

--- a/Sources/AfluentTesting/WaitUntilScheduled.swift
+++ b/Sources/AfluentTesting/WaitUntilScheduled.swift
@@ -18,7 +18,7 @@ extension Task where Failure == Error {
     /// - Returns: The spawned `Task` running the specified operation.
     ///
     /// ## Example
-    /// ```
+    /// ```swift
     /// @Sendable func fetchData() async throws -> String {
     ///     // Simulates network request
     ///     try await Task.sleep(nanoseconds: 1_000_000_000)


### PR DESCRIPTION
Guess who forgot that you need the language specified in your example markdown so that DocC on the web highlights it?