### PR TITLE
Fix hang in SingleValueSubject + Timeout

### DIFF
--- a/Sources/Afluent/Race.swift
+++ b/Sources/Afluent/Race.swift
@@ -45,6 +45,11 @@
 ///
 /// ## Important
 /// A thrown error is considered to have won the race. Additionally, task groups don't guarantee parallelism, they guarantee concurrency. Consequently, while this is useful for lots of real world scenarios if you have strict parallelism requirements you may need to reach for GCD. [more information](https://forums.swift.org/t/taskgroup-and-parallelism/51039/1)
+///
+/// ## Warning
+/// Tasks that are passed to `Race` must all support cooperative cancellation.
+/// If they do not, this function has the risk of hanging while waiting for the non-cooperative task.
+/// See [this Swift forums thread](https://forums.swift.org/t/withthrowingtaskgroup-doesnt-re-throw-the-error/70958) for more details.
 public func Race<T: Sendable>(
     cancelAllOnWin: Bool = true, _ firstTask: @Sendable () async throws -> T,
     against tasks: (@Sendable () async throws -> T)...

--- a/Sources/Afluent/Workers/SingleValueSubject.swift
+++ b/Sources/Afluent/Workers/SingleValueSubject.swift
@@ -47,16 +47,8 @@ public final class SingleValueSubject<Success: Sendable>: AsynchronousUnitOfWork
     }
     private var subjectState = State.noValue
 
-    public let enableCooperativeCancellation: Bool
-
     /// Creates a new `SingleValueSubject`.
-    ///
-    /// - Parameter enableCooperativeCancellation: When true, this instance will properly handle cooperative cancellation.
-    ///
-    /// - Important: In the next major version of Afluent, `SingleValueSubject` will default to enabling cooperative cancellation.
-    public init(enableCooperativeCancellation: Bool = false) {
-        self.enableCooperativeCancellation = enableCooperativeCancellation
-    }
+    public init() {}
 
     public func _operation() async throws -> AsynchronousOperation<Success> {
         AsynchronousOperation { [weak self] in
@@ -101,9 +93,7 @@ public final class SingleValueSubject<Success: Sendable>: AsynchronousUnitOfWork
     public func cancel() {
         // custom implementation of cancel() required due to the need to finish the continuation
         state.cancel()
-        if enableCooperativeCancellation {
-            try? self.send(error: CancellationError())
-        }
+        try? self.send(error: CancellationError())
     }
 
     private func lock() { _lock.lock() }
@@ -123,7 +113,9 @@ public final class SingleValueSubject<Success: Sendable>: AsynchronousUnitOfWork
                     self.subjectState = .sentValue(value)
                     continuation.resume(returning: value)
                 default:
-                    throw SubjectError.alreadyCompleted
+                    if self.state.isCancelled == false {
+                        throw SubjectError.alreadyCompleted
+                    }
             }
         }
     }
@@ -141,7 +133,9 @@ public final class SingleValueSubject<Success: Sendable>: AsynchronousUnitOfWork
                     self.subjectState = .sentValue(())
                     continuation.resume(returning: ())
                 default:
-                    throw SubjectError.alreadyCompleted
+                    if self.state.isCancelled == false {
+                        throw SubjectError.alreadyCompleted
+                    }
             }
         }
     }
@@ -160,7 +154,9 @@ public final class SingleValueSubject<Success: Sendable>: AsynchronousUnitOfWork
                     self.subjectState = .sentError(error)
                     continuation.resume(throwing: error)
                 default:
-                    throw SubjectError.alreadyCompleted
+                    if self.state.isCancelled == false {
+                        throw SubjectError.alreadyCompleted
+                    }
             }
         }
     }

--- a/Sources/Afluent/Workers/SingleValueSubject.swift
+++ b/Sources/Afluent/Workers/SingleValueSubject.swift
@@ -47,8 +47,16 @@ public final class SingleValueSubject<Success: Sendable>: AsynchronousUnitOfWork
     }
     private var subjectState = State.noValue
 
+    public let enableCooperativeCancellation: Bool
+
     /// Creates a new `SingleValueSubject`.
-    public init() {}
+    ///
+    /// - Parameter enableCooperativeCancellation: When true, this instance will properly handle cooperative cancellation.
+    ///
+    /// - Important: In the next major version of Afluent, `SingleValueSubject` will default to enabling cooperative cancellation.
+    public init(enableCooperativeCancellation: Bool = false) {
+        self.enableCooperativeCancellation = enableCooperativeCancellation
+    }
 
     public func _operation() async throws -> AsynchronousOperation<Success> {
         AsynchronousOperation { [weak self] in
@@ -93,7 +101,9 @@ public final class SingleValueSubject<Success: Sendable>: AsynchronousUnitOfWork
     public func cancel() {
         // custom implementation of cancel() required due to the need to finish the continuation
         state.cancel()
-        try? self.send(error: CancellationError())
+        if enableCooperativeCancellation {
+            try? self.send(error: CancellationError())
+        }
     }
 
     private func lock() { _lock.lock() }

--- a/Sources/Afluent/Workers/SingleValueSubject.swift
+++ b/Sources/Afluent/Workers/SingleValueSubject.swift
@@ -90,6 +90,12 @@ public final class SingleValueSubject<Success: Sendable>: AsynchronousUnitOfWork
         }
     }
 
+    public func cancel() {
+        // custom implementation of cancel() required due to the need to finish the continuation
+        state.cancel()
+        try? self.send(error: CancellationError())
+    }
+
     private func lock() { _lock.lock() }
     private func unlock() { _lock.unlock() }
 

--- a/Tests/AfluentTests/WorkerTests/SingleValueSubjectTests.swift
+++ b/Tests/AfluentTests/WorkerTests/SingleValueSubjectTests.swift
@@ -206,9 +206,9 @@ struct SingleValueSubjectTests {
         }
     }
 
-    @Test func singleValueSubjectCancellation() async throws {
+    @Test func singleValueSubjectCancellation_withCooperativeCancellation() async throws {
         await withMainSerialExecutor {
-            let subject = SingleValueSubject<Void>()
+            let subject = SingleValueSubject<Void>(enableCooperativeCancellation: true)
 
             let task = Task {
                 _ = await #expect(throws: CancellationError.self) {
@@ -219,7 +219,33 @@ struct SingleValueSubjectTests {
             // make sure we don't cancel before the subject operation has begun
             await Task.megaYield()
             task.cancel()
+
+            #expect(throws: SingleValueSubject<Void>.SubjectError.alreadyCompleted) {
+                _ = try subject.send()
+            }
+
             await task.value
+        }
+    }
+
+    @Test func singleValueSubjectCancellation_withoutCooperativeCancellation() async throws {
+        try await withMainSerialExecutor {
+            let subject = SingleValueSubject<Void>()  // this is the default
+
+            let task = Task {
+                _ = await #expect(throws: CancellationError.self) {
+                    try await subject.execute()
+                }
+            }
+
+            // make sure we don't cancel before the subject operation has begun
+            await Task.megaYield()
+            task.cancel()
+
+            try subject.send()  // doesn't throw
+
+            // this would hang forever if called
+            // await task.value
         }
     }
 }

--- a/Tests/AfluentTests/WorkerTests/SingleValueSubjectTests.swift
+++ b/Tests/AfluentTests/WorkerTests/SingleValueSubjectTests.swift
@@ -205,4 +205,21 @@ struct SingleValueSubjectTests {
             }
         }
     }
+
+    @Test func singleValueSubjectCancellation() async throws {
+        await withMainSerialExecutor {
+            let subject = SingleValueSubject<Void>()
+
+            let task = Task {
+                _ = await #expect(throws: CancellationError.self) {
+                    try await subject.execute()
+                }
+            }
+
+            // make sure we don't cancel before the subject operation has begun
+            await Task.megaYield()
+            task.cancel()
+            await task.value
+        }
+    }
 }

--- a/Tests/AfluentTests/WorkerTests/SingleValueSubjectTests.swift
+++ b/Tests/AfluentTests/WorkerTests/SingleValueSubjectTests.swift
@@ -206,7 +206,7 @@ struct SingleValueSubjectTests {
         }
     }
 
-    @Test func singleValueSubjectCancellation_withCooperativeCancellation() async throws {
+    @Test func singleValueSubjectCancellation() async throws {
         try await withMainSerialExecutor {
             let subject = SingleValueSubject<Void>()
 

--- a/Tests/AfluentTests/WorkerTests/SingleValueSubjectTests.swift
+++ b/Tests/AfluentTests/WorkerTests/SingleValueSubjectTests.swift
@@ -207,8 +207,8 @@ struct SingleValueSubjectTests {
     }
 
     @Test func singleValueSubjectCancellation_withCooperativeCancellation() async throws {
-        await withMainSerialExecutor {
-            let subject = SingleValueSubject<Void>(enableCooperativeCancellation: true)
+        try await withMainSerialExecutor {
+            let subject = SingleValueSubject<Void>()
 
             let task = Task {
                 _ = await #expect(throws: CancellationError.self) {
@@ -219,33 +219,11 @@ struct SingleValueSubjectTests {
             // make sure we don't cancel before the subject operation has begun
             await Task.megaYield()
             task.cancel()
-
-            #expect(throws: SingleValueSubject<Void>.SubjectError.alreadyCompleted) {
-                _ = try subject.send()
-            }
 
             await task.value
-        }
-    }
 
-    @Test func singleValueSubjectCancellation_withoutCooperativeCancellation() async throws {
-        try await withMainSerialExecutor {
-            let subject = SingleValueSubject<Void>()  // this is the default
-
-            let task = Task {
-                _ = await #expect(throws: CancellationError.self) {
-                    try await subject.execute()
-                }
-            }
-
-            // make sure we don't cancel before the subject operation has begun
-            await Task.megaYield()
-            task.cancel()
-
-            try subject.send()  // doesn't throw
-
-            // this would hang forever if called
-            // await task.value
+            // should not throw, even though the subject was cancelled
+            try subject.send()
         }
     }
 }

--- a/Tests/AfluentTests/WorkerTests/TimeoutTests.swift
+++ b/Tests/AfluentTests/WorkerTests/TimeoutTests.swift
@@ -45,7 +45,7 @@ struct TimeoutTests {
     @Test func taskTimesOutIfItTakesTooLong_withSingleValueSubject() async throws {
         let clock = TestClock()
 
-        let sub = SingleValueSubject<Void>(enableCooperativeCancellation: true)
+        let sub = SingleValueSubject<Void>()
 
         let task = Task {
             try await DeferredTask { try await sub.execute() }

--- a/Tests/AfluentTests/WorkerTests/TimeoutTests.swift
+++ b/Tests/AfluentTests/WorkerTests/TimeoutTests.swift
@@ -45,7 +45,7 @@ struct TimeoutTests {
     @Test func taskTimesOutIfItTakesTooLong_withSingleValueSubject() async throws {
         let clock = TestClock()
 
-        let sub = SingleValueSubject<Void>()
+        let sub = SingleValueSubject<Void>(enableCooperativeCancellation: true)
 
         let task = Task {
             try await DeferredTask { try await sub.execute() }

--- a/Tests/AfluentTests/WorkerTests/TimeoutTests.swift
+++ b/Tests/AfluentTests/WorkerTests/TimeoutTests.swift
@@ -36,7 +36,27 @@ struct TimeoutTests {
         await clock.advance(by: .milliseconds(11))
 
         let res = await task.result
-        #expect { try res.get() } throws: { error in 
+        #expect { try res.get() } throws: { error in
+            error.localizedDescription == "Timed out after waiting \(Duration.milliseconds(10))"
+        }
+    }
+
+    @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *)
+    @Test func taskTimesOutIfItTakesTooLong_withSingleValueSubject() async throws {
+        let clock = TestClock()
+
+        let sub = SingleValueSubject<Void>()
+
+        let task = Task {
+            try await DeferredTask { try await sub.execute() }
+                .timeout(.milliseconds(10), clock: clock)
+                .execute()
+        }
+
+        await clock.advance(by: .milliseconds(11))
+
+        let res = await task.result
+        #expect { try res.get() } throws: { error in
             error.localizedDescription == "Timed out after waiting \(Duration.milliseconds(10))"
         }
     }


### PR DESCRIPTION
## Bug

Fixes a bug in `SingleValueSubject` that could cause hangs due to lack of cooperative cancellation.

Most notably, it would prevent `timeout` from throwing an error if the subject never finished.

### Before

```swift
// this would hang if subject never finishes (does not throw a TimeoutError)
DeferredTask { try await subject.execute() }.timeout(.seconds(1)).execute()
```

### After

```swift
// this throws a TimeoutError as expected
DeferredTask { try await subject.execute() }.timeout(.seconds(1)).execute()
```

I've verified that without the fix (the cooperative cancellation `cancel()` implementation on `SingleValueSubject`) both new tests will hang.

## Caveats

With the diff at time of writing, this change is "opt in", due to the fact that a cancelled `SingleValueSubject` will now throw if `send()` is called and the subject has been cancelled. This is breaking behavioral change that may cause unexpected failures in consumer code (in fact, some of Afluent's own tests would break with this change).

Another option to consider would be ignoring the already-finished continuation when `send()` is called if the `SingleValueSubject` was finished due to cancellation. This may be a more desirable behavior, since it would enable cooperative cancellation to be rolled out without breaking current consumer expectations.

Please let me know what you think and which path forward seems preferable!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added public cancellation capability for single-value operations so they can be cancelled cleanly.

* **Documentation**
  * Added a warning about requiring cooperative cancellation on inputs to avoid hangs.

* **Bug Fixes**
  * Suppress spurious completion errors when an operation is cancelled, improving cancellation behavior.

* **Tests**
  * Added tests for cancellation behavior and timeout error message assertions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->