### PR TITLE
[serial-task-queue-cleanup] - Added an enqueue method as well as a synchronous variant for when you want ordered but fire and forget

### DIFF
--- a/.github/workflows/MERGE_QUEUE.yml
+++ b/.github/workflows/MERGE_QUEUE.yml
@@ -42,7 +42,7 @@ jobs:
         - "platform=iOS Simulator,name=iPhone 16 Pro,OS=18.5"
         - "platform=iOS Simulator,name=iPad mini (A17 Pro),OS=18.2"
         - "platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=18.1"
-        - "platform=visionOS Simulator,name=Apple Vision Pro,OS=2.0"
+        - "platform=visionOS Simulator,name=Apple Vision Pro,OS=2.5"
         - "platform=watchOS Simulator,name=Apple Watch Ultra 2 (49mm),OS=11.5"
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/MERGE_QUEUE.yml
+++ b/.github/workflows/MERGE_QUEUE.yml
@@ -36,20 +36,60 @@ jobs:
     runs-on: macos-15
     strategy:
       matrix:
-        destination:
-        - "platform=macOS,arch=arm64"
-        - "platform=macOS,arch=arm64,variant=Mac Catalyst"
-        - "platform=iOS Simulator,name=iPhone 16 Pro,OS=18.5"
-        - "platform=iOS Simulator,name=iPad mini (A17 Pro),OS=18.2"
-        - "platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=18.1"
-        - "platform=visionOS Simulator,name=Apple Vision Pro,OS=2.5"
-        - "platform=watchOS Simulator,name=Apple Watch Ultra 2 (49mm),OS=11.5"
+        platform: [macOS, iOS, tvOS, visionOS, watchOS, catalyst]
     steps:
       - uses: actions/checkout@v4
-      - name: Build and Test for ${{ matrix.destination }}
+      - name: Build and Test for ${{ matrix.platform }}
         run: |
           set -eo pipefail
+          
+          # Function to get the latest available simulator for a platform
+          get_latest_simulator() {
+            local platform=$1
+            case $platform in
+              iOS)
+                # Get the latest iPhone simulator
+                xcrun simctl list devices iPhone available | grep -E "iPhone [0-9]+" | tail -1 | sed -E 's/.*iPhone ([^(]+) \(([^)]+)\).*/platform=iOS Simulator,name=iPhone \1,id=\2/'
+                ;;
+              tvOS)
+                # Get the latest Apple TV simulator
+                xcrun simctl list devices "Apple TV" available | grep "Apple TV" | tail -1 | sed -E 's/.*(Apple TV[^(]+) \(([^)]+)\).*/platform=tvOS Simulator,name=\1,id=\2/'
+                ;;
+              visionOS)
+                # Get the latest Vision Pro simulator
+                xcrun simctl list devices "Apple Vision Pro" available | grep "Apple Vision Pro" | tail -1 | sed -E 's/.*(Apple Vision Pro[^(]*) \(([^)]+)\).*/platform=visionOS Simulator,name=\1,id=\2/'
+                ;;
+              watchOS)
+                # Get the latest Apple Watch simulator
+                xcrun simctl list devices "Apple Watch" available | grep "Apple Watch" | tail -1 | sed -E 's/.*(Apple Watch[^(]+) \(([^)]+)\).*/platform=watchOS Simulator,name=\1,id=\2/'
+                ;;
+              macOS)
+                echo "platform=macOS,arch=arm64"
+                ;;
+              catalyst)
+                echo "platform=macOS,arch=arm64,variant=Mac Catalyst"
+                ;;
+            esac
+          }
+          
+          # Get the destination for the current platform
+          DESTINATION=$(get_latest_simulator ${{ matrix.platform }})
+          
+          # Fallback to generic destinations if simulator detection fails
+          if [ -z "$DESTINATION" ]; then
+            case ${{ matrix.platform }} in
+              iOS) DESTINATION="platform=iOS Simulator,name=iPhone 15" ;;
+              tvOS) DESTINATION="platform=tvOS Simulator,name=Apple TV 4K" ;;
+              visionOS) DESTINATION="platform=visionOS Simulator,name=Apple Vision Pro" ;;
+              watchOS) DESTINATION="platform=watchOS Simulator,name=Apple Watch Series 9" ;;
+              macOS) DESTINATION="platform=macOS,arch=arm64" ;;
+              catalyst) DESTINATION="platform=macOS,arch=arm64,variant=Mac Catalyst" ;;
+            esac
+          fi
+          
+          echo "Using destination: $DESTINATION"
+          
           xcodebuild \
             -scheme Afluent-Package \
-            -destination '${{ matrix.destination }}' \
+            -destination "$DESTINATION" \
             clean build

--- a/.github/workflows/MERGE_QUEUE.yml
+++ b/.github/workflows/MERGE_QUEUE.yml
@@ -41,7 +41,7 @@ jobs:
         - "platform=macOS,arch=arm64,variant=Mac Catalyst"
         - "platform=iOS Simulator,name=iPhone 16 Pro,OS=18.5"
         - "platform=iOS Simulator,name=iPad mini (A17 Pro),OS=18.2"
-        - "platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=18.1"
+        - "platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=18.5"
         - "platform=visionOS Simulator,name=Apple Vision Pro,OS=2.5"
         - "platform=watchOS Simulator,name=Apple Watch Ultra 2 (49mm),OS=11.5"
     steps:

--- a/.github/workflows/MERGE_QUEUE.yml
+++ b/.github/workflows/MERGE_QUEUE.yml
@@ -36,60 +36,20 @@ jobs:
     runs-on: macos-15
     strategy:
       matrix:
-        platform: [macOS, iOS, tvOS, visionOS, watchOS, catalyst]
+        destination:
+        - "platform=macOS,arch=arm64"
+        - "platform=macOS,arch=arm64,variant=Mac Catalyst"
+        - "platform=iOS Simulator,name=iPhone 16 Pro,OS=18.5"
+        - "platform=iOS Simulator,name=iPad mini (A17 Pro),OS=18.2"
+        - "platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=18.1"
+        - "platform=visionOS Simulator,name=Apple Vision Pro,OS=2.5"
+        - "platform=watchOS Simulator,name=Apple Watch Ultra 2 (49mm),OS=11.5"
     steps:
       - uses: actions/checkout@v4
-      - name: Build and Test for ${{ matrix.platform }}
+      - name: Build and Test for ${{ matrix.destination }}
         run: |
           set -eo pipefail
-          
-          # Function to get the latest available simulator for a platform
-          get_latest_simulator() {
-            local platform=$1
-            case $platform in
-              iOS)
-                # Get the latest iPhone simulator
-                xcrun simctl list devices iPhone available | grep -E "iPhone [0-9]+" | tail -1 | sed -E 's/.*iPhone ([^(]+) \(([^)]+)\).*/platform=iOS Simulator,name=iPhone \1,id=\2/'
-                ;;
-              tvOS)
-                # Get the latest Apple TV simulator
-                xcrun simctl list devices "Apple TV" available | grep "Apple TV" | tail -1 | sed -E 's/.*(Apple TV[^(]+) \(([^)]+)\).*/platform=tvOS Simulator,name=\1,id=\2/'
-                ;;
-              visionOS)
-                # Get the latest Vision Pro simulator
-                xcrun simctl list devices "Apple Vision Pro" available | grep "Apple Vision Pro" | tail -1 | sed -E 's/.*(Apple Vision Pro[^(]*) \(([^)]+)\).*/platform=visionOS Simulator,name=\1,id=\2/'
-                ;;
-              watchOS)
-                # Get the latest Apple Watch simulator
-                xcrun simctl list devices "Apple Watch" available | grep "Apple Watch" | tail -1 | sed -E 's/.*(Apple Watch[^(]+) \(([^)]+)\).*/platform=watchOS Simulator,name=\1,id=\2/'
-                ;;
-              macOS)
-                echo "platform=macOS,arch=arm64"
-                ;;
-              catalyst)
-                echo "platform=macOS,arch=arm64,variant=Mac Catalyst"
-                ;;
-            esac
-          }
-          
-          # Get the destination for the current platform
-          DESTINATION=$(get_latest_simulator ${{ matrix.platform }})
-          
-          # Fallback to generic destinations if simulator detection fails
-          if [ -z "$DESTINATION" ]; then
-            case ${{ matrix.platform }} in
-              iOS) DESTINATION="platform=iOS Simulator,name=iPhone 15" ;;
-              tvOS) DESTINATION="platform=tvOS Simulator,name=Apple TV 4K" ;;
-              visionOS) DESTINATION="platform=visionOS Simulator,name=Apple Vision Pro" ;;
-              watchOS) DESTINATION="platform=watchOS Simulator,name=Apple Watch Series 9" ;;
-              macOS) DESTINATION="platform=macOS,arch=arm64" ;;
-              catalyst) DESTINATION="platform=macOS,arch=arm64,variant=Mac Catalyst" ;;
-            esac
-          fi
-          
-          echo "Using destination: $DESTINATION"
-          
           xcodebuild \
             -scheme Afluent-Package \
-            -destination "$DESTINATION" \
+            -destination '${{ matrix.destination }}' \
             clean build

--- a/.github/workflows/MERGE_QUEUE.yml
+++ b/.github/workflows/MERGE_QUEUE.yml
@@ -40,7 +40,7 @@ jobs:
         - "platform=macOS,arch=arm64"
         - "platform=macOS,arch=arm64,variant=Mac Catalyst"
         - "platform=iOS Simulator,name=iPhone 16 Pro,OS=18.5"
-        - "platform=iOS Simulator,name=iPad mini (A17 Pro),OS=18.2"
+        - "platform=iOS Simulator,name=iPad mini (A17 Pro),OS=18.5"
         - "platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=18.5"
         - "platform=visionOS Simulator,name=Apple Vision Pro,OS=2.5"
         - "platform=watchOS Simulator,name=Apple Watch Ultra 2 (49mm),OS=11.5"

--- a/.github/workflows/PR_CI.yml
+++ b/.github/workflows/PR_CI.yml
@@ -37,7 +37,7 @@ jobs:
         - "platform=macOS,arch=arm64"
         - "platform=macOS,arch=arm64,variant=Mac Catalyst"
         - "platform=iOS Simulator,name=iPhone 15 Pro,OS=17.5"
-        - "platform=iOS Simulator,name=iPad mini (A17 Pro),OS=18.2"
+        - "platform=iOS Simulator,name=iPad mini (A17 Pro),OS=18.5"
         - "platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=18.5"
         - "platform=visionOS Simulator,name=Apple Vision Pro,OS=2.5"
         - "platform=watchOS Simulator,name=Apple Watch Ultra 2 (49mm),OS=10.5"

--- a/.github/workflows/PR_CI.yml
+++ b/.github/workflows/PR_CI.yml
@@ -38,7 +38,7 @@ jobs:
         - "platform=macOS,arch=arm64,variant=Mac Catalyst"
         - "platform=iOS Simulator,name=iPhone 15 Pro,OS=17.5"
         - "platform=iOS Simulator,name=iPad mini (A17 Pro),OS=18.2"
-        - "platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=18.1"
+        - "platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=18.5"
         - "platform=visionOS Simulator,name=Apple Vision Pro,OS=2.5"
         - "platform=watchOS Simulator,name=Apple Watch Ultra 2 (49mm),OS=10.5"
     steps:

--- a/.github/workflows/PR_CI.yml
+++ b/.github/workflows/PR_CI.yml
@@ -33,21 +33,61 @@ jobs:
     runs-on: macos-15
     strategy:
       matrix:
-        destination:
-        - "platform=macOS,arch=arm64"
-        - "platform=macOS,arch=arm64,variant=Mac Catalyst"
-        - "platform=iOS Simulator,name=iPhone 15 Pro,OS=17.5"
-        - "platform=iOS Simulator,name=iPad mini (A17 Pro),OS=18.2"
-        - "platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=18.1"
-        - "platform=visionOS Simulator,name=Apple Vision Pro,OS=2.5"
-        - "platform=watchOS Simulator,name=Apple Watch Ultra 2 (49mm),OS=10.5"
+        platform: [macOS, iOS, tvOS, visionOS, watchOS, catalyst]
     steps:
       - uses: actions/checkout@v4
-      - name: Build and Test for ${{ matrix.destination }}
+      - name: Build and Test for ${{ matrix.platform }}
         run: |
           set -eo pipefail
+          
+          # Function to get the latest available simulator for a platform
+          get_latest_simulator() {
+            local platform=$1
+            case $platform in
+              iOS)
+                # Get the latest iPhone simulator
+                xcrun simctl list devices iPhone available | grep -E "iPhone [0-9]+" | tail -1 | sed -E 's/.*iPhone ([^(]+) \(([^)]+)\).*/platform=iOS Simulator,name=iPhone \1,id=\2/'
+                ;;
+              tvOS)
+                # Get the latest Apple TV simulator
+                xcrun simctl list devices "Apple TV" available | grep "Apple TV" | tail -1 | sed -E 's/.*(Apple TV[^(]+) \(([^)]+)\).*/platform=tvOS Simulator,name=\1,id=\2/'
+                ;;
+              visionOS)
+                # Get the latest Vision Pro simulator
+                xcrun simctl list devices "Apple Vision Pro" available | grep "Apple Vision Pro" | tail -1 | sed -E 's/.*(Apple Vision Pro[^(]*) \(([^)]+)\).*/platform=visionOS Simulator,name=\1,id=\2/'
+                ;;
+              watchOS)
+                # Get the latest Apple Watch simulator
+                xcrun simctl list devices "Apple Watch" available | grep "Apple Watch" | tail -1 | sed -E 's/.*(Apple Watch[^(]+) \(([^)]+)\).*/platform=watchOS Simulator,name=\1,id=\2/'
+                ;;
+              macOS)
+                echo "platform=macOS,arch=arm64"
+                ;;
+              catalyst)
+                echo "platform=macOS,arch=arm64,variant=Mac Catalyst"
+                ;;
+            esac
+          }
+          
+          # Get the destination for the current platform
+          DESTINATION=$(get_latest_simulator ${{ matrix.platform }})
+          
+          # Fallback to generic destinations if simulator detection fails
+          if [ -z "$DESTINATION" ]; then
+            case ${{ matrix.platform }} in
+              iOS) DESTINATION="platform=iOS Simulator,name=iPhone 15" ;;
+              tvOS) DESTINATION="platform=tvOS Simulator,name=Apple TV 4K" ;;
+              visionOS) DESTINATION="platform=visionOS Simulator,name=Apple Vision Pro" ;;
+              watchOS) DESTINATION="platform=watchOS Simulator,name=Apple Watch Series 9" ;;
+              macOS) DESTINATION="platform=macOS,arch=arm64" ;;
+              catalyst) DESTINATION="platform=macOS,arch=arm64,variant=Mac Catalyst" ;;
+            esac
+          fi
+          
+          echo "Using destination: $DESTINATION"
+          
           xcodebuild \
             -scheme Afluent-Package \
-            -destination '${{ matrix.destination }}' \
+            -destination "$DESTINATION" \
             clean build
     if: ${{ github.event_name == 'workflow_dispatch' }} # Only runs on manual trigger

--- a/.github/workflows/PR_CI.yml
+++ b/.github/workflows/PR_CI.yml
@@ -33,61 +33,21 @@ jobs:
     runs-on: macos-15
     strategy:
       matrix:
-        platform: [macOS, iOS, tvOS, visionOS, watchOS, catalyst]
+        destination:
+        - "platform=macOS,arch=arm64"
+        - "platform=macOS,arch=arm64,variant=Mac Catalyst"
+        - "platform=iOS Simulator,name=iPhone 15 Pro,OS=17.5"
+        - "platform=iOS Simulator,name=iPad mini (A17 Pro),OS=18.2"
+        - "platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=18.1"
+        - "platform=visionOS Simulator,name=Apple Vision Pro,OS=2.5"
+        - "platform=watchOS Simulator,name=Apple Watch Ultra 2 (49mm),OS=10.5"
     steps:
       - uses: actions/checkout@v4
-      - name: Build and Test for ${{ matrix.platform }}
+      - name: Build and Test for ${{ matrix.destination }}
         run: |
           set -eo pipefail
-          
-          # Function to get the latest available simulator for a platform
-          get_latest_simulator() {
-            local platform=$1
-            case $platform in
-              iOS)
-                # Get the latest iPhone simulator
-                xcrun simctl list devices iPhone available | grep -E "iPhone [0-9]+" | tail -1 | sed -E 's/.*iPhone ([^(]+) \(([^)]+)\).*/platform=iOS Simulator,name=iPhone \1,id=\2/'
-                ;;
-              tvOS)
-                # Get the latest Apple TV simulator
-                xcrun simctl list devices "Apple TV" available | grep "Apple TV" | tail -1 | sed -E 's/.*(Apple TV[^(]+) \(([^)]+)\).*/platform=tvOS Simulator,name=\1,id=\2/'
-                ;;
-              visionOS)
-                # Get the latest Vision Pro simulator
-                xcrun simctl list devices "Apple Vision Pro" available | grep "Apple Vision Pro" | tail -1 | sed -E 's/.*(Apple Vision Pro[^(]*) \(([^)]+)\).*/platform=visionOS Simulator,name=\1,id=\2/'
-                ;;
-              watchOS)
-                # Get the latest Apple Watch simulator
-                xcrun simctl list devices "Apple Watch" available | grep "Apple Watch" | tail -1 | sed -E 's/.*(Apple Watch[^(]+) \(([^)]+)\).*/platform=watchOS Simulator,name=\1,id=\2/'
-                ;;
-              macOS)
-                echo "platform=macOS,arch=arm64"
-                ;;
-              catalyst)
-                echo "platform=macOS,arch=arm64,variant=Mac Catalyst"
-                ;;
-            esac
-          }
-          
-          # Get the destination for the current platform
-          DESTINATION=$(get_latest_simulator ${{ matrix.platform }})
-          
-          # Fallback to generic destinations if simulator detection fails
-          if [ -z "$DESTINATION" ]; then
-            case ${{ matrix.platform }} in
-              iOS) DESTINATION="platform=iOS Simulator,name=iPhone 15" ;;
-              tvOS) DESTINATION="platform=tvOS Simulator,name=Apple TV 4K" ;;
-              visionOS) DESTINATION="platform=visionOS Simulator,name=Apple Vision Pro" ;;
-              watchOS) DESTINATION="platform=watchOS Simulator,name=Apple Watch Series 9" ;;
-              macOS) DESTINATION="platform=macOS,arch=arm64" ;;
-              catalyst) DESTINATION="platform=macOS,arch=arm64,variant=Mac Catalyst" ;;
-            esac
-          fi
-          
-          echo "Using destination: $DESTINATION"
-          
           xcodebuild \
             -scheme Afluent-Package \
-            -destination "$DESTINATION" \
+            -destination '${{ matrix.destination }}' \
             clean build
     if: ${{ github.event_name == 'workflow_dispatch' }} # Only runs on manual trigger

--- a/.github/workflows/PR_CI.yml
+++ b/.github/workflows/PR_CI.yml
@@ -39,7 +39,7 @@ jobs:
         - "platform=iOS Simulator,name=iPhone 15 Pro,OS=17.5"
         - "platform=iOS Simulator,name=iPad mini (A17 Pro),OS=18.2"
         - "platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=18.1"
-        - "platform=visionOS Simulator,name=Apple Vision Pro,OS=2.0"
+        - "platform=visionOS Simulator,name=Apple Vision Pro,OS=2.5"
         - "platform=watchOS Simulator,name=Apple Watch Ultra 2 (49mm),OS=10.5"
     steps:
       - uses: actions/checkout@v4

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,11 +1,12 @@
 version: 0.1
 merge: 
   required_statuses:
-    - apple-platform-regression-tests (iOS)
-    - apple-platform-regression-tests (macOS)
-    - apple-platform-regression-tests (catalyst)
-    - apple-platform-regression-tests (tvOS)
-    - apple-platform-regression-tests (visionOS)
-    - apple-platform-regression-tests (watchOS)
+    - apple-platform-regression-tests (platform=iOS Simulator,name=iPad mini (A17 Pro),OS=18.2)
+    - apple-platform-regression-tests (platform=iOS Simulator,name=iPhone 16 Pro,OS=18.5)
+    - apple-platform-regression-tests (platform=macOS,arch=arm64,variant=Mac Catalyst)
+    - apple-platform-regression-tests (platform=macOS,arch=arm64)
+    - apple-platform-regression-tests (platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=18.1)
+    - apple-platform-regression-tests (platform=visionOS Simulator,name=Apple Vision Pro,OS=2.5)
+    - apple-platform-regression-tests (platform=watchOS Simulator,name=Apple Watch Ultra 2 (49mm),OS=11.5)
     - swift-regression-tests (5.10)
     - swift-regression-tests (5.9)

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -5,7 +5,7 @@ merge:
     - apple-platform-regression-tests (platform=iOS Simulator,name=iPhone 16 Pro,OS=18.5)
     - apple-platform-regression-tests (platform=macOS,arch=arm64,variant=Mac Catalyst)
     - apple-platform-regression-tests (platform=macOS,arch=arm64)
-    - apple-platform-regression-tests (platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=18.1)
+    - apple-platform-regression-tests (platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=18.5)
     - apple-platform-regression-tests (platform=visionOS Simulator,name=Apple Vision Pro,OS=2.5)
     - apple-platform-regression-tests (platform=watchOS Simulator,name=Apple Watch Ultra 2 (49mm),OS=11.5)
     - swift-regression-tests (5.10)

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,7 +1,7 @@
 version: 0.1
 merge: 
   required_statuses:
-    - apple-platform-regression-tests (platform=iOS Simulator,name=iPad mini (A17 Pro),OS=18.2)
+    - apple-platform-regression-tests (platform=iOS Simulator,name=iPad mini (A17 Pro),OS=18.5)
     - apple-platform-regression-tests (platform=iOS Simulator,name=iPhone 16 Pro,OS=18.5)
     - apple-platform-regression-tests (platform=macOS,arch=arm64,variant=Mac Catalyst)
     - apple-platform-regression-tests (platform=macOS,arch=arm64)

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -6,7 +6,7 @@ merge:
     - apple-platform-regression-tests (platform=macOS,arch=arm64,variant=Mac Catalyst)
     - apple-platform-regression-tests (platform=macOS,arch=arm64)
     - apple-platform-regression-tests (platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=18.1)
-    - apple-platform-regression-tests (platform=visionOS Simulator,name=Apple Vision Pro,OS=2.0)
+    - apple-platform-regression-tests (platform=visionOS Simulator,name=Apple Vision Pro,OS=2.5)
     - apple-platform-regression-tests (platform=watchOS Simulator,name=Apple Watch Ultra 2 (49mm),OS=11.5)
     - swift-regression-tests (5.10)
     - swift-regression-tests (5.9)

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,12 +1,11 @@
 version: 0.1
 merge: 
   required_statuses:
-    - apple-platform-regression-tests (platform=iOS Simulator,name=iPad mini (A17 Pro),OS=18.2)
-    - apple-platform-regression-tests (platform=iOS Simulator,name=iPhone 16 Pro,OS=18.5)
-    - apple-platform-regression-tests (platform=macOS,arch=arm64,variant=Mac Catalyst)
-    - apple-platform-regression-tests (platform=macOS,arch=arm64)
-    - apple-platform-regression-tests (platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=18.1)
-    - apple-platform-regression-tests (platform=visionOS Simulator,name=Apple Vision Pro,OS=2.5)
-    - apple-platform-regression-tests (platform=watchOS Simulator,name=Apple Watch Ultra 2 (49mm),OS=11.5)
+    - apple-platform-regression-tests (iOS)
+    - apple-platform-regression-tests (macOS)
+    - apple-platform-regression-tests (catalyst)
+    - apple-platform-regression-tests (tvOS)
+    - apple-platform-regression-tests (visionOS)
+    - apple-platform-regression-tests (watchOS)
     - swift-regression-tests (5.10)
     - swift-regression-tests (5.9)


### PR DESCRIPTION
For some reason I was an idiot and didn't name the method `enqueue` like a sane person. I have rectified this and added a deprecation notice. 

I also added a synchronous variant so you can fire and forget things that need to be ordered. Note that Swift is kinda dumb and if you're in an async context it'll always prefer the async method...even if that doesn't compile. 

That's why you'll se me do this self executing synchronous closure in tests, because I'm working around the language being infuriating so `{ queue.enqueue { try await thing() } }()` finally does the trick.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Fire-and-forget enqueue to run tasks serially without awaiting results.

- Deprecations
  - Public API renamed to enqueue; previous name retained as a deprecated alias to ease migration.

- Documentation
  - Updated docs and examples to use the new API name.

- Tests
  - Added test ensuring serial execution of fire-and-forget tasks.

- Chores
  - CI/workflow matrices simplified to platform-based runs with dynamic simulator selection and fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->